### PR TITLE
[Doc] Repin samples off the deleted ray-ml 2.46.0.0e19ea tags

### DIFF
--- a/ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml
+++ b/ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml
@@ -16,7 +16,7 @@ spec:
       - transformers>=4.19.1
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
   rayClusterSpec:
-    rayVersion: "2.46.0"
+    rayVersion: "2.49.2"
     headGroupSpec:
       rayStartParams:
         dashboard-host: "0.0.0.0"
@@ -31,7 +31,7 @@ spec:
           serviceAccountName: pytorch-distributed-training
           containers:
           - name: ray-head
-            image: rayproject/ray:2.46.0
+            image: rayproject/ray:2.49.2
             env:
             - name: NUM_WORKERS
               value: "4"
@@ -85,7 +85,7 @@ spec:
             effect: "NoSchedule"
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39
+            image: rayproject/ray-ml:2.49.2.deprecated-py39
             resources:
               limits:
                 cpu: "1"

--- a/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
+++ b/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
@@ -15,7 +15,7 @@ spec:
       - pytorch-lightning==1.8.5
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
   rayClusterSpec:
-    rayVersion: "2.46.0"
+    rayVersion: "2.49.2"
     headGroupSpec:
       rayStartParams:
         dashboard-host: "0.0.0.0"
@@ -27,7 +27,7 @@ spec:
             effect: "NoSchedule"
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.46.0.0e19ea-py311-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py311-gpu
             ports:
             - containerPort: 6379
               name: gcs-server

--- a/ray-operator/config/samples/ray-job.batch-inference.yaml
+++ b/ray-operator/config/samples/ray-job.batch-inference.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   entrypoint: python /home/ray/samples/sample_code.py
   rayClusterSpec:
-    rayVersion: "2.46.0"
+    rayVersion: "2.49.2"
     headGroupSpec:
       rayStartParams:
         dashboard-host: "0.0.0.0"
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py39-gpu
             ports:
             - containerPort: 6379
               name: gcs-server

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -16,7 +16,7 @@ spec:
             ray_actor_options:
               num_cpus: 1
   rayClusterConfig:
-    rayVersion: "2.46.0" # should match the Ray version in the image of the containers
+    rayVersion: "2.49.2" # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -26,7 +26,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-cpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py39-cpu
             resources:
               limits:
                 cpu: "1"
@@ -47,7 +47,7 @@ spec:
         spec:
           containers:
           - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-cpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py39-cpu
             resources:
               limits:
                 cpu: "1"

--- a/ray-operator/config/samples/ray-service.stable-diffusion.yaml
+++ b/ray-operator/config/samples/ray-service.stable-diffusion.yaml
@@ -11,7 +11,7 @@ spec:
           working_dir: "https://github.com/ray-project/serve_config_examples/archive/b8af221bc0e5d6cc7daa0dd071295fd9e456e671.zip"
           pip: ["diffusers==0.32.2", "transformers==4.48.2"]
   rayClusterConfig:
-    rayVersion: "2.46.0" # Should match the Ray version in the image of the containers
+    rayVersion: "2.49.2" # Should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py39-gpu
             volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -47,7 +47,7 @@ spec:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py39-gpu
             resources:
               limits:
                 cpu: "4"


### PR DESCRIPTION
## Why are these changes needed?

The `rayproject/ray-ml:2.46.0.0e19ea-*` tag family was deleted from Docker Hub, so five samples land in `ImagePullBackOff` as written:

```console
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://hub.docker.com/v2/repositories/rayproject/ray-ml/tags/2.46.0.0e19ea-py39-gpu
404
```

Affected files (every remaining `2.46.0.0e19ea` pin in the repo):

- `ray-operator/config/samples/ray-job.batch-inference.yaml`
- `ray-operator/config/samples/ray-service.mobilenet.yaml`
- `ray-operator/config/samples/ray-service.stable-diffusion.yaml`
- `ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml`
- `ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml`

