### PR TITLE
[RayService][Test] Stop propagating proc.returncode in locust_runner.py

### DIFF
--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -130,4 +130,8 @@ assert num_failures == 0, f"num_failures: {num_failures}"
 assert num_requests != 0, f"num_requests: {num_requests}"
 
 print("returncode:", proc.returncode)
-sys.exit(proc.returncode)
+# We are not propagating proc.returncode because Locust can exit on code 2
+# on a gevent/SIGINT race during shutdown even when the run succeeded.
+# The assertions above already verify correctness.
+# See a more detailed discussion at https://github.com/ray-project/kuberay/issues/5109
+sys.exit(0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Per the conclusion in #5109, we stop the propagation of proc.returncode in locust_runner.py, because a race between gevent's greenlet scheduling and SIGINT delivery can cause the Locust master to exit with code 2 even when the run itself succeeded with no failed requests. Propagating exit code 2 today fails the e2e test despite the run being correct.

## Related issue number

<!-- For example: "Closes #1234" -->

Related to #5109 & #5098

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->

Ran the experiment in commits db7b78d & 8acb8c2: 0/50 runs failed.