### PR TITLE
[RayService][e2e] Fix misplaced max_ongoing_requests in incremental-upgrade serveConfigV2

### DIFF
--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -110,11 +110,11 @@ const highRPSServeConfigV2 serveConfigV2 = `applications:
       working_dir: "https://github.com/ray-project/serve_config_examples/archive/530e247ca195530b71b92d7e708048a1bdc02583.zip"
     deployments:
       - name: SimpleDeployment
+        max_ongoing_requests: 6
         autoscaling_config:
           min_replicas: 1
           max_replicas: 2
           target_ongoing_requests: 2
-          max_ongoing_requests: 6
           upscale_delay_s: 0.5
         ray_actor_options:
           num_cpus: 2


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The max_ongoing_requests used in highRPSServeConfigV2 is misplaced. https://github.com/ray-project/kuberay/blob/55ffdebb12a3d62b3a75b628219f01749fec3210/ray-operator/test/e2eincrementalupgrade/constant.go#L117

As [Ray Serve Autoscaling](https://docs.ray.io/en/latest/serve/autoscaling-guide.html#autoscaling-basic-configuration) points out, it is not part of the autoscaling config. Therefore, the current setup uses a default value of 5 instead of the proclaimed value 6.

https://github.com/ray-project/ray/blob/328e6b7646facad6dc92e37b8db2b478b2089a87/python/ray/serve/_private/constants.py#L283

Also, there is a 1/50 (2×25 runs) chances the RPS >= 400 check would timeout but comparing with the original setup it is not a regression, which also has a chances of failing 1 out of 50 times under 2 runs.

## Related issue number

<!-- For example: "Closes #1234" -->

related to #4782 

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  
<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

Manual test is recorded in https://github.com/ray-project/kuberay/pull/5098, the change does not introduce a regression.
