### PR TITLE
[History Server] Support Ray 2.56 task log info

### DIFF
--- a/historyserver/config/raycluster.yaml
+++ b/historyserver/config/raycluster.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 spec:
   # Enable Ray token authentication. Requires Ray 2.52.0+
-  # rayVersion: "2.55.0"
+  # rayVersion: "2.56.0"
   # authOptions:
   #   mode: token
   headGroupSpec:
@@ -32,7 +32,7 @@ spec:
             value: "http://localhost:8084/v1/events"
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "ALL"
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:2.56.0
           imagePullPolicy: IfNotPresent
           name: ray-head
           resources:
@@ -138,7 +138,7 @@ spec:
             value: "http://localhost:8084/v1/events"
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "ALL"
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:2.56.0
           imagePullPolicy: IfNotPresent
           name: ray-worker
           resources:

--- a/historyserver/config/raycluster.yaml
+++ b/historyserver/config/raycluster.yaml
@@ -119,7 +119,10 @@ spec:
     maxReplicas: 1000
     minReplicas: 1
     numOfHosts: 1
-    rayStartParams: {}
+    # Keep one reusable Python worker so the task-log E2E can prove byte-range
+    # isolation within a single physical worker log file.
+    rayStartParams:
+      num-cpus: "1"
     replicas: 1
     template:
       metadata:

--- a/historyserver/config/rayjob.yaml
+++ b/historyserver/config/rayjob.yaml
@@ -14,10 +14,6 @@ spec:
     @ray.remote(num_cpus=1)
     def my_task(x):
         print(f'Processing {x}', flush=True)
-        if x == 1:
-            # Keep the task running beyond Ray's 1-second task-event flush interval
-            # so its start and end log metadata are exported separately.
-            time.sleep(2)
         return x * 2
 
     # --- Scenario 2: Nested tasks (parent spawns child) ---

--- a/historyserver/config/rayjob.yaml
+++ b/historyserver/config/rayjob.yaml
@@ -10,11 +10,14 @@ spec:
     from ray.util.placement_group import placement_group
     ray.init()
 
-    # --- Scenario 1: Root-level NORMAL_TASK (single call) ---
-    @ray.remote(num_cpus=0.1)
+    # --- Scenario 1: Root-level NORMAL_TASK with same-worker log boundaries ---
+    @ray.remote(num_cpus=1)
     def my_task(x):
-        # NOTE: Add this to ensure will produce log.out
         print(f'Processing {x}', flush=True)
+        if x == 1:
+            # Keep the task running beyond Ray's 1-second task-event flush interval
+            # so its start and end log metadata are exported separately.
+            time.sleep(2)
         return x * 2
 
     # --- Scenario 2: Nested tasks (parent spawns child) ---
@@ -50,8 +53,11 @@ spec:
             return self.count
 
     # Execute all scenarios:
+    ray.get(my_task.options(name='task_log_before').remote(0))
     task_result = ray.get(my_task.remote(1))
     print(f'Task result: {task_result}')
+
+    ray.get(my_task.options(name='task_log_noise').remote(2))
 
     nested_result = ray.get(parent_task.remote())
     print(f'Nested result: {nested_result}')

--- a/historyserver/config/rayjob.yaml
+++ b/historyserver/config/rayjob.yaml
@@ -14,6 +14,11 @@ spec:
     @ray.remote(num_cpus=1)
     def my_task(x):
         print(f'Processing {x}', flush=True)
+        if x == 1:
+            # TODO: Remove this sleep once ray#65288 is released.
+            # Ray 2.56 overwrites task log metadata when start and end events
+            # are flushed together, which causes tasks to lose their log file path.
+            time.sleep(2)
         return x * 2
 
     # --- Scenario 2: Nested tasks (parent spawns child) ---

--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -25,7 +25,7 @@ import (
 type EventHandler struct {
 	reader storage.StorageReader
 
-	ClusterTaskMap *types.ClusterTaskMap
+	ClusterTaskMap     *types.ClusterTaskMap
 	ClusterActorMap    *types.ClusterActorMap
 	ClusterJobMap      *types.ClusterJobMap
 	ClusterNodeMap     *types.ClusterNodeMap
@@ -715,11 +715,13 @@ func (h *EventHandler) handleTaskDefinitionEvent(eventMap map[string]any, cluste
 			task.WorkerPID = existingWorkerPID
 			task.IsDebuggerPaused = existingIsDebuggerPaused
 			task.ActorReprName = existingActorReprName
-			task.TaskLogInfo = existingTaskLogInfo
 			task.State = task.GetLastState()
 			task.StartTime = existingStartTime
 			task.EndTime = existingEndTime
 			task.CreationTime = existingCreationTime
+		}
+		if existingTaskLogInfo != nil {
+			task.TaskLogInfo = existingTaskLogInfo
 		}
 
 		// Restore profile-derived fields (from TASK_PROFILE_EVENT)
@@ -733,6 +735,52 @@ func (h *EventHandler) handleTaskDefinitionEvent(eventMap map[string]any, cluste
 	})
 
 	return nil
+}
+
+// mergeTaskLogInfo combines Ray's partial log-start and log-end updates.
+func mergeTaskLogInfo(current **types.TaskLogInfo, update *types.TaskLogInfo) {
+	if update == nil {
+		return
+	}
+	if *current == nil {
+		copied := *update
+		*current = &copied
+		return
+	}
+
+	mergeTaskLogStream(
+		&(*current).StdoutFile,
+		&(*current).StdoutStart,
+		&(*current).StdoutEnd,
+		update.StdoutFile,
+		update.StdoutStart,
+		update.StdoutEnd,
+	)
+	mergeTaskLogStream(
+		&(*current).StderrFile,
+		&(*current).StderrStart,
+		&(*current).StderrEnd,
+		update.StderrFile,
+		update.StderrStart,
+		update.StderrEnd,
+	)
+}
+
+func mergeTaskLogStream(
+	currentFile *string,
+	currentStart, currentEnd *int64,
+	updateFile string,
+	updateStart, updateEnd int64,
+) {
+	if updateFile != "" {
+		*currentFile = updateFile
+		*currentStart = updateStart
+	} else if updateStart != 0 {
+		*currentStart = updateStart
+	}
+	if updateEnd != 0 || *currentEnd == 0 {
+		*currentEnd = updateEnd
+	}
 }
 
 // handleTaskLifecycleEvent processes TASK_LIFECYCLE_EVENT and merges state transitions for a given task attempt.
@@ -756,9 +804,8 @@ func (h *EventHandler) handleTaskLifecycleEvent(eventMap map[string]any, cluster
 	}
 	normalizeTaskIDsToHex(&currTask)
 
-	// TODO(jiangjiawei1103): Clarify if there must be at least one state transition. Can one task have more than one state transition?
-	if len(currTask.StateTransitions) == 0 {
-		return fmt.Errorf("TASK_LIFECYCLE_EVENT must have at least one state transition")
+	if len(currTask.StateTransitions) == 0 && currTask.TaskLogInfo == nil {
+		return fmt.Errorf("TASK_LIFECYCLE_EVENT must have at least one state transition or task log info")
 	}
 
 	taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(clusterSessionKey)
@@ -788,16 +835,18 @@ func (h *EventHandler) handleTaskLifecycleEvent(eventMap map[string]any, cluster
 			return task.StateTransitions[i].Timestamp.Before(task.StateTransitions[j].Timestamp)
 		})
 
-		if len(task.StateTransitions) == 0 {
+		if currTask.JobID != "" {
+			task.JobID = currTask.JobID
+		}
+		mergeTaskLogInfo(&task.TaskLogInfo, currTask.TaskLogInfo)
+
+		if len(currTask.StateTransitions) == 0 {
 			return
 		}
 
 		// TODO(jiangjiawei1103): Before beta, the lifecycle-related fields are overwritten.
 		// In beta, the complete historical replay will be supported.
 		task.RayErrorInfo = currTask.RayErrorInfo
-		if currTask.JobID != "" {
-			task.JobID = currTask.JobID
-		}
 		if currTask.NodeID != "" {
 			task.NodeID = currTask.NodeID
 		}
@@ -809,7 +858,6 @@ func (h *EventHandler) handleTaskLifecycleEvent(eventMap map[string]any, cluster
 		}
 		task.IsDebuggerPaused = currTask.IsDebuggerPaused
 		task.ActorReprName = currTask.ActorReprName
-		task.TaskLogInfo = currTask.TaskLogInfo
 		task.State = task.GetLastState()
 
 		// Derive creation time, start time and end time from state transitions.

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -515,6 +515,139 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 	}
 }
 
