### PR TITLE
[RayService] Validate ray.io/num-worker-groups annotation to prevent operator panic

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1370,27 +1370,33 @@ func shouldUpdateCluster(rayServiceInstance *rayv1.RayService, cluster *rayv1.Ra
 func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1.RayCluster, partial bool) bool {
 	// If `partial` is true, only compare the first `len(cluster.Spec.WorkerGroupSpecs)` worker groups in the CR spec.
 	clusterHash := cluster.ObjectMeta.Annotations[utils.HashWithoutReplicasAndWorkersToDeleteKey]
+	if clusterHash == "" {
+		return false
+	}
 	goalClusterSpec := rayClusterSpecForHashing(rayServiceInstance)
 	goalClusterHash := ""
+	var err error
 	if !partial {
-		goalClusterHash, _ = utils.GenerateHashWithoutReplicasAndWorkersToDelete(*goalClusterSpec)
+		goalClusterHash, err = utils.GenerateHashWithoutReplicasAndWorkersToDelete(*goalClusterSpec)
+		if err != nil {
+			return false
+		}
 	} else {
 		// If everything is identical except for the Replicas and WorkersToDelete of
 		// the existing workergroups, and one or more new workergroups are added at the end, then update the cluster.
 		clusterNumWorkerGroups, err := strconv.Atoi(cluster.ObjectMeta.Annotations[utils.NumWorkerGroupsKey])
-		if err != nil {
-			return true
+		if err != nil || clusterNumWorkerGroups < 0 {
+			return false
 		}
 		goalNumWorkerGroups := len(goalClusterSpec.WorkerGroupSpecs)
 		if goalNumWorkerGroups >= clusterNumWorkerGroups {
-
 			// Remove the new workergroup(s) from the end before calculating the hash.
 			goalClusterSpec.WorkerGroupSpecs = goalClusterSpec.WorkerGroupSpecs[:clusterNumWorkerGroups]
 
 			// Generate the hash of the old worker group specs.
 			goalClusterHash, err = utils.GenerateHashWithoutReplicasAndWorkersToDelete(*goalClusterSpec)
 			if err != nil {
-				return true
+				return false
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -1063,6 +1063,8 @@ func TestIsClusterSpecHashEqual(t *testing.T) {
 		expected          bool
 		addNewWorkerGroup bool
 		updateClusterSpec bool
+		numWorkerGroups   *string
+		clusterHash       *string
 	}{
 		{
 			name:              "[full] diff replicas",
@@ -1113,6 +1115,40 @@ func TestIsClusterSpecHashEqual(t *testing.T) {
 			updateClusterSpec: true,
 			expected:          false,
 		},
+		{
+			name:              "[partial] negative num worker groups annotation",
+			partial:           true,
+			numWorkerGroups:   new("-1"),
+			addNewWorkerGroup: true,
+			expected:          false,
+		},
+		{
+			name:              "[partial] invalid num worker groups annotation",
+			partial:           true,
+			numWorkerGroups:   new("invalid"),
+			addNewWorkerGroup: true,
+			expected:          false,
+		},
+		{
+			name:              "[partial] missing num worker groups annotation",
+			partial:           true,
+			numWorkerGroups:   new(""),
+			addNewWorkerGroup: true,
+			expected:          false,
+		},
+		{
+			name:        "[full] missing cluster hash annotation",
+			partial:     false,
+			clusterHash: new(""),
+			expected:    false,
+		},
+		{
+			name:              "[partial] missing cluster hash annotation",
+			partial:           true,
+			clusterHash:       new(""),
+			addNewWorkerGroup: true,
+			expected:          false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1140,6 +1176,20 @@ func TestIsClusterSpecHashEqual(t *testing.T) {
 			}
 			if tt.updateClusterSpec {
 				service.Spec.RayClusterSpec.RayVersion = "new-version"
+			}
+			if tt.numWorkerGroups != nil {
+				if *tt.numWorkerGroups == "" {
+					delete(cluster.Annotations, utils.NumWorkerGroupsKey)
+				} else {
+					cluster.Annotations[utils.NumWorkerGroupsKey] = *tt.numWorkerGroups
+				}
+			}
+			if tt.clusterHash != nil {
+				if *tt.clusterHash == "" {
+					delete(cluster.Annotations, utils.HashWithoutReplicasAndWorkersToDeleteKey)
+				} else {
+					cluster.Annotations[utils.HashWithoutReplicasAndWorkersToDeleteKey] = *tt.clusterHash
+				}
 			}
 
 			isEqual := isClusterSpecHashEqual(service, &cluster, tt.partial)


### PR DESCRIPTION
## Why are these changes needed?

In `RayService` controller's `isClusterSpecHashEqual`, the `ray.io/num-worker-groups` annotation on a `RayCluster` is parsed via `strconv.Atoi` without validating that the value is non-negative.

If the annotation contains a negative integer (e.g. `"-1"`):
1. `goalNumWorkerGroups >= clusterNumWorkerGroups` evaluates to `true` (since `len()` is non-negative).
2. Slicing `goalClusterSpec.WorkerGroupSpecs[:clusterNumWorkerGroups]` with a negative index triggers a runtime panic (`slice bounds out of range`), crashing the operator during reconciliation.

Additionally:
- When annotation parsing (`strconv.Atoi`) or hash generation failed, the function previously returned `true`, incorrectly treating the specs as matching.
- Missing cluster hash annotations could lead to false-positive matches (`"" == ""`).

Changes in this PR:
1. Ensure `clusterNumWorkerGroups` is parsed successfully and is $\ge 0$ before slicing `WorkerGroupSpecs`.
2. Return `false` if `clusterHash` is empty, if annotation parsing fails, or if hash generation fails.
3. Added test cases in `TestIsClusterSpecHashEqual` covering negative values, invalid non-integer strings, empty annotations, and missing cluster hashes.


## Related issue number


## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(