### PR TITLE
[DO NOT MERGE] repro TestRayServiceIncrementalUpgradeWithLocust RPS<=400 flakiness

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -111,6 +111,336 @@
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
+- label: 'Test RayService Incremental Upgrade With Locust-1'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-2'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-3'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-4'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-5'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-6'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-7'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-8'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-9'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-10'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'
   instance_size: large
   image: golang:1.26-bookworm

--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -441,6 +441,501 @@
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
+- label: 'Test RayService Incremental Upgrade With Locust-11'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-12'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-13'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-14'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-15'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-16'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-17'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-18'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-19'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-20'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-21'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-22'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-23'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-24'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
+- label: 'Test RayService Incremental Upgrade With Locust-25'
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install Gateway API CRDs (Required for Incremental Upgrade)
+    - kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+
+    # Install Istio Gateway controller and create GatewayClass
+    - echo "--- Installing Istio (Gateway Controller)"
+    - curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.3 sh -
+    - ./istio-1.28.3/bin/istioctl install --set profile=minimal -y
+    - echo "--- Creating Istio GatewayClass"
+    - kubectl wait --namespace istio-system --for=condition=ready pod --selector=app=istiod --timeout=120s
+    - kubectl apply -f ray-operator/config/samples/gateway-api/istio-class.yaml
+
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+
+    # Run E2E Tests
+    - echo "--- START:Running RayService Incremental Upgrade With Locust tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
+
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'
   instance_size: large
   image: golang:1.26-bookworm

--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -141,7 +141,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-2'
@@ -174,7 +174,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-3'
@@ -207,7 +207,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-4'
@@ -240,7 +240,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-5'
@@ -273,7 +273,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-6'
@@ -306,7 +306,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-7'
@@ -339,7 +339,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-8'
@@ -372,7 +372,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-9'
@@ -405,7 +405,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-10'
@@ -438,7 +438,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-11'
@@ -471,7 +471,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-12'
@@ -504,7 +504,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-13'
@@ -537,7 +537,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-14'
@@ -570,7 +570,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-15'
@@ -603,7 +603,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-16'
@@ -636,7 +636,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-17'
@@ -669,7 +669,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-18'
@@ -702,7 +702,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-19'
@@ -735,7 +735,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-20'
@@ -768,7 +768,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-21'
@@ -801,7 +801,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-22'
@@ -834,7 +834,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-23'
@@ -867,7 +867,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-24'
@@ -900,7 +900,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test RayService Incremental Upgrade With Locust-25'
@@ -933,7 +933,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^TestRayServiceIncrementalUpgradeWithLocust$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade -run '^(TestRayServiceIncrementalUpgradeWithLocust|TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust)$' 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'

--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -114,7 +114,7 @@ const highRPSServeConfigV2 serveConfigV2 = `applications:
         autoscaling_config:
           min_replicas: 1
           max_replicas: 2
-          target_ongoing_requests: 10
+          target_ongoing_requests: 2
           upscale_delay_s: 0.5
         ray_actor_options:
           num_cpus: 2

--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -110,7 +110,7 @@ const highRPSServeConfigV2 serveConfigV2 = `applications:
       working_dir: "https://github.com/ray-project/serve_config_examples/archive/530e247ca195530b71b92d7e708048a1bdc02583.zip"
     deployments:
       - name: SimpleDeployment
-        max_ongoing_requests: 20
+        max_ongoing_requests: 6
         autoscaling_config:
           min_replicas: 1
           max_replicas: 2

--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -113,8 +113,8 @@ const highRPSServeConfigV2 serveConfigV2 = `applications:
         autoscaling_config:
           min_replicas: 1
           max_replicas: 2
-          target_ongoing_requests: 2
-          max_ongoing_requests: 6
+          target_ongoing_requests: 10
+          max_ongoing_requests: 20
           upscale_delay_s: 0.5
         ray_actor_options:
           num_cpus: 2

--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -110,11 +110,11 @@ const highRPSServeConfigV2 serveConfigV2 = `applications:
       working_dir: "https://github.com/ray-project/serve_config_examples/archive/530e247ca195530b71b92d7e708048a1bdc02583.zip"
     deployments:
       - name: SimpleDeployment
+        max_ongoing_requests: 20
         autoscaling_config:
           min_replicas: 1
           max_replicas: 2
           target_ongoing_requests: 10