+func TestTaskLogInfoLifecycleReplay(t *testing.T) {
+	const (
+		clusterName = "cluster1"
+		taskID      = "ccccdddd5678ccccaaaabbbb1234aaaabbbb1234aaaabbbb"
+	)
+
+	makeLogEvent := func(attempt int, taskLogInfo map[string]any) map[string]any {
+		return map[string]any{
+			"eventType": string(types.TASK_LIFECYCLE_EVENT),
+			"taskLifecycleEvent": map[string]any{
+				"taskId":           taskID,
+				"taskAttempt":      attempt,
+				"stateTransitions": []any{},
+				"taskLogInfo":      taskLogInfo,
+			},
+		}
+	}
+	start := makeLogEvent(0, map[string]any{
+		"stdoutFile": "worker.out", "stderrFile": "worker.err",
+		"stdoutStart": "0", "stdoutEnd": "0", "stderrStart": "7", "stderrEnd": "0",
+	})
+	end := makeLogEvent(0, map[string]any{
+		"stdoutFile": "", "stderrFile": "",
+		"stdoutStart": "0", "stdoutEnd": "20", "stderrStart": "0", "stderrEnd": "30",
+	})
+	definition := makeTaskEventMap("bench_task", "", taskID, 0)
+	stateWithoutLogInfo := map[string]any{
+		"eventType": string(types.TASK_LIFECYCLE_EVENT),
+		"taskLifecycleEvent": map[string]any{
+			"taskId":      taskID,
+			"taskAttempt": 0,
+			"stateTransitions": []any{map[string]any{
+				"state": "RUNNING", "timestamp": "2026-08-08T01:45:58.211147463Z",
+			}},
+		},
+	}
+	want := &types.TaskLogInfo{
+		StdoutFile: "worker.out", StderrFile: "worker.err",
+		StdoutStart: 0, StdoutEnd: 20, StderrStart: 7, StderrEnd: 30,
+	}
+
+	for _, tt := range []struct {
+		name   string
+		events []map[string]any
+	}{
+		{name: "start then end", events: []map[string]any{start, end, definition, stateWithoutLogInfo}},
+		{name: "end then start", events: []map[string]any{end, start, definition, stateWithoutLogInfo}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewEventHandler(nil)
+			for _, event := range tt.events {
+				require.NoError(t, h.storeEvent(clusterName, event))
+			}
+			tasks := h.getTasks(clusterName)
+			require.Len(t, tasks, 1)
+			assert.Equal(t, want, tasks[0].TaskLogInfo)
+			assert.Equal(t, "bench_task", tasks[0].TaskName)
+			assert.Equal(t, types.RUNNING, tasks[0].State)
+		})
+	}
+
+	t.Run("metadata-only update preserves lifecycle fields", func(t *testing.T) {
+		h := NewEventHandler(nil)
+		state := stateWithoutLogInfo["taskLifecycleEvent"].(map[string]any)
+		state["jobId"] = "aaaabbbb"
+		state["workerPid"] = 123
+		state["actorReprName"] = "Counter.increment"
+		require.NoError(t, h.storeEvent(clusterName, stateWithoutLogInfo))
+		before := h.getTasks(clusterName)[0]
+
+		require.NoError(t, h.storeEvent(clusterName, end))
+		after := h.getTasks(clusterName)[0]
+		assert.Equal(t, before.StateTransitions, after.StateTransitions)
+		assert.Equal(t, before.State, after.State)
+		assert.Equal(t, before.JobID, after.JobID)
+		assert.Equal(t, before.WorkerPID, after.WorkerPID)
+		assert.Equal(t, before.ActorReprName, after.ActorReprName)
+		require.NotNil(t, after.TaskLogInfo)
+		assert.Equal(t, int64(20), after.TaskLogInfo.StdoutEnd)
+	})
+
+	t.Run("task attempts remain isolated", func(t *testing.T) {
+		h := NewEventHandler(nil)
+		attempt1 := makeLogEvent(1, map[string]any{
+			"stdoutFile": "attempt1.out", "stdoutStart": "25", "stdoutEnd": "0",
+		})
+		require.NoError(t, h.storeEvent(clusterName, end))
+		require.NoError(t, h.storeEvent(clusterName, attempt1))
+		tasks := h.getTasks(clusterName)
+		require.Len(t, tasks, 2)
+		assert.Equal(t, int64(20), tasks[0].TaskLogInfo.StdoutEnd)
+		assert.Equal(t, "attempt1.out", tasks[1].TaskLogInfo.StdoutFile)
+		assert.Zero(t, tasks[1].TaskLogInfo.StdoutEnd)
+	})
+
+	h := NewEventHandler(nil)
+	err := h.storeEvent(clusterName, map[string]any{
+		"eventType": string(types.TASK_LIFECYCLE_EVENT),
+		"taskLifecycleEvent": map[string]any{
+			"taskId": taskID, "taskAttempt": 0, "stateTransitions": []any{},
+		},
+	})
+	require.Error(t, err, "an empty lifecycle event without TaskLogInfo must still be rejected")
+}
+
+func TestStoreRay256TaskLogInfoJSONL(t *testing.T) {
+	const capturedEvents = `
+{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskLogInfo":{"stderrEnd":"6331","stderrFile":"","stderrStart":"0","stdoutEnd":"6331","stdoutFile":"","stdoutStart":"0"},"workerId":"","workerPid":0}}
+{"eventType":"TASK_DEFINITION_EVENT","taskDefinitionEvent":{"jobId":"AwAAAA==","language":"PYTHON","requiredResources":{"CPU":0.2},"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskName":"bench_task","taskType":"NORMAL_TASK"}}
+{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[{"state":"RUNNING","timestamp":"2026-08-08T01:45:58.211147463Z"}],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","workerId":"","workerPid":215}}
+{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"D2kMAY8zIxLFuYnLXnAKJtuumyBv618fCGSF7g==","stateTransitions":[{"state":"PENDING_ARGS_AVAIL","timestamp":"2026-08-08T01:45:57.009825296Z"},{"state":"SUBMITTED_TO_WORKER","timestamp":"2026-08-08T01:45:58.209153338Z"},{"state":"FINISHED","timestamp":"2026-08-08T01:45:58.224019505Z"}],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","workerId":"BYdHtXNHrWxpi1lRHeTmT8N+THrSsDPrfN988Q==","workerPid":0}}
+`
+
+	events, err := DecodeEventFileBytes("ray-2.56-events.jsonl", []byte(capturedEvents))
+	require.NoError(t, err)
+	require.Len(t, events, 4)
+
+	h := NewEventHandler(nil)
+	for _, event := range events {
+		require.NoError(t, h.storeEvent("cluster1", event))
+	}
+	tasks := h.getTasks("cluster1")
+	require.Len(t, tasks, 1)
+	task := tasks[0]
+	assert.Equal(t, "bench_task", task.TaskName)
+	assert.Equal(t, types.FINISHED, task.State)
+	assert.NotEmpty(t, task.NodeID)
+	assert.NotEmpty(t, task.WorkerID)
+	require.NotNil(t, task.TaskLogInfo)
+	assert.Equal(t, int64(6331), task.TaskLogInfo.StdoutEnd)
+	assert.Equal(t, int64(6331), task.TaskLogInfo.StderrEnd)
+}
+
 // TestActorLifecycleEventDeduplication verifies that duplicate actor events are correctly filtered
 func TestActorLifecycleEventDeduplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestStoreEvent for rationale.

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -532,13 +532,16 @@ func TestTaskLogInfoLifecycleReplay(t *testing.T) {
 			},
 		}
 	}
