### PR TITLE
[historyserver] Fix flaky TestShutdown_DrainsRetriedTasks

### DIFF
--- a/historyserver/pkg/collector/eventcollector/eventcollector_test.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector_test.go
@@ -83,12 +83,6 @@ func (m *mockWriter) fileKeys() []string {
 	return keys
 }
 
-func (m *mockWriter) failPending() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.failNext
-}
-
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
@@ -602,12 +596,13 @@ func TestShutdown_DrainsRetriedTasks(t *testing.T) {
 		createdAt:   time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
 		size:        int64(len(payload)),
 	}
-	ec.rotationQueue <- task
 
-	// Wait until the worker has consumed the injected failure, so the retry
-	// goroutine exists before shutdown begins.
-	require.Eventually(t, func() bool { return !writer.failPending() },
-		2*time.Second, 10*time.Millisecond)
+	// Drive the failing attempt inline so retryProcess has registered the retry
+	// with consumerWG by the time shutdown runs. Enqueuing raced it: the mock
+	// clears failNext at the start of the failing write, so the test could
+	// resume and shut down before the retry was registered, and shutdown then
+	// declines an unregistered retry by design.
+	ec.processRotatedFile(task)
 
 	// Run's real shutdown sequence. Closing stopProducers cuts the retry's
 	// backoff short and triggers its final attempt.


### PR DESCRIPTION
`TestShutdown_DrainsRetriedTasks` fails intermittently in CI on PRs that change nothing under `historyserver/`:

```
eventcollector_test.go:618:
    Error:    Should be true
    Test:     TestShutdown_DrainsRetriedTasks
    Messages: retried task never uploaded; keys: []
--- FAIL: TestShutdown_DrainsRetriedTasks (0.00s)
```

The test waits for the mock writer to clear `failNext` and treats that as "the retry goroutine now exists":

```go
require.Eventually(t, func() bool { return !writer.failPending() }, ...)
ec.shutdown()
```

But `failNext` is cleared at the *start* of the failing write, before it even returns an error — so the signal fires well before `processRotatedFile` handles that error and calls `retryProcess`. If `shutdown()` closes `stopProducers` inside that window, `retryProcess` declines the retry, which is deliberate:

```go
select {
case <-ec.stopProducers:
    logrus.Errorf("Giving up on retrying %s during shutdown; file left on disk", task.path)
    return
default:
}
```

The product behaviour is correct — the declined file stays on disk and is picked up by `resumePendingFiles` on the next start. Only the test is wrong: it wants the "retry already registered, shutdown cuts its backoff short" path, but it never actually guarantees registration first.

Driving the failing attempt inline makes that ordering a fact rather than a race. `processRotatedFile` returns only after `retryProcess` has registered the goroutine with `consumerWG`, so `shutdown()` cannot get there first. The assertions and what they cover are unchanged, and `failPending` goes with it since nothing calls it any more.

## Testing Done

The flake is load-sensitive, so it will not reproduce on an idle machine — 200 plain runs and 200 `-race` runs pass both before and after. To reproduce deterministically I widened the window the race needs, simulating the worker being descheduled exactly where CI descheduled it:

```go
if m.failNext {
    m.failNext = false
    m.mu.Unlock()
    time.Sleep(50 * time.Millisecond) // REPRO only, not committed
    return assertErr("mock write failure")
}
```

With that delay, the old test fails with the exact CI error and the new one passes:

<details><summary>Raw logs</summary>

```
=== OLD form + repro delay (5 runs) ===
    eventcollector_test.go:616:
        	Error Trace:	.../eventcollector_test.go:616
        	Error:      	Should be true
        	Test:       	TestShutdown_DrainsRetriedTasks
        	Messages:   	retried task never uploaded; keys: []
FAIL
FAIL	github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector	0.619s

=== FIXED form + repro delay (5 runs) ===
ok  	github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector	0.604s

=== FIXED form, 300 runs with -race, delay removed ===
ok  	github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector	2.331s

=== full package ===
ok  	github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector	0.542s
```

</details>

`golangci-lint run ./pkg/collector/eventcollector/...` reports 52 findings on this package both before and after the change — none new. `gofmt` clean.
