### PR TITLE
[APIServer] Wait for the terminate-actor job, not the create-actor job

### DIFF
--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -151,7 +151,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	require.True(t, jobSpecEqual(deleteActorRequest.Job, actualJob), "Job spec should match the request. Expected: %v, Actual: %v", deleteActorRequest.Job, actualJob)
-	waitForRayJobInExpectedStatuses(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
+	waitForRayJobInExpectedStatuses(t, tCtx, deleteActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 	g.Eventually(func() int32 {
 		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
 		if err != nil {


### PR DESCRIPTION
## Why are these changes needed?

`TestCreateClusterAutoscaler` submits two RayJobs against the same cluster: one that starts a detached actor, then one that terminates it. After creating the second job it calls

```go
waitForRayJobInExpectedStatuses(t, tCtx, createActorRequest.Job.Name, ...)
```

which names the first job. That job already reached `Succeeded` on line 124, so the helper matches on its first poll and returns. The terminate job is never waited on, and its success is never asserted.

The `Eventually` block right after it then has to cover two things inside one `TestTimeoutMedium` of 3 minutes: the terminate job actually running, and the autoscaler scaling the worker back down. It was only meant to cover the downscale. On a loaded CI agent that is a thinner margin than it looks.

Passing `deleteActorRequest.Job.Name` puts the synchronisation point back and turns the terminate job's completion into an assertion again.

I checked the other five `waitForRayJobInExpectedStatuses` call sites in `apiserver/test/e2e`; this is the only one whose name argument does not match the request it follows.

## Related issue number

Related to #3670. To be clear about what this does not do: #3670 reports `TestCreateClusterAutoscaler` failing with a 500 from `CreateRayJob`, and this change cannot explain that. A missing wait does not make an RPC return 500. This fixes a separate real defect in the same test that I found while reading it, so I am not claiming it closes the flake.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [x] This PR is not tested :(

### Evidence

`go vet` over the package, which type-checks the test files:

```
$ cd apiserver && go vet ./test/e2e/...
$ echo $?
0
```

### What was not tested

I did not run `TestCreateClusterAutoscaler`. It needs a kind cluster, the operator, the API server and real Ray images, and I do not have that stack on this machine. The reasoning above comes from reading the test and the helper in `apiserver/test/e2e/utils.go`, where `waitForRayJobInExpectedStatuses` polls `GetRayJobByName` until the named job is in one of the expected statuses. CI running this PR is the real check.

### AI disclosure

This change was written with AI assistance (Claude). A human reviewed the diff, ran the command shown above, and is responsible for the result.