+	// Ray reports a task's log boundaries through two separate calls:
+	// - RecordTaskLogStart sets only the file paths and start offsets
+	// - RecordTaskLogEnd sets only the end offsets.
+	// Ref: https://github.com/ray-project/ray/blob/d53df23caf6210f6bca58855607951d89c52d345/src/ray/core_worker/core_worker.cc#L4933-L4976
 	start := makeLogEvent(0, map[string]any{
 		"stdoutFile": "worker.out", "stderrFile": "worker.err",
-		"stdoutStart": "0", "stdoutEnd": "0", "stderrStart": "7", "stderrEnd": "0",
+		"stdoutStart": "0", "stderrStart": "7",
 	})
 	end := makeLogEvent(0, map[string]any{
-		"stdoutFile": "", "stderrFile": "",
-		"stdoutStart": "0", "stdoutEnd": "20", "stderrStart": "0", "stderrEnd": "30",
+		"stdoutEnd": "20", "stderrEnd": "30",
 	})
 	definition := makeTaskEventMap("bench_task", "", taskID, 0)
 	stateWithoutLogInfo := map[string]any{
@@ -599,7 +602,8 @@ func TestTaskLogInfoLifecycleReplay(t *testing.T) {
 	t.Run("task attempts remain isolated", func(t *testing.T) {
 		h := NewEventHandler(nil)
 		attempt1 := makeLogEvent(1, map[string]any{
-			"stdoutFile": "attempt1.out", "stdoutStart": "25", "stdoutEnd": "0",
+			"stdoutFile": "attempt1.out", "stderrFile": "attempt1.err",
+			"stdoutStart": "25", "stderrStart": "25",
 		})
 		require.NoError(t, h.storeEvent(clusterName, end))
 		require.NoError(t, h.storeEvent(clusterName, attempt1))
@@ -621,16 +625,19 @@ func TestTaskLogInfoLifecycleReplay(t *testing.T) {
 }
 
 func TestStoreRay256TaskLogInfoJSONL(t *testing.T) {
+	// A task whose execution spans Ray's ray_events_report_interval_ms (1s default)
+	// exports its log start and log end as two lifecycle events
 	const capturedEvents = `
-{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskLogInfo":{"stderrEnd":"6331","stderrFile":"","stderrStart":"0","stdoutEnd":"6331","stdoutFile":"","stdoutStart":"0"},"workerId":"","workerPid":0}}
+{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskLogInfo":{"stdoutFile":"/tmp/ray/session_2026-08-08_01-45-50_123456_1/logs/worker-058747b57347ad6c698b59511de4e64fc37e4c7ad2b033eb7cdf7cf1-03000000-215.out","stderrFile":"/tmp/ray/session_2026-08-08_01-45-50_123456_1/logs/worker-058747b57347ad6c698b59511de4e64fc37e4c7ad2b033eb7cdf7cf1-03000000-215.err","stdoutStart":"512","stderrStart":"0"},"workerId":"","workerPid":0}}
 {"eventType":"TASK_DEFINITION_EVENT","taskDefinitionEvent":{"jobId":"AwAAAA==","language":"PYTHON","requiredResources":{"CPU":0.2},"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskName":"bench_task","taskType":"NORMAL_TASK"}}
 {"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[{"state":"RUNNING","timestamp":"2026-08-08T01:45:58.211147463Z"}],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","workerId":"","workerPid":215}}
+{"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"","stateTransitions":[],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","taskLogInfo":{"stdoutEnd":"6331","stderrEnd":"6331"},"workerId":"","workerPid":0}}
 {"eventType":"TASK_LIFECYCLE_EVENT","taskLifecycleEvent":{"jobId":"AwAAAA==","nodeId":"D2kMAY8zIxLFuYnLXnAKJtuumyBv618fCGSF7g==","stateTransitions":[{"state":"PENDING_ARGS_AVAIL","timestamp":"2026-08-08T01:45:57.009825296Z"},{"state":"SUBMITTED_TO_WORKER","timestamp":"2026-08-08T01:45:58.209153338Z"},{"state":"FINISHED","timestamp":"2026-08-08T01:45:58.224019505Z"}],"taskAttempt":0,"taskId":"UYPGNywAXvb///////////////8DAAAA","workerId":"BYdHtXNHrWxpi1lRHeTmT8N+THrSsDPrfN988Q==","workerPid":0}}
 `
 
 	events, err := DecodeEventFileBytes("ray-2.56-events.jsonl", []byte(capturedEvents))
 	require.NoError(t, err)
-	require.Len(t, events, 4)
+	require.Len(t, events, 5)
 
 	h := NewEventHandler(nil)
 	for _, event := range events {
@@ -644,7 +651,10 @@ func TestStoreRay256TaskLogInfoJSONL(t *testing.T) {
 	assert.NotEmpty(t, task.NodeID)
 	assert.NotEmpty(t, task.WorkerID)
 	require.NotNil(t, task.TaskLogInfo)
+	assert.Equal(t, "/tmp/ray/session_2026-08-08_01-45-50_123456_1/logs/worker-058747b57347ad6c698b59511de4e64fc37e4c7ad2b033eb7cdf7cf1-03000000-215.out", task.TaskLogInfo.StdoutFile)
+	assert.Equal(t, int64(512), task.TaskLogInfo.StdoutStart)
 	assert.Equal(t, int64(6331), task.TaskLogInfo.StdoutEnd)
+	assert.Equal(t, int64(0), task.TaskLogInfo.StderrStart)
 	assert.Equal(t, int64(6331), task.TaskLogInfo.StderrEnd)
 }
 

--- a/historyserver/pkg/eventserver/types/task.go
+++ b/historyserver/pkg/eventserver/types/task.go
@@ -1,8 +1,11 @@
 package types
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -99,6 +102,69 @@ type TaskLogInfo struct {
 	StderrEnd   int64  `json:"stderrEnd"`
 }
 
+// protoJSONInt64 accepts the quoted int64 representation required by ProtoJSON
+// as well as regular JSON numbers.
+type protoJSONInt64 int64
+
+func (value *protoJSONInt64) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+
+	if len(data) > 0 && data[0] == '"' {
+		var encodedValue string
+		if err := json.Unmarshal(data, &encodedValue); err != nil {
+			return err
+		}
+		parsedValue, err := strconv.ParseInt(encodedValue, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid int64 value %q: %w", encodedValue, err)
+		}
+		*value = protoJSONInt64(parsedValue)
+		return nil
+	}
+
+	var parsedValue int64
+	if err := json.Unmarshal(data, &parsedValue); err != nil {
+		return err
+	}
+	*value = protoJSONInt64(parsedValue)
+	return nil
+}
+
+// UnmarshalJSON accepts TaskLogInfo offsets produced by both standard JSON
+// encoders and ProtoJSON encoders.
+func (t *TaskLogInfo) UnmarshalJSON(data []byte) error {
+	decoded := struct {
+		StdoutFile  string         `json:"stdoutFile"`
+		StderrFile  string         `json:"stderrFile"`
+		StdoutStart protoJSONInt64 `json:"stdoutStart"`
+		StdoutEnd   protoJSONInt64 `json:"stdoutEnd"`
+		StderrStart protoJSONInt64 `json:"stderrStart"`
+		StderrEnd   protoJSONInt64 `json:"stderrEnd"`
+	}{
+		StdoutFile:  t.StdoutFile,
+		StderrFile:  t.StderrFile,
+		StdoutStart: protoJSONInt64(t.StdoutStart),
+		StdoutEnd:   protoJSONInt64(t.StdoutEnd),
+		StderrStart: protoJSONInt64(t.StderrStart),
+		StderrEnd:   protoJSONInt64(t.StderrEnd),
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	t.StdoutFile = decoded.StdoutFile
+	t.StderrFile = decoded.StderrFile
+	t.StdoutStart = int64(decoded.StdoutStart)
+	t.StdoutEnd = int64(decoded.StdoutEnd)
+	t.StderrStart = int64(decoded.StderrStart)
+	t.StderrEnd = int64(decoded.StderrEnd)
+	return nil
+}
+
 // Task's fields are populated from the TASK_DEFINITION_EVENT, ACTOR_TASK_DEFINITION_EVENT, and TASK_LIFECYCLE_EVENT.
 // A TASK_DEFINITION_EVENT or an ACTOR_TASK_DEFINITION_EVENT is expected to be emitted once per task attempt,
 // For proto definitions, please refer to:
@@ -153,8 +219,7 @@ type Task struct {
 	// Actor task repr name, if applicable.
 	ActorReprName *string `json:"actorReprName,omitempty"`
 
-	// TaskLogInfo is just added at https://github.com/ray-project/ray/pull/60287.
-	// TODO(jiangjiawei1103): Add support for TaskLogInfo.
+	// TaskLogInfo was added at https://github.com/ray-project/ray/pull/60287.
 	TaskLogInfo *TaskLogInfo `json:"taskLogInfo,omitempty"`
 
 	State        TaskStatus

--- a/historyserver/pkg/eventserver/types/task.go
+++ b/historyserver/pkg/eventserver/types/task.go
@@ -1,11 +1,8 @@
 package types
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -96,73 +93,10 @@ type TaskStateTransition struct {
 type TaskLogInfo struct {
 	StdoutFile  string `json:"stdoutFile"`
 	StderrFile  string `json:"stderrFile"`
-	StdoutStart int64  `json:"stdoutStart"`
-	StdoutEnd   int64  `json:"stdoutEnd"`
-	StderrStart int64  `json:"stderrStart"`
-	StderrEnd   int64  `json:"stderrEnd"`
-}
-
-// protoJSONInt64 accepts the quoted int64 representation required by ProtoJSON
-// as well as regular JSON numbers.
-type protoJSONInt64 int64
-
-func (value *protoJSONInt64) UnmarshalJSON(data []byte) error {
-	data = bytes.TrimSpace(data)
-	if bytes.Equal(data, []byte("null")) {
-		return nil
-	}
-
-	if len(data) > 0 && data[0] == '"' {
-		var encodedValue string
-		if err := json.Unmarshal(data, &encodedValue); err != nil {
-			return err
-		}
-		parsedValue, err := strconv.ParseInt(encodedValue, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid int64 value %q: %w", encodedValue, err)
-		}
-		*value = protoJSONInt64(parsedValue)
-		return nil
-	}
-
-	var parsedValue int64
-	if err := json.Unmarshal(data, &parsedValue); err != nil {
-		return err
-	}
-	*value = protoJSONInt64(parsedValue)
-	return nil
-}
-
-// UnmarshalJSON accepts TaskLogInfo offsets produced by both standard JSON
-// encoders and ProtoJSON encoders.
-func (t *TaskLogInfo) UnmarshalJSON(data []byte) error {
-	decoded := struct {
-		StdoutFile  string         `json:"stdoutFile"`
-		StderrFile  string         `json:"stderrFile"`
-		StdoutStart protoJSONInt64 `json:"stdoutStart"`
-		StdoutEnd   protoJSONInt64 `json:"stdoutEnd"`
-		StderrStart protoJSONInt64 `json:"stderrStart"`
-		StderrEnd   protoJSONInt64 `json:"stderrEnd"`
-	}{
-		StdoutFile:  t.StdoutFile,
-		StderrFile:  t.StderrFile,
-		StdoutStart: protoJSONInt64(t.StdoutStart),
-		StdoutEnd:   protoJSONInt64(t.StdoutEnd),
-		StderrStart: protoJSONInt64(t.StderrStart),
-		StderrEnd:   protoJSONInt64(t.StderrEnd),
-	}
-
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
-	}
-
-	t.StdoutFile = decoded.StdoutFile
-	t.StderrFile = decoded.StderrFile
-	t.StdoutStart = int64(decoded.StdoutStart)
-	t.StdoutEnd = int64(decoded.StdoutEnd)
-	t.StderrStart = int64(decoded.StderrStart)
-	t.StderrEnd = int64(decoded.StderrEnd)
-	return nil
+	StdoutStart int64  `json:"stdoutStart,string"`
+	StdoutEnd   int64  `json:"stdoutEnd,string"`
+	StderrStart int64  `json:"stderrStart,string"`
+	StderrEnd   int64  `json:"stderrEnd,string"`
 }
 
 // Task's fields are populated from the TASK_DEFINITION_EVENT, ACTOR_TASK_DEFINITION_EVENT, and TASK_LIFECYCLE_EVENT.

--- a/historyserver/pkg/eventserver/types/task_test.go
+++ b/historyserver/pkg/eventserver/types/task_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTaskLogInfoUnmarshalJSON(t *testing.T) {
+func TestTaskLogInfoProtoJSON(t *testing.T) {
 	want := TaskLogInfo{
 		StdoutFile:  "worker.out",
 		StderrFile:  "worker.err",
@@ -19,25 +19,9 @@ func TestTaskLogInfoUnmarshalJSON(t *testing.T) {
 		StderrEnd:   40,
 	}
 
-	for _, tt := range []struct {
-		name string
-		data string
-	}{
-		{
-			name: "ProtoJSON quoted int64 values",
-			data: `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":"10","stdoutEnd":"20","stderrStart":"30","stderrEnd":"40"}`,
-		},
-		{
-			name: "regular JSON numbers",
-			data: `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":10,"stdoutEnd":20,"stderrStart":30,"stderrEnd":40}`,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			var got TaskLogInfo
-			require.NoError(t, json.Unmarshal([]byte(tt.data), &got))
-			assert.Equal(t, want, got)
-		})
-	}
+	var got TaskLogInfo
+	require.NoError(t, json.Unmarshal([]byte(`{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":"10","stdoutEnd":"20","stderrStart":"30","stderrEnd":"40"}`), &got))
+	assert.Equal(t, want, got)
 
 	t.Run("missing and null fields keep their existing values", func(t *testing.T) {
 		got := want
@@ -59,18 +43,18 @@ func TestTaskLogInfoUnmarshalJSON(t *testing.T) {
 	for _, data := range []string{
 		`{"stdoutEnd":"not-an-integer"}`,
 		`{"stdoutEnd":"9223372036854775808"}`,
+		`{"stdoutEnd":1}`,
 		`{"stdoutEnd":1.5}`,
 	} {
 		t.Run("invalid value "+data, func(t *testing.T) {
-			got := want
+			var got TaskLogInfo
 			require.Error(t, json.Unmarshal([]byte(data), &got))
-			assert.Equal(t, want, got, "a failed decode must not partially mutate TaskLogInfo")
 		})
 	}
 
-	t.Run("marshals offsets as JSON numbers", func(t *testing.T) {
+	t.Run("marshals offsets as ProtoJSON strings", func(t *testing.T) {
 		data, err := json.Marshal(want)
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":10,"stdoutEnd":20,"stderrStart":30,"stderrEnd":40}`, string(data))
+		assert.JSONEq(t, `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":"10","stdoutEnd":"20","stderrStart":"30","stderrEnd":"40"}`, string(data))
 	})
 }

--- a/historyserver/pkg/eventserver/types/task_test.go
+++ b/historyserver/pkg/eventserver/types/task_test.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskLogInfoUnmarshalJSON(t *testing.T) {
+	want := TaskLogInfo{
+		StdoutFile:  "worker.out",
+		StderrFile:  "worker.err",
+		StdoutStart: 10,
+		StdoutEnd:   20,
+		StderrStart: 30,
+		StderrEnd:   40,
+	}
+
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "ProtoJSON quoted int64 values",
+			data: `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":"10","stdoutEnd":"20","stderrStart":"30","stderrEnd":"40"}`,
+		},
+		{
+			name: "regular JSON numbers",
+			data: `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":10,"stdoutEnd":20,"stderrStart":30,"stderrEnd":40}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var got TaskLogInfo
+			require.NoError(t, json.Unmarshal([]byte(tt.data), &got))
+			assert.Equal(t, want, got)
+		})
+	}
+
+	t.Run("missing and null fields keep their existing values", func(t *testing.T) {
+		got := want
+		require.NoError(t, json.Unmarshal([]byte(`{"stdoutFile":"new.out","stdoutStart":null}`), &got))
+		assert.Equal(t, "new.out", got.StdoutFile)
+		assert.Equal(t, want.StdoutStart, got.StdoutStart)
+		assert.Equal(t, want.StdoutEnd, got.StdoutEnd)
+		assert.Equal(t, want.StderrFile, got.StderrFile)
+	})
+
+	t.Run("full int64 range", func(t *testing.T) {
+		var got TaskLogInfo
+		data := `{"stdoutStart":"-9223372036854775808","stdoutEnd":"9223372036854775807"}`
+		require.NoError(t, json.Unmarshal([]byte(data), &got))
+		assert.Equal(t, int64(math.MinInt64), got.StdoutStart)
+		assert.Equal(t, int64(math.MaxInt64), got.StdoutEnd)
+	})
+
+	for _, data := range []string{
+		`{"stdoutEnd":"not-an-integer"}`,
+		`{"stdoutEnd":"9223372036854775808"}`,
+		`{"stdoutEnd":1.5}`,
+	} {
+		t.Run("invalid value "+data, func(t *testing.T) {
+			got := want
+			require.Error(t, json.Unmarshal([]byte(data), &got))
+			assert.Equal(t, want, got, "a failed decode must not partially mutate TaskLogInfo")
+		})
+	}
+
+	t.Run("marshals offsets as JSON numbers", func(t *testing.T) {
+		data, err := json.Marshal(want)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"stdoutFile":"worker.out","stderrFile":"worker.err","stdoutStart":10,"stdoutEnd":20,"stderrStart":30,"stderrEnd":40}`, string(data))
+	})
+}

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -499,9 +499,8 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPath
 		)
 	}
 
-	// Try to use task_log_info if available
-	// NOTE: task_log_info is currently not supported in ray export event, so we will always
-	// fallback to following logic.
+	// Prefer task_log_info when Ray provides a file name. Some lifecycle events
+	// contain only offsets, so keep the worker ID fallback below.
 	if foundTask.TaskLogInfo != nil {
 		var logFilename string
 		if suffix == "err" {
@@ -509,7 +508,7 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPath
 		} else {
 			logFilename = foundTask.TaskLogInfo.StdoutFile
 		}
-		if logFilename != "" {
+		if logFilename = taskLogBasename(logFilename); logFilename != "" {
 			return foundTask.NodeID, logFilename, nil
 		}
 	}
@@ -530,6 +529,19 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPath
 	}
 
 	return nodeIDHex, logFilename, nil
+}
+
+// taskLogBasename maps Ray's absolute worker-container log path to the file
+// name stored below the History Server's per-node logs prefix.
+func taskLogBasename(filename string) string {
+	if filename == "" {
+		return ""
+	}
+	filename = path.Base(filename)
+	if filename == "." || filename == ".." || filename == "/" {
+		return ""
+	}
+	return filename
 }
 
 // resolveActorLogFilename resolves log file for an actor by querying actor events.

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -50,6 +50,10 @@ type logByteRange struct {
 	end   int64
 }
 
+// exactRangeReader reads exactly `remaining` bytes from the underlying reader.
+// Unlike io.LimitReader, it returns io.ErrUnexpectedEOF if the reader ends
+// early, so a truncated log file surfaces as an error instead of silently
+// returning a partial task log.
 type exactRangeReader struct {
 	reader    io.Reader
 	remaining int64

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -45,6 +45,31 @@ const (
 // Matches patterns like: \x1b[31m (red color), \x1b[0m (reset), etc.
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]+m`)
 
+type logByteRange struct {
+	start int64
+	end   int64
+}
+
+type exactRangeReader struct {
+	reader    io.Reader
+	remaining int64
+}
+
+func (r *exactRangeReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.reader.Read(p)
+	r.remaining -= int64(n)
+	if errors.Is(err, io.EOF) && r.remaining > 0 {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
 // filterAnsiEscapeCodes removes ANSI escape sequences from log content
 func filterAnsiEscapeCodes(content []byte) []byte {
 	return ansiEscapePattern.ReplaceAll(content, []byte(""))
@@ -292,7 +317,7 @@ func categorizeLogFiles(files []string) map[string][]string {
 
 func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, clusterLogPathPrefix, sessionID string, options GetLogFileOptions) ([]byte, error) {
 	// Resolve node_id and filename based on options
-	nodeID, filename, err := s.resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options)
+	nodeID, filename, byteRange, err := s.resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options)
 	if err != nil {
 		// Preserve HTTPError status code if already set, otherwise use BadRequest
 		var httpErr *utils.HTTPError
@@ -308,6 +333,10 @@ func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, clusterLogPathPrefix,
 
 	if reader == nil {
 		return nil, utils.NewHTTPError(fmt.Errorf("log file not found: %s", logPath), http.StatusNotFound)
+	}
+	reader, err = applyLogByteRange(reader, byteRange)
+	if err != nil {
+		return nil, err
 	}
 
 	maxLines := options.Lines
@@ -376,21 +405,38 @@ func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, clusterLogPathPrefix,
 	return result, nil
 }
 
+func applyLogByteRange(reader io.Reader, byteRange *logByteRange) (io.Reader, error) {
+	if byteRange == nil {
+		return reader, nil
+	}
+	if byteRange.start < 0 || byteRange.end < 0 || byteRange.end < byteRange.start {
+		return nil, fmt.Errorf("invalid task log byte range [%d,%d)", byteRange.start, byteRange.end)
+	}
+
+	if byteRange.start > 0 {
+		if _, err := io.CopyN(io.Discard, reader, byteRange.start); err != nil {
+			return nil, fmt.Errorf("task log ended before byte range start %d: %w", byteRange.start, err)
+		}
+	}
+
+	return &exactRangeReader{reader: reader, remaining: byteRange.end - byteRange.start}, nil
+}
+
 // resolveLogFilename resolves the log file node_id and filename based on the provided options.
 // This mirrors Ray Dashboard's resolve_filename logic.
 // The sessionID parameter is required for task_id resolution to search worker log files.
-func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID string, options GetLogFileOptions) (nodeID, filename string, err error) {
+func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID string, options GetLogFileOptions) (nodeID, filename string, byteRange *logByteRange, err error) {
 	// If filename is explicitly provided, use it and ignore suffix
 	if options.Filename != "" {
 		if options.NodeID == "" {
-			return "", "", fmt.Errorf("node_id is required when filename is provided")
+			return "", "", nil, fmt.Errorf("node_id is required when filename is provided")
 		}
 		filename := options.Filename
 		// Append attempt_number if specified for explicit filenames
 		if options.AttemptNumber > 0 {
 			filename = fmt.Sprintf("%s.%d", filename, options.AttemptNumber)
 		}
-		return options.NodeID, filename, nil
+		return options.NodeID, filename, nil, nil
 	}
 
 	// If task_id is provided, resolve from task events
@@ -400,15 +446,17 @@ func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterLogPathPref
 
 	// If actor_id is provided, resolve from actor events
 	if options.ActorID != "" {
-		return s.resolveActorLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options.ActorID, options.Suffix)
+		nodeID, filename, err := s.resolveActorLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options.ActorID, options.Suffix)
+		return nodeID, filename, nil, err
 	}
 
 	// If pid is provided, resolve worker log file
 	if options.PID > 0 {
-		return s.resolvePidLogFilename(clusterLogPathPrefix, sessionID, options.NodeID, options.PID, options.Suffix)
+		nodeID, filename, err := s.resolvePidLogFilename(clusterLogPathPrefix, sessionID, options.NodeID, options.PID, options.Suffix)
+		return nodeID, filename, nil, err
 	}
 
-	return "", "", fmt.Errorf("must provide one of: filename, task_id, actor_id, or pid")
+	return "", "", nil, fmt.Errorf("must provide one of: filename, task_id, actor_id, or pid")
 }
 
 // resolvePidLogFilename resolves a log file by PID.
@@ -454,15 +502,15 @@ func getTasksByID(tasks []eventtypes.Task, taskID string) ([]eventtypes.Task, bo
 // resolveTaskLogFilename resolves log file for a task by querying task events.
 // This mirrors Ray Dashboard's _resolve_task_filename logic.
 // The sessionID parameter is required for searching worker log files when task_log_info is not available.
-func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, taskID string, attemptNumber int, suffix string) (nodeID, filename string, err error) {
+func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, taskID string, attemptNumber int, suffix string) (nodeID, filename string, byteRange *logByteRange, err error) {
 	snap, ok := s.sessionLoader.GetSnapshot(clusterSessionKey)
 	if !ok {
-		return "", "", fmt.Errorf("snapshot not found for %s", clusterSessionKey)
+		return "", "", nil, fmt.Errorf("snapshot not found for %s", clusterSessionKey)
 	}
 
 	taskAttempts, found := getTasksByID(snap.Tasks, taskID)
 	if !found {
-		return "", "", fmt.Errorf("task not found: task_id=%s", taskID)
+		return "", "", nil, fmt.Errorf("task not found: task_id=%s", taskID)
 	}
 
 	// Find the specific attempt
@@ -475,60 +523,83 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPath
 	}
 
 	if foundTask == nil {
-		return "", "", fmt.Errorf("task attempt not found: task_id=%s, attempt_number=%d", taskID, attemptNumber)
+		return "", "", nil, fmt.Errorf("task attempt not found: task_id=%s, attempt_number=%d", taskID, attemptNumber)
 	}
 
 	// Check if task has node_id
 	if foundTask.NodeID == "" {
-		return "", "", fmt.Errorf("task %s (attempt %d) has no node_id (task not scheduled yet)", taskID, attemptNumber)
+		return "", "", nil, fmt.Errorf("task %s (attempt %d) has no node_id (task not scheduled yet)", taskID, attemptNumber)
 	}
 
 	// Check if this is an actor task
 	if foundTask.ActorID != "" {
-		return "", "", fmt.Errorf(
+		return "", "", nil, fmt.Errorf(
 			"for actor task, please query actor log for actor(%s) by providing actor_id query parameter",
 			foundTask.ActorID,
 		)
 	}
 
-	// Check if task has worker_id
+	// A task log range is only valid together with the file name from the same
+	// TaskLogInfo stream. Falling back to a worker file when that name is missing
+	// can return output from other tasks that reused the worker.
+	if foundTask.TaskLogInfo != nil {
+		var logFilename string
+		var start, end int64
+		if suffix == "err" {
+			logFilename = foundTask.TaskLogInfo.StderrFile
+			start = foundTask.TaskLogInfo.StderrStart
+			end = foundTask.TaskLogInfo.StderrEnd
+		} else {
+			logFilename = foundTask.TaskLogInfo.StdoutFile
+			start = foundTask.TaskLogInfo.StdoutStart
+			end = foundTask.TaskLogInfo.StdoutEnd
+		}
+		if logFilename = taskLogBasename(logFilename); logFilename != "" {
+			// Public Ray events use plain scalar offsets, so end == 0 is
+			// indistinguishable from a missing end update. Treat it as incomplete
+			// instead of reporting a potentially false empty log.
+			if end == 0 {
+				return "", "", nil, utils.NewHTTPError(
+					fmt.Errorf("task %s (attempt %d) has incomplete task_log_info for suffix %s: end offset is unavailable", taskID, attemptNumber, suffix),
+					http.StatusNotFound,
+				)
+			}
+			if start < 0 || end < 0 || end < start {
+				return "", "", nil, utils.NewHTTPError(
+					fmt.Errorf("task %s (attempt %d) has invalid %s log byte range [%d,%d)", taskID, attemptNumber, suffix, start, end),
+					http.StatusInternalServerError,
+				)
+			}
+			return foundTask.NodeID, logFilename, &logByteRange{start: start, end: end}, nil
+		}
+		return "", "", nil, utils.NewHTTPError(
+			fmt.Errorf("task %s (attempt %d) has incomplete task_log_info for suffix %s: log filename is empty", taskID, attemptNumber, suffix),
+			http.StatusNotFound,
+		)
+	}
+
+	// Fallback: Find worker log file by worker_id
 	if foundTask.WorkerID == "" {
-		return "", "", fmt.Errorf(
+		return "", "", nil, fmt.Errorf(
 			"task %s (attempt %d) has no worker_id",
 			taskID, attemptNumber,
 		)
 	}
-
-	// Prefer task_log_info when Ray provides a file name. Some lifecycle events
-	// contain only offsets, so keep the worker ID fallback below.
-	if foundTask.TaskLogInfo != nil {
-		var logFilename string
-		if suffix == "err" {
-			logFilename = foundTask.TaskLogInfo.StderrFile
-		} else {
-			logFilename = foundTask.TaskLogInfo.StdoutFile
-		}
-		if logFilename = taskLogBasename(logFilename); logFilename != "" {
-			return foundTask.NodeID, logFilename, nil
-		}
-	}
-
-	// Fallback: Find worker log file by worker_id
 	if sessionID == "" {
-		return "", "", fmt.Errorf(
+		return "", "", nil, fmt.Errorf(
 			"task %s (attempt %d) has no task_log_info and sessionID is required to search for worker log files",
 			taskID, attemptNumber,
 		)
 	}
 	nodeIDHex, logFilename, err := s.findWorkerLogFile(clusterLogPathPrefix, sessionID, foundTask.NodeID, foundTask.WorkerID, suffix)
 	if err != nil {
-		return "", "", fmt.Errorf(
+		return "", "", nil, fmt.Errorf(
 			"failed to find worker log file for task %s (attempt %d, worker_id=%s, node_id=%s): %w",
 			taskID, attemptNumber, foundTask.WorkerID, foundTask.NodeID, err,
 		)
 	}
 
-	return nodeIDHex, logFilename, nil
+	return nodeIDHex, logFilename, nil, nil
 }
 
 // taskLogBasename maps Ray's absolute worker-container log path to the file

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -1837,6 +1837,20 @@ func (s *ServerHandler) getTasks(req *restful.Request, resp *restful.Response) {
 	resp.Write(respData)
 }
 
+func formatTaskLogInfoForResponse(taskLogInfo *eventtypes.TaskLogInfo) interface{} {
+	if taskLogInfo == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"stdout_file":  taskLogInfo.StdoutFile,
+		"stderr_file":  taskLogInfo.StderrFile,
+		"stdout_start": taskLogInfo.StdoutStart,
+		"stdout_end":   taskLogInfo.StdoutEnd,
+		"stderr_start": taskLogInfo.StderrStart,
+		"stderr_end":   taskLogInfo.StderrEnd,
+	}
+}
+
 // formatTaskForResponse formats a task data result of a single task attempt for the response.
 // The schema aligns with the Ray Dashboard API.
 // Ref: https://github.com/ray-project/ray/blob/d0b1d151d8ea964a711e451d0ae736f8bf95b629/python/ray/util/state/common.py#L730-L819.
@@ -1898,7 +1912,7 @@ func formatTaskForResponse(task eventtypes.Task, detail bool) map[string]interfa
 		// TODO(jiangjiawei1103): Support profiling_data after TASK_PROFILE_EVENT is supported.
 		// Ref: https://github.com/ray-project/ray/blob/d0b1d151d8ea964a711e451d0ae736f8bf95b629/python/ray/util/state/common.py#L1616-L1622.
 		// result["profiling_data"] = task.ProfilingData
-		result["task_log_info"] = task.TaskLogInfo
+		result["task_log_info"] = formatTaskLogInfoForResponse(task.TaskLogInfo)
 		if task.RayErrorInfo != nil {
 			result["error_message"] = task.RayErrorInfo.ErrorMessage
 		} else {

--- a/historyserver/pkg/historyserver/tasks_test.go
+++ b/historyserver/pkg/historyserver/tasks_test.go
@@ -1,0 +1,115 @@
+package historyserver
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
+	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+type taskLogStorageReader struct {
+	filename string
+}
+
+func (*taskLogStorageReader) List() []utils.ClusterInfo { return nil }
+
+func (r *taskLogStorageReader) GetContent(_ string, filename string) io.Reader {
+	r.filename = filename
+	return strings.NewReader("Processing 1\n")
+}
+
+func (*taskLogStorageReader) ListFiles(_, _ string) []string { return nil }
+
+func TestTaskLogBasename(t *testing.T) {
+	tests := map[string]struct {
+		filename string
+		want     string
+	}{
+		"absolute Ray path": {
+			filename: "/tmp/ray/session_latest/logs/worker-abc-123.out",
+			want:     "worker-abc-123.out",
+		},
+		"stored basename": {
+			filename: "worker-abc-123.err",
+			want:     "worker-abc-123.err",
+		},
+		"path traversal": {
+			filename: "../../worker-abc-123.out",
+			want:     "worker-abc-123.out",
+		},
+		"empty": {filename: "", want: ""},
+		"directory": {
+			filename: "/",
+			want:     "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := taskLogBasename(test.filename); got != test.want {
+				t.Fatalf("taskLogBasename(%q) = %q, want %q", test.filename, got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetTaskLogFileUsesStoredBasename(t *testing.T) {
+	const clusterSessionKey = "raycluster_default_session"
+	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
+		TaskID:      "task-id",
+		TaskAttempt: 0,
+		NodeID:      "node-id",
+		WorkerID:    "worker-id",
+		TaskLogInfo: &eventtypes.TaskLogInfo{
+			StdoutFile: "/tmp/ray/session_latest/logs/worker-abc-123.out",
+		},
+	}}})
+
+	reader := &taskLogStorageReader{}
+	handler := &ServerHandler{sessionLoader: loader, reader: reader}
+	content, err := handler._getNodeLogFile(
+		clusterSessionKey,
+		"cluster-prefix",
+		"session",
+		GetLogFileOptions{TaskID: "task-id", Suffix: "out", Lines: -1},
+	)
+	if err != nil {
+		t.Fatalf("_getNodeLogFile() error = %v", err)
+	}
+	if got, want := string(content), "Processing 1\n"; got != want {
+		t.Fatalf("_getNodeLogFile() content = %q, want %q", got, want)
+	}
+	if got, want := reader.filename, "session/node-id/logs/worker-abc-123.out"; got != want {
+		t.Fatalf("storage filename = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTaskForResponseTaskLogInfo(t *testing.T) {
+	task := eventtypes.Task{TaskLogInfo: &eventtypes.TaskLogInfo{
+		StdoutFile:  "worker.out",
+		StderrFile:  "worker.err",
+		StdoutStart: 10,
+		StdoutEnd:   20,
+		StderrStart: 30,
+		StderrEnd:   40,
+	}}
+
+	response := formatTaskForResponse(task, true)
+	assert.Equal(t, map[string]interface{}{
+		"stdout_file":  "worker.out",
+		"stderr_file":  "worker.err",
+		"stdout_start": int64(10),
+		"stdout_end":   int64(20),
+		"stderr_start": int64(30),
+		"stderr_end":   int64(40),
+	}, response["task_log_info"])
+
+	response = formatTaskForResponse(eventtypes.Task{}, true)
+	assert.Nil(t, response["task_log_info"])
+}

--- a/historyserver/pkg/historyserver/tasks_test.go
+++ b/historyserver/pkg/historyserver/tasks_test.go
@@ -14,16 +14,18 @@ import (
 
 type taskLogStorageReader struct {
 	filename string
+	content  string
+	files    []string
 }
 
 func (*taskLogStorageReader) List() []utils.ClusterInfo { return nil }
 
 func (r *taskLogStorageReader) GetContent(_ string, filename string) io.Reader {
 	r.filename = filename
-	return strings.NewReader("Processing 1\n")
+	return strings.NewReader(r.content)
 }
 
-func (*taskLogStorageReader) ListFiles(_, _ string) []string { return nil }
+func (r *taskLogStorageReader) ListFiles(_, _ string) []string { return r.files }
 
 func TestTaskLogBasename(t *testing.T) {
 	tests := map[string]struct {
@@ -65,13 +67,13 @@ func TestGetTaskLogFileUsesStoredBasename(t *testing.T) {
 		TaskID:      "task-id",
 		TaskAttempt: 0,
 		NodeID:      "node-id",
-		WorkerID:    "worker-id",
 		TaskLogInfo: &eventtypes.TaskLogInfo{
 			StdoutFile: "/tmp/ray/session_latest/logs/worker-abc-123.out",
+			StdoutEnd:  int64(len("Processing 1\n")),
 		},
 	}}})
 
-	reader := &taskLogStorageReader{}
+	reader := &taskLogStorageReader{content: "Processing 1\n"}
 	handler := &ServerHandler{sessionLoader: loader, reader: reader}
 	content, err := handler._getNodeLogFile(
 		clusterSessionKey,
@@ -87,6 +89,132 @@ func TestGetTaskLogFileUsesStoredBasename(t *testing.T) {
 	}
 	if got, want := reader.filename, "session/node-id/logs/worker-abc-123.out"; got != want {
 		t.Fatalf("storage filename = %q, want %q", got, want)
+	}
+}
+
+func TestGetTaskLogFileAppliesRangeBeforeLineLimit(t *testing.T) {
+	const clusterSessionKey = "raycluster_default_session"
+	const content = "before\ntask line 1\ntask line 2\nafter\n"
+	const taskContent = "task line 1\ntask line 2\n"
+	start := int64(strings.Index(content, taskContent))
+	end := start + int64(len(taskContent))
+
+	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
+		TaskID:      "task-id",
+		TaskAttempt: 0,
+		NodeID:      "node-id",
+		WorkerID:    "worker-id",
+		TaskLogInfo: &eventtypes.TaskLogInfo{
+			StdoutFile:  "/tmp/ray/session_latest/logs/worker-abc-123.out",
+			StdoutStart: start,
+			StdoutEnd:   end,
+		},
+	}}})
+
+	reader := &taskLogStorageReader{content: content}
+	handler := &ServerHandler{sessionLoader: loader, reader: reader}
+	got, err := handler._getNodeLogFile(
+		clusterSessionKey,
+		"cluster-prefix",
+		"session",
+		GetLogFileOptions{TaskID: "task-id", Suffix: "out", Lines: 1},
+	)
+	if err != nil {
+		t.Fatalf("_getNodeLogFile() error = %v", err)
+	}
+	if want := "task line 2"; string(got) != want {
+		t.Fatalf("_getNodeLogFile() content = %q, want %q", got, want)
+	}
+}
+
+func TestGetTaskLogFileRejectsIncompleteTaskLogInfo(t *testing.T) {
+	const clusterSessionKey = "raycluster_default_session"
+	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
+		TaskID:      "task-id",
+		TaskAttempt: 0,
+		NodeID:      "aa",
+		WorkerID:    "bb",
+		TaskLogInfo: &eventtypes.TaskLogInfo{StdoutEnd: 20},
+	}}})
+
+	reader := &taskLogStorageReader{
+		content: "other task\ntarget task\n",
+		files:   []string{"worker-bb-job-123.out"},
+	}
+	handler := &ServerHandler{sessionLoader: loader, reader: reader}
+	_, err := handler._getNodeLogFile(
+		clusterSessionKey,
+		"cluster-prefix",
+		"session",
+		GetLogFileOptions{TaskID: "task-id", Suffix: "out", Lines: -1},
+	)
+	if err == nil {
+		t.Fatal("_getNodeLogFile() should reject TaskLogInfo without a filename")
+	}
+	var httpErr *utils.HTTPError
+	if !assert.ErrorAs(t, err, &httpErr) {
+		return
+	}
+	assert.Equal(t, 404, httpErr.StatusCode())
+	assert.Empty(t, reader.filename, "incomplete task metadata must not read a guessed worker log")
+}
+
+func TestGetTaskLogFileRejectsAmbiguousZeroEnd(t *testing.T) {
+	const clusterSessionKey = "raycluster_default_session"
+	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
+		TaskID:      "task-id",
+		TaskAttempt: 0,
+		NodeID:      "node-id",
+		TaskLogInfo: &eventtypes.TaskLogInfo{StdoutFile: "worker.out"},
+	}}})
+
+	handler := &ServerHandler{sessionLoader: loader, reader: &taskLogStorageReader{content: "other task\n"}}
+	_, err := handler._getNodeLogFile(
+		clusterSessionKey,
+		"cluster-prefix",
+		"session",
+		GetLogFileOptions{TaskID: "task-id", Suffix: "out", Lines: -1},
+	)
+	var httpErr *utils.HTTPError
+	if !assert.ErrorAs(t, err, &httpErr) {
+		return
+	}
+	assert.Equal(t, 404, httpErr.StatusCode())
+}
+
+func TestApplyLogByteRange(t *testing.T) {
+	tests := map[string]struct {
+		byteRange *logByteRange
+		want      string
+		wantErr   bool
+	}{
+		"unbounded":       {byteRange: nil, want: "0123456789"},
+		"half-open range": {byteRange: &logByteRange{start: 2, end: 5}, want: "234"},
+		"empty range":     {byteRange: &logByteRange{start: 4, end: 4}, want: ""},
+		"end past EOF":    {byteRange: &logByteRange{start: 8, end: 20}, wantErr: true},
+		"start past EOF":  {byteRange: &logByteRange{start: 20, end: 30}, wantErr: true},
+		"negative start":  {byteRange: &logByteRange{start: -1, end: 2}, wantErr: true},
+		"negative end":    {byteRange: &logByteRange{start: 0, end: -1}, wantErr: true},
+		"reversed":        {byteRange: &logByteRange{start: 5, end: 4}, wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			reader, err := applyLogByteRange(strings.NewReader("0123456789"), test.byteRange)
+			var got []byte
+			if err == nil {
+				got, err = io.ReadAll(reader)
+			}
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.want, string(got))
+		})
 	}
 }
 

--- a/historyserver/pkg/historyserver/tasks_test.go
+++ b/historyserver/pkg/historyserver/tasks_test.go
@@ -62,7 +62,7 @@ func TestTaskLogBasename(t *testing.T) {
 
 func TestGetTaskLogFileUsesStoredBasename(t *testing.T) {
 	const clusterSessionKey = "raycluster_default_session"
-	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1})
 	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
 		TaskID:      "task-id",
 		TaskAttempt: 0,
@@ -99,7 +99,7 @@ func TestGetTaskLogFileAppliesRangeBeforeLineLimit(t *testing.T) {
 	start := int64(strings.Index(content, taskContent))
 	end := start + int64(len(taskContent))
 
-	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1})
 	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
 		TaskID:      "task-id",
 		TaskAttempt: 0,
@@ -130,7 +130,7 @@ func TestGetTaskLogFileAppliesRangeBeforeLineLimit(t *testing.T) {
 
 func TestGetTaskLogFileRejectsIncompleteTaskLogInfo(t *testing.T) {
 	const clusterSessionKey = "raycluster_default_session"
-	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1})
 	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
 		TaskID:      "task-id",
 		TaskAttempt: 0,
@@ -163,7 +163,7 @@ func TestGetTaskLogFileRejectsIncompleteTaskLogInfo(t *testing.T) {
 
 func TestGetTaskLogFileRejectsAmbiguousZeroEnd(t *testing.T) {
 	const clusterSessionKey = "raycluster_default_session"
-	loader := newTestSessionLoader(t, &fakeProcessor{}, 1)
+	loader := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1})
 	loader.putSnapshot(clusterSessionKey, &eventserver.SessionSnapshot{Tasks: []eventtypes.Task{{
 		TaskID:      "task-id",
 		TaskAttempt: 0,

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -88,7 +89,7 @@ func TestHistoryServer(t *testing.T) {
 			testFunc: testLiveClusterTasks,
 		},
 		{
-			name:     "Dead cluster: /api/v0/tasks should return the detailed task information of all task attempts (historical replay isn't supported)",
+			name:     "Dead cluster: /api/v0/tasks should return detailed task information from historical replay",
 			testFunc: testDeadClusterTasks,
 		},
 		{
@@ -1762,8 +1763,8 @@ func testLiveClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 	LogWithTimestamp(test.T(), "Live cluster /api/v0/tasks?detail=1 tests completed successfully")
 }
 
-// testDeadClusterTasks verifies that the /api/v0/tasks endpoint for a dead cluster will return the
-// detailed task information of all task attempts without historical replay.
+// testDeadClusterTasks verifies that the /api/v0/tasks endpoint for a dead cluster returns
+// detailed task information reconstructed from historical events.
 //
 // The test case follows these steps:
 // 1. Prepare test environment by applying a Ray cluster with the collector
@@ -1800,6 +1801,7 @@ func testDeadClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	client := CreateHTTPClientWithCookieJar(g)
 	setClusterContext(test, g, client, historyServerURL, namespace.Name, rayCluster.Name, clusterInfo.SessionName)
+	verifyDeadClusterTaskLogInfo(g, client, historyServerURL)
 
 	jobIDs := getAllEligibleJobIDs(g, client, historyServerURL)
 	jobIDForFilter := jobIDs[0]
@@ -1900,6 +1902,59 @@ func testDeadClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	DeleteS3Bucket(test, g, s3Client)
 	LogWithTimestamp(test.T(), "Dead cluster /api/v0/tasks tests completed successfully")
+}
+
+func verifyDeadClusterTaskLogInfo(g *WithT, client *http.Client, historyServerURL string) {
+	resp, err := client.Get(historyServerURL + EndpointTasks + "?detail=1")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	body, err := io.ReadAll(resp.Body)
+	g.Expect(err).NotTo(HaveOccurred())
+	var response map[string]any
+	g.Expect(json.Unmarshal(body, &response)).To(Succeed())
+
+	data, ok := response["data"].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	result, ok := data["result"].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	tasks, ok := result["result"].([]any)
+	g.Expect(ok).To(BeTrue())
+
+	var taskID string
+	for _, value := range tasks {
+		task, ok := value.(map[string]any)
+		if !ok || task["name"] != "my_task" || task["type"] != "NORMAL_TASK" || task["state"] != "FINISHED" {
+			continue
+		}
+		workerID, ok := task["worker_id"].(string)
+		if !ok || workerID == "" {
+			continue
+		}
+		taskLogInfo, ok := task["task_log_info"].(map[string]any)
+		if !ok {
+			continue
+		}
+		stdoutEnd, stdoutErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_end"]), 10, 64)
+		stderrEnd, stderrErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stderr_end"]), 10, 64)
+		if stdoutErr == nil && stderrErr == nil && (stdoutEnd > 0 || stderrEnd > 0) {
+			taskID, _ = task["task_id"].(string)
+			break
+		}
+	}
+	g.Expect(taskID).NotTo(BeEmpty(),
+		"completed Ray 2.56 my_task should expose non-empty task_log_info")
+
+	logURL := fmt.Sprintf("%s%s?task_id=%s&suffix=out&lines=-1",
+		historyServerURL, EndpointLogsFile, url.QueryEscape(taskID))
+	logResp, err := client.Get(logURL)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer logResp.Body.Close()
+	g.Expect(logResp.StatusCode).To(Equal(http.StatusOK))
+	logBody, err := io.ReadAll(logResp.Body)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(logBody)).To(ContainSubstring("Processing 1"))
 }
 
 // testLiveClusterNodes verifies that the /nodes?view=summary endpoint for a live cluster will return the current

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"testing"
@@ -1922,7 +1923,7 @@ func verifyDeadClusterTaskLogInfo(g *WithT, client *http.Client, historyServerUR
 	tasks, ok := result["result"].([]any)
 	g.Expect(ok).To(BeTrue())
 
-	var taskID string
+	var taskID, nodeID, stdoutFile string
 	for _, value := range tasks {
 		task, ok := value.(map[string]any)
 		if !ok || task["name"] != "my_task" || task["type"] != "NORMAL_TASK" || task["state"] != "FINISHED" {
@@ -1936,15 +1937,35 @@ func verifyDeadClusterTaskLogInfo(g *WithT, client *http.Client, historyServerUR
 		if !ok {
 			continue
 		}
-		stdoutEnd, stdoutErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_end"]), 10, 64)
-		stderrEnd, stderrErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stderr_end"]), 10, 64)
-		if stdoutErr == nil && stderrErr == nil && (stdoutEnd > 0 || stderrEnd > 0) {
+		stdoutFileValue, _ := taskLogInfo["stdout_file"].(string)
+		stdoutStart, startErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_start"]), 10, 64)
+		stdoutEnd, endErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_end"]), 10, 64)
+		if stdoutFileValue != "" && startErr == nil && endErr == nil && stdoutStart > 0 && stdoutEnd > stdoutStart {
 			taskID, _ = task["task_id"].(string)
+			nodeID, _ = task["node_id"].(string)
+			stdoutFile = stdoutFileValue
 			break
 		}
 	}
 	g.Expect(taskID).NotTo(BeEmpty(),
-		"completed Ray 2.56 my_task should expose non-empty task_log_info")
+		"completed Ray 2.56 my_task should expose a complete stdout byte range")
+	g.Expect(nodeID).NotTo(BeEmpty())
+
+	workerLogURL := fmt.Sprintf("%s%s?node_id=%s&filename=%s&lines=-1",
+		historyServerURL,
+		EndpointLogsFile,
+		url.QueryEscape(nodeID),
+		url.QueryEscape(path.Base(stdoutFile)),
+	)
+	workerLogResp, err := client.Get(workerLogURL)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer workerLogResp.Body.Close()
+	g.Expect(workerLogResp.StatusCode).To(Equal(http.StatusOK))
+	workerLogBody, err := io.ReadAll(workerLogResp.Body)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(workerLogBody)).To(ContainSubstring("Processing 0"))
+	g.Expect(string(workerLogBody)).To(ContainSubstring("Processing 1"))
+	g.Expect(string(workerLogBody)).To(ContainSubstring("Processing 2"))
 
 	logURL := fmt.Sprintf("%s%s?task_id=%s&suffix=out&lines=-1",
 		historyServerURL, EndpointLogsFile, url.QueryEscape(taskID))
@@ -1955,6 +1976,8 @@ func verifyDeadClusterTaskLogInfo(g *WithT, client *http.Client, historyServerUR
 	logBody, err := io.ReadAll(logResp.Body)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(string(logBody)).To(ContainSubstring("Processing 1"))
+	g.Expect(string(logBody)).NotTo(ContainSubstring("Processing 0"))
+	g.Expect(string(logBody)).NotTo(ContainSubstring("Processing 2"))
 }
 
 // testLiveClusterNodes verifies that the /nodes?view=summary endpoint for a live cluster will return the current

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1938,9 +1937,9 @@ func verifyDeadClusterTaskLogInfo(g *WithT, client *http.Client, historyServerUR
 			continue
 		}
 		stdoutFileValue, _ := taskLogInfo["stdout_file"].(string)
-		stdoutStart, startErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_start"]), 10, 64)
-		stdoutEnd, endErr := strconv.ParseInt(fmt.Sprint(taskLogInfo["stdout_end"]), 10, 64)
-		if stdoutFileValue != "" && startErr == nil && endErr == nil && stdoutStart > 0 && stdoutEnd > stdoutStart {
+		stdoutStart, startOK := taskLogInfo["stdout_start"].(float64)
+		stdoutEnd, endOK := taskLogInfo["stdout_end"].(float64)
+		if stdoutFileValue != "" && startOK && endOK && stdoutStart > 0 && stdoutEnd > stdoutStart {
 			taskID, _ = task["task_id"].(string)
 			nodeID, _ = task["node_id"].(string)
 			stdoutFile = stdoutFileValue


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray 2.56 added `TaskLogInfo` to task lifecycle events in [ray#60287](https://github.com/ray-project/ray/pull/60287) and [ray#60288](https://github.com/ray-project/ray/pull/60288), but History Server dropped every event carrying it, so the Dashboard [TaskPage](https://github.com/ray-project/ray/blob/ray-2.56.0/python/ray/dashboard/client/src/pages/task/TaskPage.tsx#L295-L334) could not load historical task logs. Two independent blockers:

- ProtoJSON encodes the `int64` offsets as quoted strings, which failed to unmarshal into the plain `int64` fields.
- `handleTaskLifecycleEvent` rejected any event with no state transitions, and Ray reports log boundaries through transition-less events.

This PR accepts the quoted offsets produced by ProtoJSON, merges partial lifecycle updates, and applies the raw `[start,end)` byte range before line tailing and ANSI filtering.

### Design decision

Incomplete `TaskLogInfo` fails closed with 404 instead of guessing a reused worker file; a stored file shorter than `end` also errors rather than returning partial output. The Ray 2.56 E2E puts A/B/C (`Processing 0/1/2`) in one worker log and proves the task-B endpoint returns only B.

### Known limitations
- On Ray 2.56 a task that starts and finishes inside one flush window loses its log metadata upstream: same-attempt events accumulate into one `TaskLifecycleEvent` and `task_log_info` is assigned rather than merged ([task_event_buffer.cc](https://github.com/ray-project/ray/blob/637fd062205393b9e1929996bfe1d49bd3f8469d/src/ray/core_worker/task_event_buffer.cc#L331-L334)), so the end offsets overwrite the file paths. Such tasks fail closed with 404. This issue is fixed correctly in https://github.com/ray-project/ray/pull/65288/
- Ray skips `RecordTaskLogStart`/`End` entirely when worker log rotation is enabled, so those clusters keep using the existing worker-log fallback.

## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

Follow [historyserver/DEVELOPMENT.md](https://github.com/ray-project/kuberay/blob/master/historyserver/DEVELOPMENT.md) steps 1–7 to stand up MinIO, generate a dead session, and reach the Ray Dashboard

`config/rayjob.yaml` runs three `my_task` calls back to back on a single reusable worker (`num_cpus=1` against a one-CPU worker group), so `task_log_before`, `my_task`, and `task_log_noise` all append to the same worker log file:
  ```
  Processing 0   <- task_log_before
  Processing 1   <- my_task
  Processing 2   <- task_log_noise
  ```

1. Task Table → `my_task`
<img width="2462" height="1328" alt="image" src="https://github.com/user-attachments/assets/d9f5cf2f-b9ba-4f84-a7ef-ac2e1968df9d" />

<img width="1562" height="904" alt="image" src="https://github.com/user-attachments/assets/5fe5b59a-1ac6-4fb2-b865-d9b6b2c912cf" />



2. Task Table → `child_task`

`child_task` finishes in milliseconds, so its log metadata is lost upstream and the endpoint fails closed with 404. This is the first entry under [Known limitations](#known-limitations), not a regression in this PR.

<img width="2349" height="1190" alt="image" src="https://github.com/user-attachments/assets/72701196-978a-4649-b5b7-382b480df638" />

<img width="2085" height="1125" alt="image" src="https://github.com/user-attachments/assets/c6ff83c2-e8df-4a0f-b7db-f1c944a02f31" />



