### PR TITLE
[CI][kubectl-plugin] Deflake session reconnect e2e test

### DIFF
--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		Eventually(func() error {
 			_, err := exec.CommandContext(ctx, "curl", "http://localhost:8265").CombinedOutput()
 			return err
-		}, 60*time.Second, 1*time.Millisecond).ShouldNot(HaveOccurred())
+		}, 60*time.Second, 500*time.Millisecond).ShouldNot(HaveOccurred())
 	})
 
 	It("should not succeed", func() {

--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -3,8 +3,8 @@ package e2e
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -77,11 +77,14 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		// Set the command to run in a new process group
 		// This is necessary to ensure that the signal is sent to all child processes
 		sessionCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		sessionCmd.Stdout = GinkgoWriter
+		sessionCmd.Stderr = GinkgoWriter
 		err := sessionCmd.Start()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make sure we kill the whole process group, even if the test is failure
 		defer cleanUpCmdProcessAndCheckPortForwarding(sessionCmd)
+		GinkgoWriter.Printf("[%s] session started pid=%d namespace=%s\n", time.Now().Format(time.RFC3339Nano), sessionCmd.Process.Pid, namespace)
 
 		// Send a request to localhost:8265, it should succeed
 		Eventually(func() error {
@@ -93,32 +96,39 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		cmd := exec.Command("kubectl", "get", "--namespace", namespace, "raycluster/raycluster-kuberay", "-o", "jsonpath={.status.head.podName}")
 		output, err := cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
-		oldPodName := string(output)
+		oldPodName := strings.TrimSpace(string(output))
+		Expect(oldPodName).NotTo(BeEmpty())
+		GinkgoWriter.Printf("[%s] old head pod=%q\n", time.Now().Format(time.RFC3339Nano), oldPodName)
 		var newPodName string
 
 		// Delete the pod
 		cmd = exec.Command("kubectl", "delete", "--namespace", namespace, "pod", oldPodName)
-		err = cmd.Run()
-		Expect(err).NotTo(HaveOccurred())
+		output, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "kubectl delete output: %s", string(output))
+		GinkgoWriter.Printf("[%s] delete completed output=%q\n", time.Now().Format(time.RFC3339Nano), string(output))
 
-		// Wait for the new pod to be created
-		Eventually(func() error {
+		// Wait for the current replacement pod to be ready. Resolve the current head
+		// pod on every attempt because it may be replaced again while becoming ready.
+		Eventually(func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "--namespace", namespace, "raycluster/raycluster-kuberay", "-o", "jsonpath={.status.head.podName}")
 			output, err := cmd.CombinedOutput()
-			newPodName = string(output)
-			if err != nil {
-				return err
-			}
-			if newPodName == oldPodName {
-				return fmt.Errorf("head pod has not changed (Name still %s)", oldPodName)
-			}
-			return nil
-		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get the current head pod: %s", string(output))
 
-		// Wait for the new pod to be ready
-		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod", newPodName, "--for=condition=Ready", "--timeout=120s")
-		err = cmd.Run()
-		Expect(err).NotTo(HaveOccurred())
+			candidatePodName := strings.TrimSpace(string(output))
+			g.Expect(candidatePodName).NotTo(BeEmpty(), "current head pod name is empty")
+			g.Expect(candidatePodName).NotTo(Equal(oldPodName), "head pod has not changed")
+
+			cmd = exec.Command(
+				"kubectl", "get", "--namespace", namespace, "pod", candidatePodName,
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}",
+			)
+			output, err = cmd.CombinedOutput()
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get replacement head pod %q: %s", candidatePodName, string(output))
+			g.Expect(strings.TrimSpace(string(output))).To(Equal("True"), "replacement head pod %q is not ready", candidatePodName)
+
+			newPodName = candidatePodName
+		}, 180*time.Second, 1*time.Second).Should(Succeed())
+		GinkgoWriter.Printf("[%s] replacement head pod ready=%q\n", time.Now().Format(time.RFC3339Nano), newPodName)
 
 		// Send a request to localhost:8265, it should succeed
 		Eventually(func() error {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After the original Head Pod is deleted, `.status.head.podName` may temporarily be empty or reference a replacement Pod that does not yet exist. The previous test only checked whether the value differed from the old Pod name, so it could accept an invalid candidate and fail during the subsequent one-shot `kubectl wait`. This change continuously re-resolves the current Head Pod until it exists and is Ready, then verifies that the original session reconnects successfully.

This race is consistent with Buildkite build 14551, which failed at the `kubectl wait` assertion with exit status 1. Because the original build did not retain stderr or Kubernetes events, the exact historical state of the replacement Pod cannot be confirmed.

### What's changed:

- Re-resolves the current Head Pod on every polling attempt.
- Rejects an empty Head Pod name and the original Pod name.
- Verifies that the current candidate Pod still exists and is Ready.
- Automatically follows a newer replacement if the previous candidate
  disappears.
- Writes session and Pod deletion output to the Ginkgo log for future
  diagnostics.

The final end-to-end assertion is unchanged: the same `kubectl ray session`
process must successfully serve `localhost:8265` after the Head Pod
replacement.

### Manual test Results:
```
ubuntu@ip-172-31-23-15:~/work/kuberay/kubectl-plugin$ SUMMARY="$HOME/session-reconnect-20-summary.txt"

PASSED=0
FAILED=0

{
  echo "KubeRay session reconnect e2e - 20 repeated runs"
  echo "Base commit: $(git -C ~/work/kuberay rev-parse HEAD)"
  echo "Test: should reconnect after pod connection is lost"
  echo
  printf '%-8s %-14s %-8s\n' "Run" "Seed" "Result"

  for logfile in "$LOG_DIR"/run-*.log; do
    filename=$(basename "$logfile")
    run=${filename#run-}
    run=${run%%-seed-*}
    seed=${filename#*-seed-}
    seed=${seed%.log}

    if grep -q 'SUCCESS!' "$logfile" &&
       grep -q '^PASS$' "$logfile"; then
      result=PASS
      PASSED=$((PASSED + 1))
    else
      result=FAIL
      FAILED=$((FAILED + 1))
    fi

    printf '%-8s %-14s %-8s\n' \
      "$run" \
      "$seed" \
      "$result"
  done

  echo
  echo "Total passed: $PASSED"
  echo "Total failed: $FAILED"
} | tee "$SUMMARY"
KubeRay session reconnect e2e - 20 repeated runs
Base commit: 18bec08a779ff658d9e710a44561345ccbda9e84
Test: should reconnect after pod connection is lost

Run      Seed           Result  
01       1776400015     PASS    
02       1776400016     PASS    
03       1776400017     PASS    
04       1776400018     PASS    
05       1776400019     PASS    
06       1776400020     PASS    
07       1776400021     PASS    
08       1776400022     PASS    
09       1776400023     PASS    
10       1776400024     PASS    
11       1776400025     PASS    
12       1776400026     PASS    
13       1776400027     PASS    
14       1776400028     PASS    
15       1776400029     PASS    
16       1776400030     PASS    
17       1776400031     PASS    
18       1776400032     PASS    
19       1776400033     PASS    
20       1776400034     PASS    

Total passed: 20
Total failed: 0
```

## Related issue number

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/14551/canvas?jid=019d99ab-3e37-46c6-87df-a6da1e8d4e39&tab=output

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(