### PR TITLE
[history server][CI] fix broken test build on master

### DIFF
--- a/historyserver/pkg/historyserver/byte_cache_integration_test.go
+++ b/historyserver/pkg/historyserver/byte_cache_integration_test.go
@@ -9,8 +9,13 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 // TestByteCache_ReadEndpointsRoundTripIsLossless is an in-process HTTP test:
@@ -29,9 +34,18 @@ func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
 		session = "session_2026-04-22_10-00-00_000000_1"
 	)
 
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
 	handler := &ServerHandler{
 		maxClusters: 100,
-		clustersMap: make(map[utils.ClusterKey][]utils.ClusterInfo),
+		reader: &mockStorageReader{
+			clusters: []utils.ClusterInfo{
+				{Namespace: ns, Name: name, SessionName: session, OwnerKind: "rayjob", OwnerName: "job-bc"},
+			},
+		},
+		clientManager: &ClientManager{
+			clients: []client.Client{fake.NewClientBuilder().WithScheme(scheme).Build()},
+		},
 	}
 	fp := &fakeProcessor{
 		fn: func(_ context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
@@ -40,9 +54,6 @@ func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
 		},
 	}
 	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
-	handler.clustersMap[utils.ClusterKey{Namespace: ns, Name: name}] = []utils.ClusterInfo{
-		{Namespace: ns, Name: name, SessionName: session, OwnerKind: "RayJob", OwnerName: "job-bc"},
-	}
 
 	routerRayClusterSet(handler)
 	routerNodes(handler)
@@ -51,7 +62,7 @@ func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
 	routerLogical(handler)
 	container := restful.DefaultContainer
 
-	enterURL := "/enter_cluster/" + ns + "/" + name + "/" + session
+	enterURL := "/enter_cluster/" + ns + "/raycluster/" + name + "/" + session
 	enterReq := httptest.NewRequest(http.MethodGet, enterURL, nil)
 	enterResp := httptest.NewRecorder()
 	container.ServeHTTP(enterResp, enterReq)

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -275,7 +275,7 @@ func TestEnterClusterLatestFromStorage(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -340,7 +340,7 @@ func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
 			return SessionStatusLive, nil, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -392,7 +392,7 @@ func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -450,7 +450,7 @@ func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -508,7 +508,7 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PR #4918 and PR #4960 were developed in parallell, and #4960 was merged without rebasing onto the latest master  branch. As a result, go vet now fails with the following error:

```
❯ go vet ./...

# github.com/ray-project/kuberay/historyserver/pkg/historyserver
# [github.com/ray-project/kuberay/historyserver/pkg/historyserver]
vet: pkg/historyserver/byte_cache_integration_test.go:34:31: undefined: utils.ClusterKey
```

## Change

Update both test files to the current API:

- `byte_cache_integration_test.go`: seed clusters through a `mockStorageReader` plus a fake `ClientManager` instead of `clustersMap`, and request `/enter_cluster/{ns}/raycluster/{name}/{session}`.
- `enter_cluster_test.go`: pass `DefaultSessionCacheMaxBytes` to the  five remaining `NewSessionLoader` calls.

## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
