### PR TITLE
docs: fix broken relative links

### DIFF
--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -124,7 +124,7 @@ To update the swagger ui files deployed with the Kuberay API server, you'll need
 
 * Manually run the [hack/update-swagger-ui.bash](hack/update-swagger-ui.bash) script. The script downloads the swagger ui release and copies the downloaded files
 to the [../third_party/swagger-ui](../third_party/swagger-ui/) directory. It copies the [swagger-initializer.js](../third_party/swagger-ui/swagger-initializer.js)
-to [swagger-initializer.js.backup](../third_party/swagger-ui/swagger-initializer.js.backup).
+to `swagger-initializer.js.backup` in the same directory..
 * Update the contents of the [swagger-initializer.js](../third_party/swagger-ui/swagger-initializer.js) to set the URLs for for the individual swagger docs.
 * Execute `make build-swagger` target to update the contents of the [datafile.go](pkg/swagger/datafile.go) file. This will package the content of the [swagger-ui](../third_party/swagger-ui/) directory for serving by the api server (see [func serveSwaggerUI(mux *http.ServeMux)](https://github.com/ray-project/kuberay/blob/f1067378bc99987f3eba1e5b12b4cc797465336d/apiserver/cmd/main.go#L149) in [main.go](cmd/main.go))
 

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -162,8 +162,8 @@ The following steps allow you to validate the integration of the KubeRay APIServ
 
 The KubeRay APIServer supports Swagger UI. The Swagger page can be accessed at:
 
-- [localhost:31888/swagger-ui](localhost:31888/swagger-ui) for local kind deployments
-- [localhost:8888/swagger-ui](localhost:8888/swagger-ui) for instances started with `make run` (development machine builds)
+- [http://localhost:31888/swagger-ui](http://localhost:31888/swagger-ui) for local kind deployments
+- [http://localhost:8888/swagger-ui](http://localhost:8888/swagger-ui) for instances started with `make run` (development machine builds)
 - `<host name>:31888/swagger-ui` for NodePort deployments
 
 ## HTTP definition endpoints

--- a/apiserver/SecuringImplementation.md
+++ b/apiserver/SecuringImplementation.md
@@ -8,8 +8,8 @@ The solution is based on the architecture below:
 
 It essentially adds an Authorization sidecar to the KubeRay APIServer pod. This architecture is highly flexible and allows users to integrate sidecar implementations that meet their specific security requirements, which can vary significantly across organizations.
 
-Here, we will use a very simple [sidecar implementation](../experimental/cmd/main.go) with
-a reverse proxy using token-based authorization. This is a basic authorization mechanism
+Here, we will use a very simple sidecar implementation with a reverse proxy using
+token-based authorization. This is a basic authorization mechanism
 based on a string token shared between the proxy and the client. This implementation is not intended for
 production but serves as a demonstration. Additional examples of reverse proxy
 implementations can be found [here](https://github.com/blublinsky/auth-reverse-proxy).

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -161,7 +161,7 @@ Trigger the [`release-kubectl-plugin`](https://github.com/ray-project/kuberay/ac
 ### Step 6: Publish KubeRay Helm Charts
 
 Helm charts are published via the [ray-project/kuberay-helm](https://github.com/ray-project/kuberay-helm) repository. This repo uses release branches (`release-X.Y`) mirroring the main `kuberay` repo.
-See [helm-chart.md](./helm-chart.md) for the end-to-end workflow. Below are steps to cut a new release branch in the kuberay-helm repo and publish new charts.
+See [helm-chart.md](../release/helm-chart.md) for the end-to-end workflow. Below are steps to cut a new release branch in the kuberay-helm repo and publish new charts.
 
 1. **Create Release Branch (if it doesn't exist):**
     * Clone the `kuberay-helm` repository if you haven't already.

--- a/docs/guidance/rayclient-nginx-ingress.md
+++ b/docs/guidance/rayclient-nginx-ingress.md
@@ -68,7 +68,7 @@ The Ray client server is a GRPC service. The NGINX Ingress Controller supports G
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-cluster.tls.yaml
 ```
 
-Refer to the [TLS document](tls.md) for more detail.
+Refer to the [TLS Authentication document](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/tls.html) for more detail.
 
 ## Step 5: Create an ingress for the Ray client service
 


### PR DESCRIPTION
## Why are these changes needed?

Five relative Markdown links in the docs don't resolve:

- `docs/development/release.md` points at `./helm-chart.md`, but the file is at `docs/release/helm-chart.md`.
- `docs/guidance/rayclient-nginx-ingress.md` points at `tls.md`, which doesn't exist in this repo; the TLS guide now lives in the Ray docs.
- The two swagger-ui links in `apiserver/README.md` are missing the `http://` scheme, so they render as relative paths. `apiserver/DEVELOPMENT.md` already writes the same two URLs correctly.
- `apiserver/SecuringImplementation.md` links to `../experimental/cmd/main.go`, which was removed in #4890. This was the last remaining reference to that folder.
- `apiserver/DEVELOPMENT.md` links to `swagger-initializer.js.backup`, which is generated by `hack/update-swagger-ui.bash` and is gitignored, so it is never in the tree. Changed to an inline code span.

Found by scanning every `.md` file for relative links that don't resolve.

## Related issue number

N/A — doc link cleanup.

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Verified each link resolves after the change, and re-ran the relative-link scan over all `.md`
files.