### PR TITLE
fix(grafana): move autoscaler node count into collapsed section

### DIFF
--- a/config/grafana/default_grafana_dashboard.json
+++ b/config/grafana/default_grafana_dashboard.json
@@ -32,6 +32,18 @@
             "panels": []
         },
         {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 1
+            },
+            "id": 1007,
+            "title": "Autoscaling",
+            "type": "row",
+            "panels": [
+        {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -186,6 +198,8 @@
                 "align": false,
                 "alignLevel": null
             }
+        }
+    ]
         },
         {
             "aliasColors": {},


### PR DESCRIPTION
## Why are these changes needed?

The default Grafana dashboard displays a "Node Count" panel that depends on autoscaler metrics. When autoscaling is disabled, these metrics are unavailable and the panel appears empty, which can be confusing to users.

This change moves the autoscaler-dependent "Node Count" panel into a collapsed "Autoscaling" section. This keeps the default dashboard clean while preserving the existing Node Count panel configuration and queries.

## Related issue number

Closes #5026

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [x] This PR is not tested :(

### Manual test instructions

1. Validated the modified Grafana dashboard JSON successfully.
2. Verified that the "Node Count" panel is no longer a top-level dashboard panel.
3. Verified that the "Node Count" panel is present inside the collapsed "Autoscaling" section.
4. Ran 'git diff --check' successfully with no errors.
5. Verified that the final Git diff contains only the intended dashboard change.
6. Verified that the existing Node Count panel configuration and queries were preserved.

A live Grafana UI test was not performed.