### PR TITLE
[CRD] Mark ray.io/v1alpha1 as a deprecated API version

### DIFF
--- a/benchmark/memory_benchmark/scripts/ray-cluster.benchmark.yaml.template
+++ b/benchmark/memory_benchmark/scripts/ray-cluster.benchmark.yaml.template
@@ -1,4 +1,4 @@
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: '$raycluster_name'

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -884,6 +884,10 @@ _Appears in:_
 
 Package v1alpha1 contains API Schema definitions for the ray v1alpha1 API group
 
+Deprecated: ray.io/v1alpha1 is served for backward compatibility only and is
+frozen at its December 2023 feature set. Use
+github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
+
 ### Resource Types
 - [RayCluster](#raycluster)
 - [RayJob](#rayjob)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -884,9 +884,9 @@ _Appears in:_
 
 Package v1alpha1 contains API Schema definitions for the ray v1alpha1 API group
 
-Deprecated: ray.io/v1alpha1 is served for backward compatibility only and is
-frozen at its December 2023 feature set. Use
-github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
+Deprecated: ray.io/v1alpha1 is served for backward compatibility only, is
+frozen at its December 2023 feature set, and will be unavailable in KubeRay
+1.9. Use github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
 
 ### Resource Types
 - [RayCluster](#raycluster)
@@ -948,8 +948,9 @@ _Appears in:_
 RayCluster is the Schema for the RayClusters API
 
 Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-compatibility only and is frozen at its December 2023 feature set. Use
-ray.io/v1, the storage version, for all new and existing RayClusters.
+compatibility only, is frozen at its December 2023 feature set, and will be
+unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+and existing RayClusters.
 
 
 
@@ -994,8 +995,9 @@ _Appears in:_
 RayJob is the Schema for the rayjobs API
 
 Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-compatibility only and is frozen at its December 2023 feature set. Use
-ray.io/v1, the storage version, for all new and existing RayJobs.
+compatibility only, is frozen at its December 2023 feature set, and will be
+unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+and existing RayJobs.
 
 
 
@@ -1046,8 +1048,9 @@ _Appears in:_
 RayService is the Schema for the rayservices API
 
 Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-compatibility only and is frozen at its December 2023 feature set. Use
-ray.io/v1, the storage version, for all new and existing RayServices.
+compatibility only, is frozen at its December 2023 feature set, and will be
+unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+and existing RayServices.
 
 
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -943,6 +943,10 @@ _Appears in:_
 
 RayCluster is the Schema for the RayClusters API
 
+Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+compatibility only and is frozen at its December 2023 feature set. Use
+ray.io/v1, the storage version, for all new and existing RayClusters.
+
 
 
 
@@ -984,6 +988,10 @@ _Appears in:_
 
 
 RayJob is the Schema for the rayjobs API
+
+Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+compatibility only and is frozen at its December 2023 feature set. Use
+ray.io/v1, the storage version, for all new and existing RayJobs.
 
 
 
@@ -1032,6 +1040,10 @@ _Appears in:_
 
 
 RayService is the Schema for the rayservices API
+
+Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+compatibility only and is frozen at its December 2023 feature set. Use
+ray.io/v1, the storage version, for all new and existing RayServices.
 
 
 

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -9349,6 +9349,9 @@ spec:
       name: head service IP
       priority: 1
       type: string
+    deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster.
+      v1alpha1 receives no new fields and will be removed in a future release.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -9351,7 +9351,7 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -13296,7 +13296,7 @@ spec:
       status: {}
   - deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -13294,7 +13294,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob.
+      v1alpha1 receives no new fields and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -9765,7 +9765,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService.
+      v1alpha1 receives no new fields and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -9767,7 +9767,7 @@ spec:
       status: {}
   - deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/ray-operator/apis/ray/v1alpha1/groupversion_info.go
+++ b/ray-operator/apis/ray/v1alpha1/groupversion_info.go
@@ -1,4 +1,8 @@
 // Package v1alpha1 contains API Schema definitions for the ray v1alpha1 API group
+//
+// Deprecated: ray.io/v1alpha1 is served for backward compatibility only and is
+// frozen at its December 2023 feature set. Use
+// github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
 // +kubebuilder:object:generate=true
 // +groupName=ray.io
 package v1alpha1

--- a/ray-operator/apis/ray/v1alpha1/groupversion_info.go
+++ b/ray-operator/apis/ray/v1alpha1/groupversion_info.go
@@ -1,8 +1,8 @@
 // Package v1alpha1 contains API Schema definitions for the ray v1alpha1 API group
 //
-// Deprecated: ray.io/v1alpha1 is served for backward compatibility only and is
-// frozen at its December 2023 feature set. Use
-// github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
+// Deprecated: ray.io/v1alpha1 is served for backward compatibility only, is
+// frozen at its December 2023 feature set, and will be unavailable in KubeRay
+// 1.9. Use github.com/ray-project/kuberay/ray-operator/apis/ray/v1 instead.
 // +kubebuilder:object:generate=true
 // +groupName=ray.io
 package v1alpha1

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -169,7 +169,12 @@ const (
 )
 
 // RayCluster is the Schema for the RayClusters API
+//
+// Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+// compatibility only and is frozen at its December 2023 feature set. Use
+// ray.io/v1, the storage version, for all new and existing RayClusters.
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster. v1alpha1 receives no new fields and will be removed in a future release."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -171,10 +171,11 @@ const (
 // RayCluster is the Schema for the RayClusters API
 //
 // Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-// compatibility only and is frozen at its December 2023 feature set. Use
-// ray.io/v1, the storage version, for all new and existing RayClusters.
+// compatibility only, is frozen at its December 2023 feature set, and will be
+// unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+// and existing RayClusters.
 // +kubebuilder:object:root=true
-// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster. v1alpha1 receives no new fields and will be removed in a future release."
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster. v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -102,15 +102,16 @@ type RayJobStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob. v1alpha1 receives no new fields and will be removed in a future release."
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob. v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayJob is the Schema for the rayjobs API
 //
 // Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-// compatibility only and is frozen at its December 2023 feature set. Use
-// ray.io/v1, the storage version, for all new and existing RayJobs.
+// compatibility only, is frozen at its December 2023 feature set, and will be
+// unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+// and existing RayJobs.
 type RayJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -102,10 +102,15 @@ type RayJobStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob. v1alpha1 receives no new fields and will be removed in a future release."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayJob is the Schema for the rayjobs API
+//
+// Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+// compatibility only and is frozen at its December 2023 feature set. Use
+// ray.io/v1, the storage version, for all new and existing RayJobs.
 type RayJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -100,10 +100,15 @@ type ServeDeploymentStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService. v1alpha1 receives no new fields and will be removed in a future release."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayService is the Schema for the rayservices API
+//
+// Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
+// compatibility only and is frozen at its December 2023 feature set. Use
+// ray.io/v1, the storage version, for all new and existing RayServices.
 type RayService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -100,15 +100,16 @@ type ServeDeploymentStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService. v1alpha1 receives no new fields and will be removed in a future release."
+// +kubebuilder:deprecatedversion:warning="ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService. v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9."
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayService is the Schema for the rayservices API
 //
 // Deprecated: ray.io/v1alpha1 is deprecated. It is served for backward
-// compatibility only and is frozen at its December 2023 feature set. Use
-// ray.io/v1, the storage version, for all new and existing RayServices.
+// compatibility only, is frozen at its December 2023 feature set, and will be
+// unavailable in KubeRay 1.9. Use ray.io/v1, the storage version, for all new
+// and existing RayServices.
 type RayService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -9349,6 +9349,9 @@ spec:
       name: head service IP
       priority: 1
       type: string
+    deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster.
+      v1alpha1 receives no new fields and will be removed in a future release.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -9351,7 +9351,7 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -13296,7 +13296,7 @@ spec:
       status: {}
   - deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -13294,7 +13294,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob.
+      v1alpha1 receives no new fields and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -9765,7 +9765,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService.
+      v1alpha1 receives no new fields and will be removed in a future release.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -9767,7 +9767,7 @@ spec:
       status: {}
   - deprecated: true
     deprecationWarning: ray.io/v1alpha1 RayService is deprecated; use ray.io/v1 RayService.
-      v1alpha1 receives no new fields and will be removed in a future release.
+      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## Why are these changes needed?

`ray.io/v1alpha1` is served but not stored, and has been since #1482 made `v1` the storage version in October 2023. Today nothing tells users that. There's no `deprecated` flag on the version, no `deprecationWarning`, and no conversion webhook, so `kubectl apply` of a `ray.io/v1alpha1` manifest succeeds with no output at all.

That silence is the problem, because the two versions are far apart now:

- `ray.io/v1` exposes 63 exported types; `ray.io/v1alpha1` exposes 27.
- Everything added since December 2023 is v1-only: `authOptions`, `tlsOptions`, `networkPolicy`, `gcsFaultToleranceOptions`, `historyServerOptions`, `deletionPolicy`, the RayCluster and RayService upgrade strategies, and `RayCronJob`.
- `RayClusterSpec` has 14 fields in v1 and 7 in v1alpha1.

None of the CRDs declare a `conversion:` stanza, so the strategy is `None` and fields absent from the v1alpha1 schema are pruned on that request path. A user who applies a v1alpha1 RayCluster with `tlsOptions` set gets a cluster without TLS and no error.

Worth flagging that this isn't just an unfortunate side effect. [The CRD versioning docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/) describe `strategy: None` as being for the case where all served versions share an identical schema, since the only thing the API server rewrites is the `apiVersion` field. Ours diverged a long time ago — 14 fields vs. 7 on `RayClusterSpec` alone. Serving two materially different schemas through a no-op converter is what produces the silent pruning, so the behavior is the predictable consequence of the current configuration rather than a bug in it.

The v1alpha1 Go types also aren't wired into anything anymore. `main.go` registers only `rayv1` in the manager scheme, the generated clientset under `pkg/client/.../typed/ray/` contains only `v1`, and no non-generated file in the repo imports `apis/ray/v1alpha1`. The package exists so `controller-gen` still emits the schema. Its last functional change was #1788 on 2023-12-29.

This PR adds the missing signal. It doesn't remove anything.

## What changed

Added `+kubebuilder:deprecatedversion:warning=...` to the three v1alpha1 root types, plus a Go `Deprecated:` doc comment on each and one on the package itself, then regenerated.

The generated CRD change is three stanzas, one per kind:

```yaml
  - deprecated: true
    deprecationWarning: ray.io/v1alpha1 RayJob is deprecated; use ray.io/v1 RayJob.
      v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.
    name: v1alpha1
```

No schema churn beyond that.

The warning names a release rather than saying "a future release" because #5124 now records the target: `served: false` in 1.9, removal from the CRD in 1.10. Naming 1.9 tells a user reading the `kubectl` warning when their manifest stops working, which is the number they need.

The benchmark manifest template also moves to `ray.io/v1`. It only sets fields that exist in both versions, so the cluster it generates is unchanged. It was the last committed manifest in the repo carrying `apiVersion: ray.io/v1alpha1`; after this, the only remaining occurrences are the generated CRDs and API reference. The remaining `config.ray.io/v1alpha1` hits in the Helm templates are a different and current API group.

The `Deprecated:` doc comments do double duty. They don't reach the CRD, because `CRD_OPTIONS` sets `maxDescLen=0`, but they do reach `docs/reference/api.md`, and they give Go consumers a `staticcheck` SA1019 warning when they import the v1alpha1 types. The package-level notice covers any import of the package, not only a reference to one of the three kinds. It lives in `groupversion_info.go`, which already holds the package doc comment and the `+groupName` marker; putting it in `doc.go` instead would create a second package comment and duplicate the summary line in the generated reference.

Files:

| File | Change |
| --- | --- |
| `ray-operator/apis/ray/v1alpha1/{raycluster,rayjob,rayservice}_types.go` | Hand-edited: marker + `Deprecated:` comment |
| `ray-operator/apis/ray/v1alpha1/groupversion_info.go` | Hand-edited: package-level `Deprecated:` comment |
| `ray-operator/config/crd/bases/ray.io_ray{clusters,jobs,services}.yaml` | Generated by `make manifests` |
| `helm-chart/kuberay-operator/crds/ray.io_ray{clusters,jobs,services}.yaml` | Generated by `make helm` |
| `docs/reference/api.md` | Generated by `make api-docs` |
| `benchmark/memory_benchmark/scripts/ray-cluster.benchmark.yaml.template` | Hand-edited: `apiVersion` moved to `ray.io/v1` |

## This is the deprecation step of a sequence that stalled

Framing this as "a new deprecation" undersells it. The standard removal runway for a CRD version is four steps, stated most explicitly in [Gateway API's versioning policy](https://gateway-api.sigs.k8s.io/docs/concepts/versioning/):

> Within the Standard Channel, the removal of an API version is spread into at least four minor releases: a newer API version is configured as the storage version, the version is deprecated, the version is no longer served but still included in the CRD, and finally the version is no longer included in the CRD.

Where KubeRay actually sits:

| Step | Status |
| --- | --- |
| 1. Newer version becomes the storage version | Done — #1482, October 2023 |
| 2. Old version marked deprecated | **This PR** |
| 3. `served: false`, still present in the CRD | Open |
| 4. Removed from the CRD | Open |

Step 1 landed almost three years ago and step 2 was never taken. That's the whole reason there's no user-visible signal today, and it's why I'd frame this as finishing something rather than starting it.

## Should v1alpha1 be removed instead?

I think yes, eventually, and I'd like maintainer input on the timing. I'm not proposing removal in this PR because step 3 and step 4 need a deprecation period that has never formally started — but I don't think "keep it indefinitely" is the alternative either.

**The precedent says removal is normal.** Kubernetes' own [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) Rule #4a says alpha versions "may be removed in any release without prior deprecation notice." That policy governs core APIs rather than CRDs, so it isn't binding here, but it's the rung `v1alpha1` sits on. Two comparable projects, both with larger blast radius than KubeRay:

| Project | Stable version introduced | Old versions removed | Window |
| --- | --- | --- | --- |
| cert-manager | v1.0.0 (2020-09-02) | v1.7.0 (2022-01-26) — dropped `v1alpha2`, `v1alpha3`, `v1beta1` | ~17 months |
| Cluster API | v1.0.0 (2021-10-06) | v1.6.0 dropped `v1alpha3`; v1.7.0 (2024-04-16) dropped `v1alpha4` | ~30 months |
| KubeRay | v1.0.0 (2023-11-07) | still served | ~33 months |

**The spec argument is the strongest one.** As noted above, `strategy: None` is specified for versions sharing one schema, and ours haven't for years. The two ways back into spec are a conversion webhook or removal. Writing and maintaining a converter for a version nobody develops against is hard to justify, which leaves removal.

**But a straight removal PR still shouldn't go first, for two reasons.**

First, downstream consumers. #1771 deleted v1alpha1 in December 2023 and #1784 reverted it four days later because Kueue couldn't straddle both versions; the plan recorded there was removal in 1.2.0, and we're on 1.6.2. Kueue itself is resolved — `kubernetes-sigs/kueue` now has 43 references to `apis/ray/v1` and zero to `v1alpha1`. The class of problem isn't:

- GitHub code search returns on the order of 1,500 YAML files matching `ray.io/v1alpha1`, including manifests in `awslabs/ai-on-eks`, `Azure-Samples/aks-labs`, `data-prep-kit/data-prep-kit`, and `project-codeflare/multi-cluster-app-dispatcher`. Some of those hits are `config.ray.io/v1alpha1`, a different and current API group, so treat that as an upper bound.
- At least one live Go consumer still builds on the v1alpha1 types: `koordinator-sh/koord-queue`, last pushed 2026-04-27, whose `pkg/jobext/handles/rayjob.go` reconciles `rayv1alpha1.RayJob`. Same shape as the Kueue problem in 2023. The `Deprecated:` doc comments in this PR are what would give that project a `staticcheck` signal.

Second, `status.storedVersions`. Removal isn't purely a code deletion: the API server rejects removing a version from `spec.versions` while it remains in `status.storedVersions`, and that field doesn't self-clean. Any cluster that installed KubeRay before v1.0 still lists `v1alpha1` there until every object is rewritten and the status is patched. cert-manager handled this by making it a hard user prerequisite in their [1.6 to 1.7 upgrade notes](https://cert-manager.io/docs/releases/upgrading/upgrading-1.6-1.7/) rather than shipping automation. RayClusters are much shorter-lived than Certificates so most clusters will already be clean, but the eventual removal PR needs an upgrade note with a verification command, not just the deletion.

**KubeRay's own published policy suggests the cadence.** The [API reference page in Ray docs](https://docs.ray.io/en/master/cluster/kubernetes/references.html) already carries a "KubeRay API compatibility and guarantees" section, which says maintainers "preserve the right to mark fields as deprecated and remove functionality associated with deprecated fields after a minimum of two minor releases."

That clause is scoped to *fields within v1*, and the section is silent on non-v1 API versions, so it doesn't settle this on its own. But two minor releases is the project's own stated interval for deprecate-then-remove, and applying it here gives a defensible timeline without importing anyone else's: deprecate in the next release, then `served: false` and removal from 1.9 onward. That's a stronger basis than the Gateway API runway I quoted above, which I'd treat as the sequence of steps rather than the schedule.

So my suggestion is: land the warning now, take step 3 once it's been out for the interval above, then step 4. Happy to write either. If you'd rather go straight to removal, or name a target release now, say so and I'll follow up with that PR instead.

The one documentation gap worth naming: that compatibility section covers field stability inside v1 and says nothing about the lifecycle of API *versions*. Extending it to cover version deprecation and removal would have prevented this drift, but it lives in the Ray repo rather than here, so it's a separate change with a different reviewer. I'm happy to draft it if maintainers want it.

## Related issue number

#5124 tracks the full four-step runway. @machichima filed it during review, and it records target releases for the remaining steps: `served: false` in 1.9 and removal from the CRD in 1.10. @tenzen-y confirmed on this thread that Kueue no longer depends on the alpha API and is fine with removal at any time.

Adjacent but separate: #5091 covers the anchor collision between the v1 and v1alpha1 sections of `docs/reference/api.md`. Removing v1alpha1 from generation would resolve it, which is part of why the removal question matters, but this PR doesn't touch that.

## Labels

- [x] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

Not breaking: this adds a warning and removes nothing. v1alpha1 remains served and every existing manifest still applies.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Confirm the generated output and that the API server surfaces the warning.

1. Verify the generators are deterministic and the committed files match:

```bash
cd ray-operator
make manifests helm api-docs
git diff --exit-code   # expect no output
./hack/verify-api-docs.sh
```

2. Confirm the version flags are right — v1 stored, v1alpha1 deprecated:

```bash
for f in config/crd/bases/ray.io_ray{clusters,jobs,services}.yaml; do
  echo "## $f"
  grep -nE "^  - name: v1|^    name: v1|^    served:|^    storage:|^    deprecated:" "$f"
done
```

3. Check the warning reaches a client. Against a cluster with the new CRDs applied:

```bash
kubectl apply -f - <<'EOF'
apiVersion: ray.io/v1alpha1
kind: RayCluster
metadata:
  name: deprecation-warning-check
spec:
  rayVersion: 2.9.0
  headGroupSpec:
    rayStartParams: {}
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.9.0
EOF
```

Expected: `Warning: ray.io/v1alpha1 RayCluster is deprecated; use ray.io/v1 RayCluster. v1alpha1 receives no new fields and will be unavailable in KubeRay 1.9.` The object is still created.

The same manifest with `apiVersion: ray.io/v1` produces no warning.

Verified locally: `make manifests`, `make helm`, and `make api-docs` all produce exactly the diff in this PR, and `go build ./...` and `go vet ./apis/ray/v1alpha1/` are clean with `controller-gen@v0.16.5`.

