### PR TITLE
Add fqdn

### DIFF
--- a/.buildkite/values-kuberay-operator-override.yaml
+++ b/.buildkite/values-kuberay-operator-override.yaml
@@ -24,3 +24,5 @@ featureGates:
     enabled: true
   - name: RayClusterMTLS
     enabled: true
+  - name: RayClusterWorkerFQDN
+    enabled: true

--- a/ray-operator/config/overlays/test-overrides/deployment-override.yaml
+++ b/ray-operator/config/overlays/test-overrides/deployment-override.yaml
@@ -9,4 +9,4 @@ spec:
       containers:
       - name: kuberay-operator
         args:
-        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,GCSFaultToleranceEmbeddedStorage=true,RayClusterMTLS=true
+        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,GCSFaultToleranceEmbeddedStorage=true,RayClusterMTLS=true,RayClusterWorkerFQDN=true

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -591,6 +591,19 @@ func getEnableProbesInjection() bool {
 	return true
 }
 
+// generateWorkerHostname returns a stable DNS label for a worker Pod based on
+// its group name and replica/host indices. For multi-host groups the host index
+// is included so each host in a replica gets a unique name.
+func generateWorkerHostname(groupName string, replicaIndex int, hostIndex int, numOfHosts int32) string {
+	var hostname string
+	if numOfHosts > 1 {
+		hostname = fmt.Sprintf("%s-%d-%d", groupName, replicaIndex, hostIndex)
+	} else {
+		hostname = fmt.Sprintf("%s-%d", groupName, replicaIndex)
+	}
+	return utils.CheckLabel(hostname)
+}
+
 // DefaultWorkerPodTemplate sets the config values
 func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, workerSpec rayv1.WorkerGroupSpec, podName string, fqdnRayIP string, headPort string, replicaGrpName string, replicaIndex int, numHostIndex int) corev1.PodTemplateSpec {
 	podTemplate := workerSpec.Template
@@ -670,16 +683,25 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 	mergedLabels := mergeLabels(workerSpec.Template.ObjectMeta.Labels, workerSpec.Labels)
 	podTemplate.Labels = labelPod(rayv1.WorkerNode, instance.Name, workerSpec.GroupName, mergedLabels)
 
-	// Add additional labels when RayMultihostIndexing is enabled.
-	if features.Enabled(features.RayMultiHostIndexing) {
-		// The ordered replica index can be used for the single-host, multi-slice case.
+	// Assign stable replica indices for RayMultiHostIndexing and/or RayClusterWorkerFQDN.
+	if features.NeedsWorkerIndices() {
+		// The ordered replica index can be used for the single-host, multi-slice case
+		// and for stable FQDN hostnames.
 		podTemplate.Labels[utils.RayWorkerReplicaIndexKey] = strconv.Itoa(replicaIndex)
+		// Slice labels (replica name + host index) when this group has multiple hosts.
 		if workerSpec.NumOfHosts > 1 {
-			// These labels are specific to multi-host group setup and reconciliation.
 			podTemplate.Labels[utils.RayWorkerReplicaNameKey] = replicaGrpName
 			podTemplate.Labels[utils.RayHostIndexKey] = strconv.Itoa(numHostIndex)
 		}
 	}
+
+	// Stable per-pod FQDN via hostname + subdomain matching the headless Service.
+	// See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field
+	if features.Enabled(features.RayClusterWorkerFQDN) {
+		podTemplate.Spec.Hostname = generateWorkerHostname(workerSpec.GroupName, replicaIndex, numHostIndex, workerSpec.NumOfHosts)
+		podTemplate.Spec.Subdomain = instance.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	}
+
 	workerSpec.RayStartParams = setMissingRayStartParams(ctx, workerSpec.RayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 
 	initTemplateAnnotations(instance, &podTemplate)

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -584,6 +584,19 @@ func getEnableProbesInjection() bool {
 	return true
 }
 
+// generateWorkerHostname returns a stable DNS label for a worker Pod based on
+// its group name and RayMultiHostIndexing indices. For multi-host groups the
+// host index is included so each host in a replica gets a unique name.
+func generateWorkerHostname(groupName string, replicaIndex int, hostIndex int, numOfHosts int32) string {
+	var hostname string
+	if numOfHosts > 1 {
+		hostname = fmt.Sprintf("%s-%d-%d", groupName, replicaIndex, hostIndex)
+	} else {
+		hostname = fmt.Sprintf("%s-%d", groupName, replicaIndex)
+	}
+	return utils.CheckLabel(hostname)
+}
+
 // DefaultWorkerPodTemplate sets the config values
 func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, workerSpec rayv1.WorkerGroupSpec, podName string, fqdnRayIP string, headPort string, replicaGrpName string, replicaIndex int, numHostIndex int) corev1.PodTemplateSpec {
 	podTemplate := workerSpec.Template
@@ -672,6 +685,11 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 			podTemplate.Labels[utils.RayWorkerReplicaNameKey] = replicaGrpName
 			podTemplate.Labels[utils.RayHostIndexKey] = strconv.Itoa(numHostIndex)
 		}
+
+		// Stable per-Pod FQDN via hostname + subdomain matching the headless Service.
+		// See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field
+		podTemplate.Spec.Hostname = generateWorkerHostname(workerSpec.GroupName, replicaIndex, numHostIndex, workerSpec.NumOfHosts)
+		podTemplate.Spec.Subdomain = instance.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
 	}
 	workerSpec.RayStartParams = setMissingRayStartParams(ctx, workerSpec.RayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1544,7 +1544,9 @@ func TestDeafultWorkerPodTemplateWithReplicaGrpAndIndex(t *testing.T) {
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 
+	// Production default: indexing on, FQDN off. Slice labels are stamped; hostname/subdomain are not.
 	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
+	features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, false)
 
 	worker.Template.ObjectMeta.Name = "ray-worker-test"
 	worker.NumOfHosts = 4
@@ -1557,6 +1559,99 @@ func TestDeafultWorkerPodTemplateWithReplicaGrpAndIndex(t *testing.T) {
 	assert.Equal(t, podTemplateSpec.Labels[utils.RayWorkerReplicaNameKey], groupReplicaName)
 	assert.Equal(t, "0", podTemplateSpec.Labels[utils.RayWorkerReplicaIndexKey])
 	assert.Equal(t, "2", podTemplateSpec.Labels[utils.RayHostIndexKey])
+	assert.Empty(t, podTemplateSpec.Spec.Hostname)
+	assert.Empty(t, podTemplateSpec.Spec.Subdomain)
+}
+
+// TestDefaultWorkerPodTemplateStableFQDN covers hostname/subdomain stamping vs the two
+// feature gates. FQDN-off cases assert that indexing labels can still be present while
+// per-pod DNS names stay unset (the production default).
+func TestDefaultWorkerPodTemplateStableFQDN(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := instance.DeepCopy()
+
+	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	expectedSubdomain := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	worker.Template.ObjectMeta.Name = "ray-worker-test"
+	podName := func(groupName string) string {
+		return cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + groupName + utils.DashSymbol + utils.FormatInt32(0)
+	}
+
+	t.Run("fqdn on, indexing off, multi-host", func(t *testing.T) {
+		// FQDN assigns replica indices itself and reuses slice labels so each host
+		// gets a unique hostname even when RayMultiHostIndexing is off.
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
+		features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, true)
+
+		w := worker.DeepCopy()
+		w.NumOfHosts = 4
+		groupReplicaName := utils.GenerateRayWorkerReplicaGroupName(w.GroupName)
+		pod := DefaultWorkerPodTemplate(ctx, *cluster, *w, podName(w.GroupName), fqdnRayIP, "6379", groupReplicaName, 0, 2)
+		assert.Equal(t, "small-group-0-2", pod.Spec.Hostname)
+		assert.Equal(t, expectedSubdomain, pod.Spec.Subdomain)
+		assert.Equal(t, "0", pod.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Equal(t, groupReplicaName, pod.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Equal(t, "2", pod.Labels[utils.RayHostIndexKey])
+	})
+	t.Run("fqdn on, indexing off, single-host", func(t *testing.T) {
+		// Single-host FQDN is {group}-{replicaIndex}; slice labels are not set.
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
+		features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, true)
+
+		w := worker.DeepCopy()
+		w.NumOfHosts = 1
+		pod := DefaultWorkerPodTemplate(ctx, *cluster, *w, podName(w.GroupName), fqdnRayIP, "6379", "", 3, 0)
+		assert.Equal(t, "small-group-3", pod.Spec.Hostname)
+		assert.Equal(t, expectedSubdomain, pod.Spec.Subdomain)
+		assert.Equal(t, "3", pod.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Empty(t, pod.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Empty(t, pod.Labels[utils.RayHostIndexKey])
+	})
+	t.Run("both off", func(t *testing.T) {
+		// Pre-indexing, pre-FQDN: no replica labels and no per-pod DNS names.
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
+		features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, false)
+
+		w := worker.DeepCopy()
+		w.NumOfHosts = 1
+		pod := DefaultWorkerPodTemplate(ctx, *cluster, *w, podName(w.GroupName), fqdnRayIP, "6379", "", 3, 0)
+		assert.Empty(t, pod.Spec.Hostname)
+		assert.Empty(t, pod.Spec.Subdomain)
+		assert.Empty(t, pod.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Empty(t, pod.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Empty(t, pod.Labels[utils.RayHostIndexKey])
+	})
+	t.Run("indexing on, fqdn off, single-host", func(t *testing.T) {
+		// Production default for single-host: replica index only, no hostname/subdomain.
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
+		features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, false)
+
+		w := worker.DeepCopy()
+		w.NumOfHosts = 1
+		pod := DefaultWorkerPodTemplate(ctx, *cluster, *w, podName(w.GroupName), fqdnRayIP, "6379", "", 3, 0)
+		assert.Empty(t, pod.Spec.Hostname)
+		assert.Empty(t, pod.Spec.Subdomain)
+		assert.Equal(t, "3", pod.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Empty(t, pod.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Empty(t, pod.Labels[utils.RayHostIndexKey])
+	})
+	t.Run("indexing on, fqdn off, multi-host", func(t *testing.T) {
+		// Production default for multi-host: slice labels only, no hostname/subdomain.
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
+		features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, false)
+
+		w := worker.DeepCopy()
+		w.NumOfHosts = 4
+		groupReplicaName := utils.GenerateRayWorkerReplicaGroupName(w.GroupName)
+		pod := DefaultWorkerPodTemplate(ctx, *cluster, *w, podName(w.GroupName), fqdnRayIP, "6379", groupReplicaName, 0, 2)
+		assert.Empty(t, pod.Spec.Hostname)
+		assert.Empty(t, pod.Spec.Subdomain)
+		assert.Equal(t, "0", pod.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Equal(t, groupReplicaName, pod.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Equal(t, "2", pod.Labels[utils.RayHostIndexKey])
+	})
 }
 
 func containerPortExists(ports []corev1.ContainerPort, containerPort int32) error {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1546,17 +1546,38 @@ func TestDeafultWorkerPodTemplateWithReplicaGrpAndIndex(t *testing.T) {
 
 	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
 
-	worker.Template.ObjectMeta.Name = "ray-worker-test"
-	worker.NumOfHosts = 4
-	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
-	groupReplicaName := utils.GenerateRayWorkerReplicaGroupName(worker.GroupName)
+	expectedSubdomain := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
 
-	// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
-	podTemplateSpec := DefaultWorkerPodTemplate(ctx, *cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379", groupReplicaName, 0, 2)
-	assert.Empty(t, podTemplateSpec.ObjectMeta.Name)
-	assert.Equal(t, podTemplateSpec.Labels[utils.RayWorkerReplicaNameKey], groupReplicaName)
-	assert.Equal(t, "0", podTemplateSpec.Labels[utils.RayWorkerReplicaIndexKey])
-	assert.Equal(t, "2", podTemplateSpec.Labels[utils.RayHostIndexKey])
+	t.Run("multi-host", func(t *testing.T) {
+		worker.Template.ObjectMeta.Name = "ray-worker-test"
+		worker.NumOfHosts = 4
+		podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+		groupReplicaName := utils.GenerateRayWorkerReplicaGroupName(worker.GroupName)
+
+		// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
+		podTemplateSpec := DefaultWorkerPodTemplate(ctx, *cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379", groupReplicaName, 0, 2)
+		assert.Empty(t, podTemplateSpec.ObjectMeta.Name)
+		assert.Equal(t, podTemplateSpec.Labels[utils.RayWorkerReplicaNameKey], groupReplicaName)
+		assert.Equal(t, "0", podTemplateSpec.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Equal(t, "2", podTemplateSpec.Labels[utils.RayHostIndexKey])
+		assert.Equal(t, "small-group-0-2", podTemplateSpec.Spec.Hostname)
+		assert.Equal(t, expectedSubdomain, podTemplateSpec.Spec.Subdomain)
+	})
+
+	t.Run("single-host", func(t *testing.T) {
+		worker.Template.ObjectMeta.Name = "ray-worker-test"
+		worker.NumOfHosts = 1
+		podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+
+		// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
+		podTemplateSpec := DefaultWorkerPodTemplate(ctx, *cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379", "", 3, 0)
+		assert.Empty(t, podTemplateSpec.ObjectMeta.Name)
+		assert.Equal(t, "3", podTemplateSpec.Labels[utils.RayWorkerReplicaIndexKey])
+		assert.Empty(t, podTemplateSpec.Labels[utils.RayWorkerReplicaNameKey])
+		assert.Empty(t, podTemplateSpec.Labels[utils.RayHostIndexKey])
+		assert.Equal(t, "small-group-3", podTemplateSpec.Spec.Hostname)
+		assert.Equal(t, expectedSubdomain, podTemplateSpec.Spec.Subdomain)
+	})
 }
 
 func containerPortExists(ports []corev1.ContainerPort, containerPort int32) error {

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -295,7 +295,9 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 	return serveService, nil
 }
 
-// BuildHeadlessService builds the headless service for workers in multi-host worker groups to communicate
+// BuildHeadlessServiceForRayCluster builds the headless service for worker Pods.
+// It enables stable per-worker Pod FQDNs via hostname + subdomain, and supports
+// peer communication between multi-host workers.
 func BuildHeadlessServiceForRayCluster(rayCluster rayv1.RayCluster) *corev1.Service {
 	name := rayCluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
 	namespace := rayCluster.Namespace
@@ -318,8 +320,8 @@ func BuildHeadlessServiceForRayCluster(rayCluster rayv1.RayCluster) *corev1.Serv
 			ClusterIP: "None",
 			Selector:  selectorLabels,
 			Type:      corev1.ServiceTypeClusterIP,
-			// The headless worker service is used for peer communication between multi-host workers and should not be
-			// dependent on Proxy Actor placement to publish DNS addresses.
+			// Publish addresses even before Pods are Ready so peer DNS and per-Pod FQDNs
+			// are available without depending on Proxy Actor placement.
 			PublishNotReadyAddresses: true,
 		},
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -896,36 +896,37 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 
 // Return nil only when the headless service for multi-host worker groups is successfully created or already exists.
 func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, instance *rayv1.RayCluster) error {
-	// Check if there are worker groups with NumOfHosts > 1 in the cluster
-	isMultiHost := false
-	for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
-		if workerGroup.NumOfHosts > 1 {
-			isMultiHost = true
-			break
+	// Check if Stable Worker FQDN is enabled
+	needHeadless := features.Enabled(features.RayClusterWorkerFQDN)
+
+	// If Stable Worker FQDN is not enabled, check if there are worker groups with NumOfHosts > 1 in the cluster
+	if !needHeadless {
+		for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
+			if workerGroup.NumOfHosts > 1 {
+				needHeadless = true
+				break
+			}
 		}
 	}
-
-	if isMultiHost {
-		services := corev1.ServiceList{}
-		options := common.RayClusterHeadlessServiceListOptions(instance)
-
-		if err := r.List(ctx, &services, options...); err != nil {
-			return err
-		}
-		// Check if there's an existing headless service in the cluster.
-		if len(services.Items) != 0 {
-			// service exists, do nothing
-			return nil
-		}
-		// Create headless tpu worker service if there's no existing one in the cluster.
-		headlessSvc := common.BuildHeadlessServiceForRayCluster(*instance)
-
-		if err := r.createService(ctx, headlessSvc, instance); err != nil {
-			return err
-		}
+	if !needHeadless {
+		return nil
 	}
 
-	return nil
+	services := corev1.ServiceList{}
+	options := common.RayClusterHeadlessServiceListOptions(instance)
+
+	if err := r.List(ctx, &services, options...); err != nil {
+		return err
+	}
+	// Check if there's an existing headless service in the cluster.
+	if len(services.Items) != 0 {
+		// service exists, do nothing
+		return nil
+	}
+	// Create headless tpu worker service if there's no existing one in the cluster.
+	headlessSvc := common.BuildHeadlessServiceForRayCluster(*instance)
+
+	return r.createService(ctx, headlessSvc, instance)
 }
 
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {
@@ -1092,7 +1093,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			continue
 		}
 
-		isRayMultiHostIndexing := worker.NumOfHosts > 1 && features.Enabled(features.RayMultiHostIndexing)
+		isRayMultiHostIndexing := worker.NumOfHosts > 1 && features.NeedsWorkerIndices()
 		if isRayMultiHostIndexing {
 			if err := r.reconcileMultiHostWorkerGroup(ctx, instance, &worker, workerPods.Items); err != nil {
 				return err
@@ -1168,9 +1169,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 
 		logger.Info("reconcilePods", "workerReplicas", numExpectedWorkerPods, "NumOfHosts", worker.NumOfHosts, "runningPods", len(runningPods.Items), "diff", diff)
 
-		// Support replica indices for single-host, multi-slice environments.
+		// Support replica indices for single-host workers (RayMultiHostIndexing and/or RayClusterWorkerFQDN).
 		validReplicaIndices := make(map[int]bool)
-		if features.Enabled(features.RayMultiHostIndexing) {
+		if features.NeedsWorkerIndices() {
 			for _, pod := range runningPods.Items {
 				if indexStr, ok := pod.Labels[utils.RayWorkerReplicaIndexKey]; ok {
 					if index, err := strconv.Atoi(indexStr); err == nil {
@@ -1189,7 +1190,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 					return fmt.Errorf("mTLS secrets not ready: %w", err)
 				}
 			}
-			if features.Enabled(features.RayMultiHostIndexing) {
+			if features.NeedsWorkerIndices() {
 				newReplicaIndex := 0
 				// create all workers of this group
 				for i := range diff {
@@ -1280,7 +1281,7 @@ func (r *RayClusterReconciler) deletePods(ctx context.Context, instance *rayv1.R
 }
 
 // reconcileMultiHostWorkerGroup handles reconciliation and Pod deletion for worker groups with NumOfHosts > 1 when
-// the RayMultihostIndexing feature is enabled. This function is responsible for:
+// NeedsWorkerIndices is true (RayMultiHostIndexing and/or RayClusterWorkerFQDN). This function is responsible for:
 // 1. Deleting incomplete or unhealthy multi-host groups atomically.
 // 2. Explicit deletes of entire multi-host groups for the autoscaler.
 // 3. Scale up/down of multi-host groups.

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -896,33 +896,23 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 
 // Return nil only when the headless service for multi-host worker groups is successfully created or already exists.
 func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, instance *rayv1.RayCluster) error {
-	// Check if there are worker groups with NumOfHosts > 1 in the cluster
-	isMultiHost := false
-	for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
-		if workerGroup.NumOfHosts > 1 {
-			isMultiHost = true
-			break
-		}
+	services := corev1.ServiceList{}
+	options := common.RayClusterHeadlessServiceListOptions(instance)
+
+	if err := r.List(ctx, &services, options...); err != nil {
+		return err
 	}
+	// Check if there's an existing headless service in the cluster.
+	if len(services.Items) != 0 {
+		// service exists, do nothing
+		return nil
+	}
+	// Create headless worker service if there's no existing one in the cluster.
+	// Used for stable per-worker Pod FQDNs (hostname + subdomain) and multi-host peer communication.
+	headlessSvc := common.BuildHeadlessServiceForRayCluster(*instance)
 
-	if isMultiHost {
-		services := corev1.ServiceList{}
-		options := common.RayClusterHeadlessServiceListOptions(instance)
-
-		if err := r.List(ctx, &services, options...); err != nil {
-			return err
-		}
-		// Check if there's an existing headless service in the cluster.
-		if len(services.Items) != 0 {
-			// service exists, do nothing
-			return nil
-		}
-		// Create headless tpu worker service if there's no existing one in the cluster.
-		headlessSvc := common.BuildHeadlessServiceForRayCluster(*instance)
-
-		if err := r.createService(ctx, headlessSvc, instance); err != nil {
-			return err
-		}
+	if err := r.createService(ctx, headlessSvc, instance); err != nil {
+		return err
 	}
 
 	return nil

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -911,11 +911,7 @@ func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, ins
 	// Used for stable per-worker Pod FQDNs (hostname + subdomain) and multi-host peer communication.
 	headlessSvc := common.BuildHeadlessServiceForRayCluster(*instance)
 
-	if err := r.createService(ctx, headlessSvc, instance); err != nil {
-		return err
-	}
-
-	return nil
+	return r.createService(ctx, headlessSvc, instance)
 }
 
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1100,62 +1100,90 @@ func TestReconcileHeadService(t *testing.T) {
 func TestReconcileHeadlessService(t *testing.T) {
 	setupTest(t)
 
-	// Specify a multi-host worker group
-	testRayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = 4
+	// Headless Service create is independent of RayMultiHostIndexing:
+	//   - numOfHosts > 1: always created (pre-FQDN peer DNS for multi-host slices)
+	//   - RayClusterWorkerFQDN: also created for single-host so hostname/subdomain can resolve
+	for _, tc := range []struct {
+		name          string
+		numOfHosts    int32
+		workerFQDN    bool
+		expectService bool
+	}{
+		// FQDN off: retain old multi-host behavior (Service yes) and old single-host behavior (Service no).
+		{name: "multi-host without FQDN", numOfHosts: 4, workerFQDN: false, expectService: true},
+		{name: "single-host without FQDN", numOfHosts: 1, workerFQDN: false, expectService: false},
+		// FQDN on: Service exists for both single-host and multi-host.
+		{name: "multi-host with FQDN", numOfHosts: 4, workerFQDN: true, expectService: true},
+		{name: "single-host with FQDN", numOfHosts: 1, workerFQDN: true, expectService: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.RayClusterWorkerFQDN, tc.workerFQDN)
 
-	// Mock data
-	cluster := testRayCluster.DeepCopy()
+			// Specify worker group NumOfHosts for this test case.
+			testRayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = tc.numOfHosts
 
-	// Create a new scheme with CRDs, Pod, Service schemes.
-	newScheme := runtime.NewScheme()
-	_ = rayv1.AddToScheme(newScheme)
-	_ = corev1.AddToScheme(newScheme)
+			// Mock data
+			cluster := testRayCluster.DeepCopy()
 
-	// Initialize a fake client with newScheme and runtimeObjects.
-	runtimeObjects := []runtime.Object{cluster}
-	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
-	ctx := context.TODO()
+			// Create a new scheme with CRDs, Pod, Service schemes.
+			newScheme := runtime.NewScheme()
+			_ = rayv1.AddToScheme(newScheme)
+			_ = corev1.AddToScheme(newScheme)
 
-	// Initialize RayCluster reconciler.
-	r := &RayClusterReconciler{
-		Client:                     fakeClient,
-		Recorder:                   &events.FakeRecorder{},
-		Scheme:                     scheme.Scheme,
-		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+			// Initialize a fake client with newScheme and runtimeObjects.
+			runtimeObjects := []runtime.Object{cluster}
+			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+			ctx := context.TODO()
+
+			// Initialize RayCluster reconciler.
+			r := &RayClusterReconciler{
+				Client:                     fakeClient,
+				Recorder:                   &events.FakeRecorder{},
+				Scheme:                     scheme.Scheme,
+				rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+			}
+
+			headlessServiceSelector := labels.SelectorFromSet(map[string]string{
+				utils.RayClusterHeadlessServiceLabelKey: cluster.Name,
+			})
+
+			// Case 1: Headless service does not exist.
+			err := r.reconcileHeadlessService(ctx, cluster)
+			require.NoError(t, err, "Fail to reconcile headless service")
+
+			// Assert create-or-skip based on tc.expectService
+			serviceList := corev1.ServiceList{}
+			err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+				LabelSelector: headlessServiceSelector,
+				Namespace:     cluster.Namespace,
+			})
+
+			// If not expecting headless service to be created
+			if !tc.expectService {
+				assert.Empty(t, serviceList.Items)
+				return
+			}
+
+			expectedName := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+			require.NoError(t, err, "Fail to get service list")
+			assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
+			assert.Equal(t, expectedName, serviceList.Items[0].ObjectMeta.Name, "Headless Service name is wrong, expected %s actual %s", expectedName, serviceList.Items[0].ObjectMeta.Name)
+			assert.Equal(t, "None", serviceList.Items[0].Spec.ClusterIP, "Created service is not a headless service, ClusterIP is not None")
+
+			// Case 2: Headless service already exists, nothing should be done
+			err = r.reconcileHeadlessService(ctx, cluster)
+			require.NoError(t, err, "Fail to reconcile headless service")
+
+			// The namespace should still have only one headless service.
+			serviceList = corev1.ServiceList{}
+			err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+				LabelSelector: headlessServiceSelector,
+				Namespace:     cluster.Namespace,
+			})
+			require.NoError(t, err, "Fail to get service list")
+			assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
+		})
 	}
-
-	headlessServiceSelector := labels.SelectorFromSet(map[string]string{
-		utils.RayClusterHeadlessServiceLabelKey: cluster.Name,
-	})
-
-	// Case 1: Headless service does not exist.
-	err := r.reconcileHeadlessService(ctx, cluster)
-	require.NoError(t, err, "Fail to reconcile head service")
-
-	// One headless service should be created.
-	serviceList := corev1.ServiceList{}
-	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
-		LabelSelector: headlessServiceSelector,
-		Namespace:     cluster.Namespace,
-	})
-	expectedName := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
-	require.NoError(t, err, "Fail to get service list")
-	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
-	assert.Equal(t, expectedName, serviceList.Items[0].ObjectMeta.Name, "Headless Service name is wrong, expected %s actual %s", expectedName, serviceList.Items[0].ObjectMeta.Name)
-	assert.Equal(t, "None", serviceList.Items[0].Spec.ClusterIP, "Created service is not a headless service, ClusterIP is not None")
-
-	// Case 2: Headless service already exists, nothing should be done
-	err = r.reconcileHeadlessService(ctx, cluster)
-	require.NoError(t, err, "Fail to reconcile head service")
-
-	// The namespace should still have only one headless service.
-	serviceList = corev1.ServiceList{}
-	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
-		LabelSelector: headlessServiceSelector,
-		Namespace:     cluster.Namespace,
-	})
-	require.NoError(t, err, "Fail to get service list")
-	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
 }
 
 func getNotFailedPodItemNum(podList corev1.PodList) int {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1100,62 +1100,72 @@ func TestReconcileHeadService(t *testing.T) {
 func TestReconcileHeadlessService(t *testing.T) {
 	setupTest(t)
 
-	// Specify a multi-host worker group
-	testRayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = 4
+	for _, tc := range []struct {
+		name       string
+		numOfHosts int32
+	}{
+		{name: "multi-host worker group", numOfHosts: 4},
+		{name: "single-host worker group", numOfHosts: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Specify worker group NumOfHosts for this test case.
+			testRayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = tc.numOfHosts
 
-	// Mock data
-	cluster := testRayCluster.DeepCopy()
+			// Mock data
+			cluster := testRayCluster.DeepCopy()
 
-	// Create a new scheme with CRDs, Pod, Service schemes.
-	newScheme := runtime.NewScheme()
-	_ = rayv1.AddToScheme(newScheme)
-	_ = corev1.AddToScheme(newScheme)
+			// Create a new scheme with CRDs, Pod, Service schemes.
+			newScheme := runtime.NewScheme()
+			_ = rayv1.AddToScheme(newScheme)
+			_ = corev1.AddToScheme(newScheme)
 
-	// Initialize a fake client with newScheme and runtimeObjects.
-	runtimeObjects := []runtime.Object{cluster}
-	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
-	ctx := context.TODO()
+			// Initialize a fake client with newScheme and runtimeObjects.
+			runtimeObjects := []runtime.Object{cluster}
+			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+			ctx := context.TODO()
 
-	// Initialize RayCluster reconciler.
-	r := &RayClusterReconciler{
-		Client:                     fakeClient,
-		Recorder:                   &events.FakeRecorder{},
-		Scheme:                     scheme.Scheme,
-		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+			// Initialize RayCluster reconciler.
+			r := &RayClusterReconciler{
+				Client:                     fakeClient,
+				Recorder:                   &events.FakeRecorder{},
+				Scheme:                     scheme.Scheme,
+				rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+			}
+
+			headlessServiceSelector := labels.SelectorFromSet(map[string]string{
+				utils.RayClusterHeadlessServiceLabelKey: cluster.Name,
+			})
+
+			// Case 1: Headless service does not exist.
+			err := r.reconcileHeadlessService(ctx, cluster)
+			require.NoError(t, err, "Fail to reconcile headless service")
+
+			// One headless service should be created.
+			serviceList := corev1.ServiceList{}
+			err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+				LabelSelector: headlessServiceSelector,
+				Namespace:     cluster.Namespace,
+			})
+			expectedName := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+			require.NoError(t, err, "Fail to get service list")
+			assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
+			assert.Equal(t, expectedName, serviceList.Items[0].ObjectMeta.Name, "Headless Service name is wrong, expected %s actual %s", expectedName, serviceList.Items[0].ObjectMeta.Name)
+			assert.Equal(t, "None", serviceList.Items[0].Spec.ClusterIP, "Created service is not a headless service, ClusterIP is not None")
+
+			// Case 2: Headless service already exists, nothing should be done
+			err = r.reconcileHeadlessService(ctx, cluster)
+			require.NoError(t, err, "Fail to reconcile headless service")
+
+			// The namespace should still have only one headless service.
+			serviceList = corev1.ServiceList{}
+			err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+				LabelSelector: headlessServiceSelector,
+				Namespace:     cluster.Namespace,
+			})
+			require.NoError(t, err, "Fail to get service list")
+			assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
+		})
 	}
-
-	headlessServiceSelector := labels.SelectorFromSet(map[string]string{
-		utils.RayClusterHeadlessServiceLabelKey: cluster.Name,
-	})
-
-	// Case 1: Headless service does not exist.
-	err := r.reconcileHeadlessService(ctx, cluster)
-	require.NoError(t, err, "Fail to reconcile head service")
-
-	// One headless service should be created.
-	serviceList := corev1.ServiceList{}
-	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
-		LabelSelector: headlessServiceSelector,
-		Namespace:     cluster.Namespace,
-	})
-	expectedName := cluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
-	require.NoError(t, err, "Fail to get service list")
-	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
-	assert.Equal(t, expectedName, serviceList.Items[0].ObjectMeta.Name, "Headless Service name is wrong, expected %s actual %s", expectedName, serviceList.Items[0].ObjectMeta.Name)
-	assert.Equal(t, "None", serviceList.Items[0].Spec.ClusterIP, "Created service is not a headless service, ClusterIP is not None")
-
-	// Case 2: Headless service already exists, nothing should be done
-	err = r.reconcileHeadlessService(ctx, cluster)
-	require.NoError(t, err, "Fail to reconcile head service")
-
-	// The namespace should still have only one headless service.
-	serviceList = corev1.ServiceList{}
-	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
-		LabelSelector: headlessServiceSelector,
-		Namespace:     cluster.Namespace,
-	})
-	require.NoError(t, err, "Fail to get service list")
-	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
 }
 
 func getNotFailedPodItemNum(podList corev1.PodList) int {

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -96,6 +96,13 @@ const (
 	// selects the scheduler; it is mutually exclusive with --batch-scheduler and --enable-batch-scheduler.
 	// Requires a Kubernetes cluster that serves the scheduling.k8s.io API with GenericWorkload enabled.
 	KubernetesWAS featuregate.Feature = "KubernetesWAS"
+
+	// Enables stable per-worker Pod FQDNs (hostname/subdomain + headless Service).
+	// When enabled, also assigns stable per-worker replica indices for hostname
+	// uniqueness. For NumOfHosts > 1, FQDN reuses multi-host slice reconciliation
+	// (via NeedsWorkerIndices) so each host gets a unique hostname even if
+	// RayMultiHostIndexing is off.
+	RayClusterWorkerFQDN featuregate.Feature = "RayClusterWorkerFQDN"
 )
 
 func init() {
@@ -114,6 +121,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RayClusterMTLS:                   {Default: false, PreRelease: featuregate.Alpha},
 	RayClusterHistoryServer:          {Default: false, PreRelease: featuregate.Alpha},
 	KubernetesWAS:                    {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterWorkerFQDN:             {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest is a helper method to override feature gates in tests.
@@ -124,6 +132,14 @@ func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) 
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
 func Enabled(f featuregate.Feature) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(f)
+}
+
+// NeedsWorkerIndices reports whether the operator should assign and track
+// stable per-worker replica indices, and use multi-host slice reconciliation
+// when NumOfHosts > 1. Required for RayMultiHostIndexing and for
+// RayClusterWorkerFQDN per-host hostname uniqueness.
+func NeedsWorkerIndices() bool {
+	return Enabled(RayMultiHostIndexing) || Enabled(RayClusterWorkerFQDN)
 }
 
 func LogFeatureGates(log logr.Logger) {

--- a/ray-operator/test/e2e/raycluster_multi_host_test.go
+++ b/ray-operator/test/e2e/raycluster_multi_host_test.go
@@ -1,12 +1,14 @@
 package e2e
 
 import (
+	"maps"
 	"strconv"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -115,6 +117,53 @@ func verifyWorkerGroupIndices(t *testing.T, rayCluster *rayv1.RayCluster, worker
 	}
 }
 
+// verifyHeadlessServiceExists checks that the RayCluster headless Service exists and is headless.
+func verifyHeadlessServiceExists(t *testing.T, rayCluster *rayv1.RayCluster) {
+	test := With(t)
+	g := NewWithT(t)
+
+	expectedName := rayCluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	svc, err := test.Client().Core().CoreV1().Services(rayCluster.Namespace).Get(test.Ctx(), expectedName, metav1.GetOptions{})
+
+	g.Expect(err).NotTo(HaveOccurred(), "Headless service %s/%s should exist", rayCluster.Namespace, expectedName)
+	g.Expect(svc.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone), "Service %s should be headless", expectedName)
+	g.Expect(svc.Labels[utils.RayClusterHeadlessServiceLabelKey]).To(Equal(rayCluster.Name))
+}
+
+// verifyWorkerPodFQDNs checks that each worker Pod has hostname/subdomain matching its replica
+// (and host) index so the stable Pod FQDN can resolve via the headless Service.
+func verifyWorkerPodFQDNs(t *testing.T, rayCluster *rayv1.RayCluster, workerGroupName string, numOfHosts int) {
+	test := With(t)
+	g := NewWithT(t)
+
+	expectedSubdomain := rayCluster.Name + utils.DashSymbol + utils.HeadlessServiceSuffix
+	workerPods, err := GetWorkerPods(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, pod := range workerPods {
+		if pod.Labels[utils.RayNodeGroupLabelKey] != workerGroupName {
+			continue
+		}
+
+		g.Expect(pod.Spec.Subdomain).To(Equal(expectedSubdomain),
+			"Pod %s subdomain should match headless service name", pod.Name)
+
+		replicaIndex := pod.Labels[utils.RayWorkerReplicaIndexKey]
+		g.Expect(replicaIndex).NotTo(BeEmpty(), "Pod %s missing replica index label", pod.Name)
+
+		var expectedHostname string
+		if numOfHosts > 1 {
+			hostIndex := pod.Labels[utils.RayHostIndexKey]
+			g.Expect(hostIndex).NotTo(BeEmpty(), "Pod %s missing host index label", pod.Name)
+			expectedHostname = workerGroupName + utils.DashSymbol + replicaIndex + utils.DashSymbol + hostIndex
+		} else {
+			expectedHostname = workerGroupName + utils.DashSymbol + replicaIndex
+		}
+		g.Expect(pod.Spec.Hostname).To(Equal(expectedHostname),
+			"Pod %s hostname should be stable from group/replica indices", pod.Name)
+	}
+}
+
 func TestRayClusterSingleHostMultiSlice(t *testing.T) {
 	test := With(t)
 	g := NewWithT(t)
@@ -162,6 +211,11 @@ func TestRayClusterSingleHostMultiSlice(t *testing.T) {
 	LogWithTimestamp(t, "Verifying initial labels on single-host pods for %s/%s", rayCluster.Namespace, rayCluster.Name)
 	verifyWorkerGroupIndices(t, rayCluster, workerGroupName, 1, initialReplicas, []int{0, 1, 2})
 
+	// Verify headless service and stable worker Pod FQDNs (hostname + subdomain).
+	LogWithTimestamp(t, "Verifying headless service and worker FQDNs for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyHeadlessServiceExists(t, rayCluster)
+	verifyWorkerPodFQDNs(t, rayCluster, workerGroupName, 1)
+
 	// Manually delete the pod with replica index 1.
 	LogWithTimestamp(t, "Deleting pod with replica index 1 for %s/%s", rayCluster.Namespace, rayCluster.Name)
 	workerPods, err := GetWorkerPods(test, rayCluster)
@@ -175,6 +229,9 @@ func TestRayClusterSingleHostMultiSlice(t *testing.T) {
 		}
 	}
 	g.Expect(podToDelete).NotTo(BeNil(), "Could not find pod with replica index 1 to delete")
+	deletedPodUID := podToDelete.UID
+	deletedHostname := podToDelete.Spec.Hostname
+	deletedSubdomain := podToDelete.Spec.Subdomain
 
 	err = test.Client().Core().CoreV1().Pods(namespace.Name).Delete(test.Ctx(), podToDelete.Name, metav1.DeleteOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -190,6 +247,28 @@ func TestRayClusterSingleHostMultiSlice(t *testing.T) {
 	LogWithTimestamp(t, "Verifying labels after pod deletion and reconciliation")
 	verifyWorkerGroupIndices(t, rayCluster, workerGroupName, 1, initialReplicas, []int{0, 1, 2})
 
+	// Verify the replacement keeps the same stable FQDN (hostname/subdomain) with a new Pod UID.
+	LogWithTimestamp(t, "Verifying stable FQDN after worker recreate for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyHeadlessServiceExists(t, rayCluster)
+	verifyWorkerPodFQDNs(t, rayCluster, workerGroupName, 1)
+	g.Eventually(func(gg Gomega) {
+		pods, err := GetWorkerPods(test, rayCluster)
+		gg.Expect(err).NotTo(HaveOccurred())
+
+		var replacement *corev1.Pod
+		for i := range pods {
+			if pods[i].Labels[utils.RayWorkerReplicaIndexKey] == "1" && pods[i].DeletionTimestamp == nil {
+				replacement = &pods[i]
+				break
+			}
+		}
+
+		gg.Expect(replacement).NotTo(BeNil(), "Could not find replacement pod with replica index 1")
+		gg.Expect(replacement.UID).NotTo(Equal(deletedPodUID), "Replacement pod should be a new object")
+		gg.Expect(replacement.Spec.Hostname).To(Equal(deletedHostname), "Hostname should survive recreate")
+		gg.Expect(replacement.Spec.Subdomain).To(Equal(deletedSubdomain), "Subdomain should survive recreate")
+	}, TestTimeoutShort).Should(Succeed())
+
 	// Scale up replicas from 3 to 4.
 	const scaleUpReplicas = 4
 	LogWithTimestamp(t, "Scaling up RayCluster %s/%s from %d to %d replicas", rayCluster.Namespace, rayCluster.Name, initialReplicas, scaleUpReplicas)
@@ -204,6 +283,10 @@ func TestRayClusterSingleHostMultiSlice(t *testing.T) {
 	// Verify the new pod got the next available index, 3.
 	LogWithTimestamp(t, "Verifying labels after scale-up")
 	verifyWorkerGroupIndices(t, rayCluster, workerGroupName, 1, scaleUpReplicas, []int{0, 1, 2, 3})
+
+	// Verify FQDNs remain correct after scale-up (including new index 3).
+	LogWithTimestamp(t, "Verifying worker FQDNs after scale-up for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyWorkerPodFQDNs(t, rayCluster, workerGroupName, 1)
 }
 
 func TestRayClusterMultiHostMultiSlice(t *testing.T) {
@@ -272,6 +355,11 @@ func TestRayClusterMultiHostMultiSlice(t *testing.T) {
 	LogWithTimestamp(t, "Verifying labels after scale-down for %s/%s", rayCluster.Namespace, rayCluster.Name)
 	verifyWorkerGroupIndices(t, rayCluster, "multi-host-group", numOfHosts, scaleDownReplicas, nil)
 
+	// Verify FQDNs remain correct after scale-down.
+	LogWithTimestamp(t, "Verifying worker FQDNs after scale-down for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyHeadlessServiceExists(t, rayCluster)
+	verifyWorkerPodFQDNs(t, rayCluster, "multi-host-group", numOfHosts)
+
 	// Test scale up: Increase replicas from 1 to 3.
 	const scaleUpReplicas = 3
 	LogWithTimestamp(t, "Scaling up RayCluster %s/%s", rayCluster.Namespace, rayCluster.Name)
@@ -288,15 +376,42 @@ func TestRayClusterMultiHostMultiSlice(t *testing.T) {
 	LogWithTimestamp(t, "Verifying labels after scale-up for %s/%s", rayCluster.Namespace, rayCluster.Name)
 	verifyWorkerGroupIndices(t, rayCluster, "multi-host-group", numOfHosts, scaleUpReplicas, []int{0, 1, 2})
 
+	// Verify FQDNs remain correct after scale-up.
+	LogWithTimestamp(t, "Verifying worker FQDNs after scale-up for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyHeadlessServiceExists(t, rayCluster)
+	verifyWorkerPodFQDNs(t, rayCluster, "multi-host-group", numOfHosts)
+
 	// Manually delete a single pod and verify the controller atomically re-creates the slice.
 	LogWithTimestamp(t, "Testing atomic multi-host group recreation for RayCluster %s/%s", rayCluster.Namespace, rayCluster.Name)
 	workerPods, err := GetWorkerPods(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
+
 	podToDelete := workerPods[0]
+	deletedReplicaName := podToDelete.Labels[utils.RayWorkerReplicaNameKey]
+	deletedReplicaIndex := podToDelete.Labels[utils.RayWorkerReplicaIndexKey]
+	deletedSubdomain := podToDelete.Spec.Subdomain
+
+	g.Expect(deletedReplicaName).NotTo(BeEmpty(), "Deleted pod should have a replica name label")
+	g.Expect(deletedReplicaIndex).NotTo(BeEmpty(), "Deleted pod should have a replica index label")
+
+	// Capture the full replica slice before delete so we can assert every host is replaced.
+	oldSliceUIDs := map[types.UID]struct{}{}
+	oldSliceHostnames := map[string]struct{}{}
+	for _, pod := range workerPods {
+		if pod.Labels[utils.RayWorkerReplicaNameKey] != deletedReplicaName {
+			continue
+		}
+		oldSliceUIDs[pod.UID] = struct{}{}
+		oldSliceHostnames[pod.Spec.Hostname] = struct{}{}
+	}
+
+	g.Expect(oldSliceUIDs).To(HaveLen(numOfHosts), "Expected %d pods in the replica slice before delete", numOfHosts)
+	g.Expect(oldSliceHostnames).To(HaveLen(numOfHosts), "Expected %d unique hostnames in the replica slice before delete", numOfHosts)
+
 	err = test.Client().Core().CoreV1().Pods(namespace.Name).Delete(test.Ctx(), podToDelete.Name, metav1.DeleteOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// The controller should first clean up the broken multi-host group (-4 pods), and then re-scale it up (+4 pods).
+	// The controller should first clean up the broken multi-host group (-NumOfHosts pods), and then re-scale it up (+NumOfHosts pods).
 	LogWithTimestamp(t, "Waiting for controller to reconcile multi-host group.")
 	// Reconciliation happens too quickly to catch the state where expectedPodCount-NumOfHosts, but we can test
 	// that externally deleted Pods will be re-created to satisfy the expected number.
@@ -307,4 +422,39 @@ func TestRayClusterMultiHostMultiSlice(t *testing.T) {
 	// Verify labels are still set correctly after atomic re-creation due to unhealthy Pod.
 	LogWithTimestamp(t, "Verifying labels after atomic recreation for %s/%s", rayCluster.Namespace, rayCluster.Name)
 	verifyWorkerGroupIndices(t, rayCluster, "multi-host-group", numOfHosts, scaleUpReplicas, []int{0, 1, 2})
+
+	// Verify the entire replica slice was replaced: no old UIDs remain, all hostnames return on new Pods.
+	LogWithTimestamp(t, "Verifying full replica-slice recreate and FQDNs for %s/%s", rayCluster.Namespace, rayCluster.Name)
+	verifyHeadlessServiceExists(t, rayCluster)
+	verifyWorkerPodFQDNs(t, rayCluster, "multi-host-group", numOfHosts)
+	g.Eventually(func(gg Gomega) {
+		pods, err := GetWorkerPods(test, rayCluster)
+		gg.Expect(err).NotTo(HaveOccurred())
+
+		newSlice := []corev1.Pod{}
+		for _, pod := range pods {
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			// Match by replica index: replica name is regenerated on recreate.
+			if pod.Labels[utils.RayWorkerReplicaIndexKey] == deletedReplicaIndex &&
+				pod.Labels[utils.RayNodeGroupLabelKey] == "multi-host-group" {
+				newSlice = append(newSlice, pod)
+			}
+		}
+		gg.Expect(newSlice).To(HaveLen(numOfHosts), "Replica index %s should again have %d hosts", deletedReplicaIndex, numOfHosts)
+
+		remainingHostnames := maps.Clone(oldSliceHostnames)
+		for _, pod := range newSlice {
+			_, wasOldUID := oldSliceUIDs[pod.UID]
+
+			gg.Expect(wasOldUID).To(BeFalse(), "Pod %s still has an old slice UID %s", pod.Name, pod.UID)
+			gg.Expect(pod.Spec.Subdomain).To(Equal(deletedSubdomain), "Subdomain should survive recreate")
+
+			_, ok := remainingHostnames[pod.Spec.Hostname]
+			gg.Expect(ok).To(BeTrue(), "Pod %s has unexpected or duplicate hostname %s", pod.Name, pod.Spec.Hostname)
+			delete(remainingHostnames, pod.Spec.Hostname)
+		}
+		gg.Expect(remainingHostnames).To(BeEmpty(), "Missing hostnames from the deleted slice: %v", remainingHostnames)
+	}, TestTimeoutShort).Should(Succeed())
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray worker Pods are only addressable by Pod IP today, and that IP changes whenever a Pod is recreated. This PR sets worker `hostname` / `subdomain` from replica (and host - for multihost) indices and always creates the RayCluster headless Service so each worker gets a stable Pod FQDN that can survive recreates.

Hostname/subdomain assignment still sits behind `RayMultiHostIndexing`, since that is where replica indices are assigned. Creating the headless Service is no longer limited to multi-host groups (`NumOfHosts > 1`).

That stretches the meaning of `RayMultiHostIndexing`. Looking for guidance on whether to:

1. Add a separate feature flag for worker FQDNs / always-on headless Service alongside `RayMultiHostIndexing`, or
2. Keep this approach: headless Service by default for all worker groups, hostname/subdomain still tied to `RayMultiHostIndexing` (default on).

Note: The multi_host e2e test has been extended to support FQDN verification , depending on above decision will split into its own e2e test.

## Related issue number

Closes #5000

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

1. Build/deploy operator with this change (`./hack/local_deploy.sh` or equivalent) and ensure `RayMultiHostIndexing=true`.
2. Apply a sample cluster:
   ```bash
   kubectl apply -f ray-operator/config/samples/ray-cluster.sample.yaml
   ```
4. Confirm worker hostname/subdomain and headless Service:
   ```bash
   kubectl get svc | grep headless
   kubectl get pods -l ray.io/node-type=worker -o custom-columns=\
   NAME:.metadata.name,HOSTNAME:.spec.hostname,SUBDOMAIN:.spec.subdomain,IP:.status.podIP
   ```
5. DNS lookup:
   ```bash
   kubectl run dnscheck --rm --restart=Never --image=busybox:1.36 --attach -- \
     nslookup workergroup-0.raycluster-kuberay-headless.default.svc.cluster.local
   ```
6. Delete the worker Pod and confirm the replacement keeps the same hostname/FQDN with a new IP/UID.
7. Unit tests:
   ```bash
   cd ray-operator
   go test ./controllers/ray/common/ -run TestDeafultWorkerPodTemplateWithReplicaGrpAndIndex -count=1
   go test ./controllers/ray/ -run TestReconcileHeadlessService -count=1
   ```
8. E2E (operator image must include this change):
   ```bash
   cd ray-operator
   go test -timeout 30m -v ./test/e2e -run TestRayClusterSingleHostMultiSlice
   go test -timeout 60m -v ./test/e2e -run TestRayClusterMultiHostMultiSlice
   ```