-          max_ongoing_requests: 20
           upscale_delay_s: 0.5
         ray_actor_options:
           num_cpus: 2

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
@@ -307,7 +307,7 @@ func TestRayServiceIncrementalUpgradeWithLocust(t *testing.T) {
 					test,
 					locustHeadPod,
 					common.RayHeadContainer,
-					[]string{"pkill", "-SIGINT", "-f", "locust --headless"},
+					[]string{"pkill", "-SIGTERM", "-f", "locust --headless"},
 				)
 				LogWithTimestamp(test.T(), "Waiting for Locust load test goroutine to finish")
 				if err := eg.Wait(); err != nil && !test.T().Failed() {
@@ -666,7 +666,7 @@ func TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust(t *testing.T) {
 					test,
 					locustHeadPod,
 					common.RayHeadContainer,
-					[]string{"pkill", "-SIGINT", "-f", "locust --headless"},
+					[]string{"pkill", "-SIGTERM", "-f", "locust --headless"},
 				)
 				LogWithTimestamp(test.T(), "Waiting for Locust load test goroutine to finish")
 				if err := eg.Wait(); err != nil && !test.T().Failed() {

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
@@ -316,8 +316,10 @@ func TestRayServiceIncrementalUpgradeWithLocust(t *testing.T) {
 			}()
 
 			// Allow Locust to ramp up and send traffic to the old cluster before triggering upgrade.
+			dumpCPUThrottleStatsFromCgroup(test, locustHeadPod, "before warmup")
 			err = warmupLocust(test, locustHeadPod, locustWarmupRPSThreshold, locustWarmupStableWindowSeconds, locustWarmupTimeout)
 			g.Expect(err).NotTo(HaveOccurred())
+			dumpCPUThrottleStatsFromCgroup(test, locustHeadPod, "after warmup")
 
 			// Phase 4: Trigger incremental upgrade
 			LogWithTimestamp(test.T(), "Triggering incremental upgrade by updating RayCluster spec")
@@ -672,8 +674,10 @@ func TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust(t *testing.T) {
 				}
 			}()
 
+			dumpCPUThrottleStatsFromCgroup(test, locustHeadPod, "before warmup")
 			err = warmupLocust(test, locustHeadPod, locustWarmupRPSThreshold, locustWarmupStableWindowSeconds, locustWarmupTimeout)
 			g.Expect(err).NotTo(HaveOccurred())
+			dumpCPUThrottleStatsFromCgroup(test, locustHeadPod, "after warmup")
 
 			// Phase 4: Trigger incremental upgrade (A -> B)
 			LogWithTimestamp(test.T(), "Triggering an upgrade for RayService %s/%s (Spec B)", rayService.Namespace, rayService.Name)

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
@@ -307,7 +307,7 @@ func TestRayServiceIncrementalUpgradeWithLocust(t *testing.T) {
 					test,
 					locustHeadPod,
 					common.RayHeadContainer,
-					[]string{"pkill", "-SIGTERM", "-f", "locust --headless"},
+					[]string{"pkill", "-SIGINT", "-f", "locust --headless"},
 				)
 				LogWithTimestamp(test.T(), "Waiting for Locust load test goroutine to finish")
 				if err := eg.Wait(); err != nil && !test.T().Failed() {
@@ -666,7 +666,7 @@ func TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust(t *testing.T) {
 					test,
 					locustHeadPod,
 					common.RayHeadContainer,
-					[]string{"pkill", "-SIGTERM", "-f", "locust --headless"},
+					[]string{"pkill", "-SIGINT", "-f", "locust --headless"},
 				)
 				LogWithTimestamp(test.T(), "Waiting for Locust load test goroutine to finish")
 				if err := eg.Wait(); err != nil && !test.T().Failed() {

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -363,6 +363,16 @@ const (
 	locustWarmupTimeout = 120 * time.Second
 )
 
+// dumpCPUThrottleStatsFromCgroup logs the Locust head pod's cgroup CPU throttling stats
+// (nr_throttled / throttled_usec, or throttled_time on cgroup v1), so CI logs reveal
+// whether the load generator itself is CPU-throttled during the run.
+func dumpCPUThrottleStatsFromCgroup(test Test, locustHeadPod *corev1.Pod, label string) {
+	stdout, stderr := ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{
+		"sh", "-c", "cat /sys/fs/cgroup/cpu.stat 2>/dev/null || cat /sys/fs/cgroup/cpu/cpu.stat", // check cgroup v2 and fallback to v1
+	})
+	LogWithTimestamp(test.T(), "[%s] cpu.stat for %s:\n%s%s", label, locustHeadPod.Name, stdout.String(), stderr.String())
+}
+
 // warmupLocust waits for Locust to ramp up and enter the steady state before triggering upgrade.
 // Hence, all requests are sent to the old cluster during the warmup period.
 //

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -356,7 +356,7 @@ func generateUpgradeSteps(stepSize, maxSurge int32) []testStep {
 
 const (
 	// The lower bound of the RPS for the Locust to reach the steady state.
-	locustWarmupRPSThreshold = 400.0
+	locustWarmupRPSThreshold = 350.0
 	// The period of time that the RPS must be greater than or equal to the threshold to be considered steady state.
 	locustWarmupStableWindowSeconds = 15
 	// The maximum duration to wait for the Locust to reach the steady state.

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -369,7 +369,7 @@ const (
 func dumpCPUThrottleStatsFromCgroup(test Test, locustHeadPod *corev1.Pod, label string) {
 	stdout, stderr := ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{
 		"sh", "-c", "cat /sys/fs/cgroup/cpu.stat 2>/dev/null || cat /sys/fs/cgroup/cpu/cpu.stat", // check cgroup v2 and fallback to v1
-	})
+	}, true)
 	LogWithTimestamp(test.T(), "[%s] cpu.stat for %s:\n%s%s", label, locustHeadPod.Name, stdout.String(), stderr.String())
 }
 

--- a/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
+++ b/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
@@ -16,7 +16,7 @@ spec:
                 cpu: 300m
                 memory: 1G
               limits:
-                cpu: 500m
+                cpu: "1"
                 memory: 2G
             ports:
               - containerPort: 6379

--- a/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
+++ b/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
@@ -16,7 +16,7 @@ spec:
                 cpu: 300m
                 memory: 1G
               limits:
-                cpu: "1"
+                cpu: 500m
                 memory: 2G
             ports:
               - containerPort: 6379

--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -130,4 +130,7 @@ assert num_failures == 0, f"num_failures: {num_failures}"
 assert num_requests != 0, f"num_requests: {num_requests}"
 
 print("returncode:", proc.returncode)
-sys.exit(proc.returncode)
+# Don't propagate proc.returncode: Locust can exit nonzero on a benign
+# gevent/SIGINT race during shutdown even when the run succeeded (asserts
+# above already verify correctness).
+sys.exit(0)

--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -119,10 +119,6 @@ stdout, stderr = proc.communicate()
 
 print("STDOUT:", stdout.decode())
 print("STDERR:", stderr.decode())
-# Print returncode before parsing STDOUT as JSON, so a crash below (e.g. the
-# master producing no output) still surfaces the real exit status. A negative
-# value means the process was killed by signal N (returncode == -N).
-print("returncode:", proc.returncode)
 
 data = json.loads(stdout.decode())
 assert len(data) == 1, f"data_len: {len(data)}"
@@ -133,4 +129,8 @@ num_requests = data[0]["num_requests"]
 assert num_failures == 0, f"num_failures: {num_failures}"
 assert num_requests != 0, f"num_requests: {num_requests}"
 
-sys.exit(proc.returncode)
+print("returncode:", proc.returncode)
+# Don't propagate proc.returncode: Locust can exit nonzero on a benign
+# gevent/SIGINT race during shutdown even when the run succeeded (asserts
+# above already verify correctness).
+sys.exit(0)

--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -130,7 +130,4 @@ assert num_failures == 0, f"num_failures: {num_failures}"
 assert num_requests != 0, f"num_requests: {num_requests}"
 
 print("returncode:", proc.returncode)
-# Don't propagate proc.returncode: Locust can exit nonzero on a benign
-# gevent/SIGINT race during shutdown even when the run succeeded (asserts
-# above already verify correctness).
-sys.exit(0)
+sys.exit(proc.returncode)

--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -119,6 +119,10 @@ stdout, stderr = proc.communicate()
 
 print("STDOUT:", stdout.decode())
 print("STDERR:", stderr.decode())
+# Print returncode before parsing STDOUT as JSON, so a crash below (e.g. the
+# master producing no output) still surfaces the real exit status. A negative
+# value means the process was killed by signal N (returncode == -N).
+print("returncode:", proc.returncode)
 
 data = json.loads(stdout.decode())
 assert len(data) == 1, f"data_len: {len(data)}"
@@ -129,5 +133,4 @@ num_requests = data[0]["num_requests"]
 assert num_failures == 0, f"num_failures: {num_failures}"
 assert num_requests != 0, f"num_requests: {num_requests}"
 
-print("returncode:", proc.returncode)
 sys.exit(proc.returncode)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reproducing RPS <= 400 flakiness on buildkite with 25 distinct jobs on TestRayServiceIncrementalUpgradeWithLocust and TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust to observe the fail-before cases.

some ci failing cases related to this issue.

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/16269/list?sid=019fc713-155e-4397-965e-1f48c754c305&tab=output -> shows failures happened in  TestRayServiceIncrementalUpgradeWithLocust:BlueGreen、AggressiveGradual、ConservativeGradual

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/16394/list?jid=019fd75f-afcb-4932-981c-e6ea5d32bbe0&tab=output -> shoes failures happened in TestRayServiceIncrementalUpgradeRollbackMatrixWithLocust:ThirdSpec、EarlyRollback、FastRollback


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

related to https://github.com/ray-project/kuberay/issues/4782

## Fail Before Repro

commit [fc20caa](https://github.com/ray-project/kuberay/pull/5098/commits/fc20caad837954e52e24c7895d4b0c30de6f1c67) and the two builds above showed this flakiness. so it is worth the fix.

notice that max_ongoing_request is ignored (misplaced, Serve default applied)

---
### Checkpoint 1: no changes introduced. Ran it 25 times.

[fc20caa](https://github.com/ray-project/kuberay/pull/5098/commits/fc20caad837954e52e24c7895d4b0c30de6f1c67) 1/25 fails due to the RPS <= 400 issue

[a4fd846](https://github.com/ray-project/kuberay/pull/5098/commits/a4fd846810df3c48bbb3bb577c630143e96787f1) 0/25 fails due to the RPS issue, but three jobs failed due to the clean up issue mention below. https://github.com/ray-project/kuberay/pull/5098#issuecomment-5219408409

--- 
### Checkpoint 2: 

Fixed the canonical form, max_ongoing_requests is not part of the [autoscalingConfig](https://docs.ray.io/en/latest/serve/autoscaling-guide.html).

- Tune target_on_going to 10 and max_ongoing_target to 20.

  - the rationale is we have a set 10 concurrent requests all the time, why don't we allow it on one replicas to reduce the latency and bump max_ongoing_target to way more than 10 so we reduce queue time.
 
 - [376d838](https://github.com/ray-project/kuberay/pull/5098/commits/376d8389be4d826eb5d52dec99b6696c47c7c823)  6 out of 25 failed due to the RPS issue (not sure why but the observation is the truth)
   1 out of 25 failed due to clean up issue.

---
### Checkpoint 3:
 
- Tune target_on_going to 2 (the original value) and max_ongoing_target to 20.

 - [7507d84](https://github.com/ray-project/kuberay/pull/5098/commits/7507d849b751f9a2d365f6ead54c14aebfd40c31) 1/25 is related to the RPS issue. another job failed due to the clean up issue. https://github.com/ray-project/kuberay/pull/5098#issuecomment-5219408409
 - [565aad5](https://github.com/ray-project/kuberay/pull/5098/commits/565aad526bd54e03956515caecd02cce7b06a110) 4/25 failed due to the RPS issue.

---

### Checkpoint 4.

Keep the canonical format change, but revert the max_ongoing_requests back to the original value, 6.

[f6a9042](https://github.com/ray-project/kuberay/pull/5098/commits/f6a9042d5d5ccd589fc8346c68f1fd6cc6246f45) 1/25 failed with the RPS check.
[b74f79a](https://github.com/ray-project/kuberay/pull/5098/commits/b74f79a79d27d50daa7373f8e847ecacc0dbd5ae) 0/25 failed due to the RPS check. 2/25 failed due to the flakiness due to the issue mention below.

Results: 1/50 failed to meet the RPS >= 400 requirement. (not a regression from the current set up but fix the canonical format)

---

### Suggestion.

After conducting the experiment, I would suggest max_ongoing_requests stays at the intended 6 since there is no regression and it fits the orignal intent more. The fix will fix the canonical format issue, and use the value, 6.