`ray-ml` itself is still published, just under `.deprecated`-suffixed tags, with `2.49.2.deprecated-*` as the newest release family. So this is a repin, not a rebuild, and it is the same fix #4811 already applied to `ray-service.text-summarizer.yaml`: bump image and `rayVersion` to 2.49.2, keeping each sample's existing Python and CPU/GPU variant.

Note for #5123: the issue reasoned that no working `ray-ml` tag existed, so a replacement image had to be built or the ML dependencies moved into `runtimeEnvYAML`. The `.deprecated` tag family makes that unnecessary — the samples' dependencies still come from the image (see below).

## Related issue number

Closes #5123

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests

### Manual test instructions

**1. Every image tag referenced by the five changed files resolves on Docker Hub.**

```console
$ for f in ray-operator/config/samples/ray-job.batch-inference.yaml \
          ray-operator/config/samples/ray-service.mobilenet.yaml \
          ray-operator/config/samples/ray-service.stable-diffusion.yaml \
          ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml \
          ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml; do
    grep -oE 'rayproject/[a-z-]+:[^ ]+' "$f" | while read -r img; do
      printf "%s %s\n" \
        "$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${img%%:*}/tags/${img##*:}")" "$img"
    done
  done
200 rayproject/ray-ml:2.49.2.deprecated-py39-gpu
200 rayproject/ray-ml:2.49.2.deprecated-py39-cpu
200 rayproject/ray-ml:2.49.2.deprecated-py39-cpu
200 rayproject/ray-ml:2.49.2.deprecated-py39-gpu
200 rayproject/ray-ml:2.49.2.deprecated-py39-gpu
200 rayproject/ray:2.49.2
200 rayproject/ray-ml:2.49.2.deprecated-py39
200 rayproject/ray-ml:2.49.2.deprecated-py39
200 rayproject/ray-ml:2.49.2.deprecated-py311-gpu
```

The same loop on `master` returns 404 for all seven `ray-ml` lines.

**2. The images really are Ray 2.49.2 on the expected Python**, so the new `rayVersion` is accurate. From the image config of `ray-ml:2.49.2.deprecated-py39-gpu`:

```
COPY .whl/ray-2.49.2-cp39-cp39-manylinux2014_x86_64.whl .
CUDA_VERSION=12.1.1
```

**3. The suffix-less tag is the GPU image**, so `pytorch-image-classifier`'s GPU worker keeps a CUDA image despite `2.49.2.deprecated-py39` carrying no `-gpu`:

```
2.49.2.deprecated-py39      sha256:21b0b684...  CUDA 12.1.1
2.49.2.deprecated-py39-gpu  sha256:21b0b684...  (same digest)
2.49.2.deprecated-py39-cpu  sha256:5e6be059...  (no CUDA)
```

Same aliasing holds on the older still-live family (`2.30.0-py39` == `2.30.0-py39-gpu`), so this is the tag layout's convention rather than a one-off.

**4. The samples' image-supplied dependencies survive the bump.** `requirements_compiled.txt` at `ray-2.49.2` still pins `tensorflow==2.15.1` (py<3.12, needed by `mobilenet`), `torch==2.3.0`, `transformers==4.36.2`, `pillow==10.3.0` (needed by `batch-inference`). Keeping each sample on its current Python variant rather than moving to py311 is deliberate: the py39 images are the ones that carry TensorFlow under that marker.

**5. `batch-inference`'s mounted `sample_code.py` needs no change.** It passes `compute=ActorPoolStrategy(...)` to `map_batches`; in Ray 2.49.2 `get_compute_strategy` takes the legacy branch and only logs a deprecation warning ([util.py#L605](https://github.com/ray-project/ray/blob/ray-2.49.2/python/ray/data/_internal/util.py#L605)).

**Not covered:** full end-to-end runs. `batch-inference` and `stable-diffusion` need 4x T4 GPUs and `pytorch-image-classifier` needs a GKE GCSFuse-backed service account, none of which I have access to. None of these five samples are in the `test/sampleyaml` matrix, so CI does not exercise them either.
