### PR TITLE
[RayCluster] Reject worker group removal in default installs

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -500,7 +500,7 @@ RayCluster is the Schema for the RayClusters API
 | `apiVersion` _string_ | `ray.io/v1` | | |
 | `kind` _string_ | `RayCluster` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster. |  |  |
+| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster.<br />The has() guards keep the rule valid when workerGroupSpecs is unset or an empty list,<br />so updates that omit the field (e.g. controller finalizer writes) are not rejected. |  |  |
 
 
 
@@ -533,7 +533,7 @@ _Appears in:_
 | `tlsOptions` _[TLSOptions](#tlsoptions)_ | TLSOptions specifies optional TLS encryption settings for the RayCluster.<br />If omitted or Enabled is false, TLS is disabled. When Enabled is true,<br />the operator enables mTLS using cert-manager to provision and manage certificates.<br />Requires the RayClusterMTLS feature gate on the operator. |  |  |
 | `headGroupSpec` _[HeadGroupSpec](#headgroupspec)_ | HeadGroupSpec is the spec for the head pod |  |  |
 | `rayVersion` _string_ | RayVersion is used to determine the command for the Kubernetes Job managed by RayJob |  |  |
-| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
+| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods<br />MaxItems is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove. |  | MaxItems: 100 <br /> |
 
 
 #### RayClusterUpgradeStrategy
@@ -864,7 +864,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `suspend` _boolean_ | Suspend indicates whether a worker group should be suspended.<br />A suspended worker group will have all pods deleted.<br />This is not a user-facing API and is only used by RayJob DeletionStrategy. |  |  |
-| `groupName` _string_ | we can have multiple worker groups, we distinguish them by name |  |  |
+| `groupName` _string_ | we can have multiple worker groups, we distinguish them by name<br />MaxLength is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove. |  | MaxLength: 63 <br /> |
 | `replicas` _integer_ | Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional. | 0 |  |
 | `minReplicas` _integer_ | MinReplicas denotes the minimum number of desired Pods for this worker group. | 0 |  |
 | `maxReplicas` _integer_ | MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32. | 2147483647 |  |
@@ -952,7 +952,7 @@ RayCluster is the Schema for the RayClusters API
 | `apiVersion` _string_ | `ray.io/v1alpha1` | | |
 | `kind` _string_ | `RayCluster` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster. |  |  |
+| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster.<br />The has() guards keep the rule valid when workerGroupSpecs is unset or an empty list,<br />so updates that omit the field (e.g. controller finalizer writes) are not rejected. |  |  |
 
 
 #### RayClusterSpec
@@ -976,7 +976,7 @@ _Appears in:_
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
 | `headGroupSpec` _[HeadGroupSpec](#headgroupspec)_ | HeadGroupSpec is the spec for the head pod |  |  |
 | `rayVersion` _string_ | RayVersion is used to determine the command for the Kubernetes Job managed by RayJob |  |  |
-| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
+| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods<br />MaxItems is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove. |  | MaxItems: 100 <br /> |
 
 
 #### RayJob
@@ -1110,7 +1110,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `groupName` _string_ | we can have multiple worker groups, we distinguish them by name |  |  |
+| `groupName` _string_ | we can have multiple worker groups, we distinguish them by name<br />MaxLength is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove. |  | MaxLength: 63 <br /> |
 | `replicas` _integer_ | Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional. | 0 |  |
 | `minReplicas` _integer_ | MinReplicas denotes the minimum number of desired Pods for this worker group. | 0 |  |
 | `maxReplicas` _integer_ | MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32. | 2147483647 |  |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -5325,6 +5325,7 @@ spec:
                 items:
                   properties:
                     groupName:
+                      maxLength: 63
                       type: string
                     idleTimeoutSeconds:
                       format: int32
@@ -9194,10 +9195,17 @@ spec:
                   - minReplicas
                   - template
                   type: object
+                maxItems: 100
                 type: array
             required:
             - headGroupSpec
             type: object
+            x-kubernetes-validations:
+            - message: workerGroupSpecs entries cannot be removed; scale the group
+                to zero replicas or suspend it instead
+              rule: '!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup,
+                has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup,
+                newGroup.groupName == oldGroup.groupName))'
           status:
             properties:
               availableWorkerReplicas:
@@ -13653,6 +13661,7 @@ spec:
                 items:
                   properties:
                     groupName:
+                      maxLength: 63
                       type: string
                     maxReplicas:
                       default: 2147483647
@@ -17502,10 +17511,17 @@ spec:
                   - rayStartParams
                   - template
                   type: object
+                maxItems: 100
                 type: array
             required:
             - headGroupSpec
             type: object
+            x-kubernetes-validations:
+            - message: workerGroupSpecs entries cannot be removed; scale the group
+                to zero replicas or suspend it instead
+              rule: '!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup,
+                has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup,
+                newGroup.groupName == oldGroup.groupName))'
           status:
             properties:
               availableWorkerReplicas:

--- a/helm-chart/kuberay-operator/crds/ray.io_raycronjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_raycronjobs.yaml
@@ -5419,6 +5419,7 @@ spec:
                         items:
                           properties:
                             groupName:
+                              maxLength: 63
                               type: string
                             idleTimeoutSeconds:
                               format: int32
@@ -9288,6 +9289,7 @@ spec:
                           - minReplicas
                           - template
                           type: object
+                        maxItems: 100
                         type: array
                     required:
                     - headGroupSpec

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -5420,6 +5420,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         idleTimeoutSeconds:
                           format: int32
@@ -9289,6 +9290,7 @@ spec:
                       - minReplicas
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec
@@ -17618,6 +17620,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         maxReplicas:
                           default: 2147483647
@@ -21467,6 +21470,7 @@ spec:
                       - rayStartParams
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -5313,6 +5313,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         idleTimeoutSeconds:
                           format: int32
@@ -9182,6 +9183,7 @@ spec:
                       - minReplicas
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec
@@ -14074,6 +14076,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         maxReplicas:
                           default: 2147483647
@@ -17923,6 +17926,7 @@ spec:
                       - rayStartParams
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -67,6 +67,8 @@ type RayClusterSpec struct {
 	RayVersion string `json:"rayVersion,omitempty"`
 	// WorkerGroupSpecs are the specs for the worker pods
 	// +optional
+	// MaxItems is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
+	// +kubebuilder:validation:MaxItems=100
 	WorkerGroupSpecs []WorkerGroupSpec `json:"workerGroupSpecs,omitempty"`
 }
 
@@ -440,6 +442,8 @@ type WorkerGroupSpec struct {
 	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 	// we can have multiple worker groups, we distinguish them by name
+	// MaxLength is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
+	// +kubebuilder:validation:MaxLength=63
 	GroupName string `json:"groupName"`
 	// Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional.
 	// +kubebuilder:default:=0
@@ -709,6 +713,9 @@ type RayCluster struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the RayCluster.
+	// The has() guards keep the rule valid when workerGroupSpecs is unset or an empty list,
+	// so updates that omit the field (e.g. controller finalizer writes) are not rejected.
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup, has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup, newGroup.groupName == oldGroup.groupName))",message="workerGroupSpecs entries cannot be removed; scale the group to zero replicas or suspend it instead"
 	Spec RayClusterSpec `json:"spec,omitempty"`
 	// +optional
 	Status RayClusterStatus `json:"status,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -24,6 +24,8 @@ type RayClusterSpec struct {
 	// RayVersion is used to determine the command for the Kubernetes Job managed by RayJob
 	RayVersion string `json:"rayVersion,omitempty"`
 	// WorkerGroupSpecs are the specs for the worker pods
+	// MaxItems is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
+	// +kubebuilder:validation:MaxItems=100
 	WorkerGroupSpecs []WorkerGroupSpec `json:"workerGroupSpecs,omitempty"`
 }
 
@@ -44,6 +46,8 @@ type HeadGroupSpec struct {
 // WorkerGroupSpec are the specs for the worker pods
 type WorkerGroupSpec struct {
 	// we can have multiple worker groups, we distinguish them by name
+	// MaxLength is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
+	// +kubebuilder:validation:MaxLength=63
 	GroupName string `json:"groupName"`
 	// Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional.
 	// +kubebuilder:default:=0
@@ -189,6 +193,9 @@ type RayCluster struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the RayCluster.
+	// The has() guards keep the rule valid when workerGroupSpecs is unset or an empty list,
+	// so updates that omit the field (e.g. controller finalizer writes) are not rejected.
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup, has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup, newGroup.groupName == oldGroup.groupName))",message="workerGroupSpecs entries cannot be removed; scale the group to zero replicas or suspend it instead"
 	Spec   RayClusterSpec   `json:"spec,omitempty"`
 	Status RayClusterStatus `json:"status,omitempty"`
 }

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -5325,6 +5325,7 @@ spec:
                 items:
                   properties:
                     groupName:
+                      maxLength: 63
                       type: string
                     idleTimeoutSeconds:
                       format: int32
@@ -9194,10 +9195,17 @@ spec:
                   - minReplicas
                   - template
                   type: object
+                maxItems: 100
                 type: array
             required:
             - headGroupSpec
             type: object
+            x-kubernetes-validations:
+            - message: workerGroupSpecs entries cannot be removed; scale the group
+                to zero replicas or suspend it instead
+              rule: '!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup,
+                has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup,
+                newGroup.groupName == oldGroup.groupName))'
           status:
             properties:
               availableWorkerReplicas:
@@ -13653,6 +13661,7 @@ spec:
                 items:
                   properties:
                     groupName:
+                      maxLength: 63
                       type: string
                     maxReplicas:
                       default: 2147483647
@@ -17502,10 +17511,17 @@ spec:
                   - rayStartParams
                   - template
                   type: object
+                maxItems: 100
                 type: array
             required:
             - headGroupSpec
             type: object
+            x-kubernetes-validations:
+            - message: workerGroupSpecs entries cannot be removed; scale the group
+                to zero replicas or suspend it instead
+              rule: '!has(oldSelf.workerGroupSpecs) || oldSelf.workerGroupSpecs.all(oldGroup,
+                has(self.workerGroupSpecs) && self.workerGroupSpecs.exists(newGroup,
+                newGroup.groupName == oldGroup.groupName))'
           status:
             properties:
               availableWorkerReplicas:

--- a/ray-operator/config/crd/bases/ray.io_raycronjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_raycronjobs.yaml
@@ -5419,6 +5419,7 @@ spec:
                         items:
                           properties:
                             groupName:
+                              maxLength: 63
                               type: string
                             idleTimeoutSeconds:
                               format: int32
@@ -9288,6 +9289,7 @@ spec:
                           - minReplicas
                           - template
                           type: object
+                        maxItems: 100
                         type: array
                     required:
                     - headGroupSpec

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -5420,6 +5420,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         idleTimeoutSeconds:
                           format: int32
@@ -9289,6 +9290,7 @@ spec:
                       - minReplicas
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec
@@ -17618,6 +17620,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         maxReplicas:
                           default: 2147483647
@@ -21467,6 +21470,7 @@ spec:
                       - rayStartParams
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -5313,6 +5313,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         idleTimeoutSeconds:
                           format: int32
@@ -9182,6 +9183,7 @@ spec:
                       - minReplicas
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec
@@ -14074,6 +14076,7 @@ spec:
                     items:
                       properties:
                         groupName:
+                          maxLength: 63
                           type: string
                         maxReplicas:
                           default: 2147483647
@@ -17923,6 +17926,7 @@ spec:
                       - rayStartParams
                       - template
                       type: object
+                    maxItems: 100
                     type: array
                 required:
                 - headGroupSpec

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/raycluster.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/raycluster.go
@@ -17,6 +17,8 @@ type RayClusterApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the RayCluster.
+	// The has() guards keep the rule valid when workerGroupSpecs is unset or an empty list,
+	// so updates that omit the field (e.g. controller finalizer writes) are not rejected.
 	Spec   *RayClusterSpecApplyConfiguration   `json:"spec,omitempty"`
 	Status *RayClusterStatusApplyConfiguration `json:"status,omitempty"`
 }

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
@@ -49,6 +49,7 @@ type RayClusterSpecApplyConfiguration struct {
 	// RayVersion is used to determine the command for the Kubernetes Job managed by RayJob
 	RayVersion *string `json:"rayVersion,omitempty"`
 	// WorkerGroupSpecs are the specs for the worker pods
+	// MaxItems is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
 	WorkerGroupSpecs []WorkerGroupSpecApplyConfiguration `json:"workerGroupSpecs,omitempty"`
 }
 

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/workergroupspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/workergroupspec.go
@@ -16,6 +16,7 @@ type WorkerGroupSpecApplyConfiguration struct {
 	// This is not a user-facing API and is only used by RayJob DeletionStrategy.
 	Suspend *bool `json:"suspend,omitempty"`
 	// we can have multiple worker groups, we distinguish them by name
+	// MaxLength is load-bearing: it caps the worker group removal validation rule's CEL cost so the CRD stays installable. Do not remove.
 	GroupName *string `json:"groupName,omitempty"`
 	// Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional.
 	Replicas *int32 `json:"replicas,omitempty"`

--- a/ray-operator/pkg/webhooks/v1/raycluster_crd_validation_test.go
+++ b/ray-operator/pkg/webhooks/v1/raycluster_crd_validation_test.go
@@ -1,0 +1,188 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+)
+
+var _ = Describe("RayCluster CRD validation", func() {
+	It("allows worker groups to be added and modified", func() {
+		rayCluster := newRayClusterForCRDValidation("raycluster-update", "small-group")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		replicas := int32(2)
+		rayCluster.Spec.WorkerGroupSpecs[0].Replicas = &replicas
+		rayCluster.Spec.WorkerGroupSpecs = append(rayCluster.Spec.WorkerGroupSpecs, newWorkerGroupForCRDValidation("large-group"))
+		Expect(k8sClient.Update(context.Background(), rayCluster)).To(Succeed())
+	})
+
+	It("allows worker groups to be reordered", func() {
+		rayCluster := newRayClusterForCRDValidation("raycluster-reorder", "small-group", "large-group")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.WorkerGroupSpecs[0], rayCluster.Spec.WorkerGroupSpecs[1] = rayCluster.Spec.WorkerGroupSpecs[1], rayCluster.Spec.WorkerGroupSpecs[0]
+		Expect(k8sClient.Update(context.Background(), rayCluster)).To(Succeed())
+	})
+
+	It("rejects worker group removal", func() {
+		rayCluster := newRayClusterForCRDValidation("raycluster-remove", "small-group", "large-group")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.WorkerGroupSpecs = rayCluster.Spec.WorkerGroupSpecs[:1]
+		err := k8sClient.Update(context.Background(), rayCluster)
+		Expect(err).To(MatchError(ContainSubstring("workerGroupSpecs entries cannot be removed")))
+	})
+
+	It("allows updates to a head-only cluster that has no worker groups", func() {
+		rayCluster := newRayClusterForCRDValidation("raycluster-head-only")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.RayVersion = "2.9.0"
+		Expect(k8sClient.Update(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Labels = map[string]string{"foo": "bar"}
+		Expect(k8sClient.Update(context.Background(), rayCluster)).To(Succeed())
+	})
+
+	It("allows updates that omit workerGroupSpecs on a cluster stored with an empty list", func() {
+		name := uniqueNameForCRDValidation("raycluster-empty-list")
+		created := &unstructured.Unstructured{}
+		created.SetGroupVersionKind(rayv1.GroupVersion.WithKind("RayCluster"))
+		created.SetNamespace("default")
+		created.SetName(name)
+		Expect(unstructured.SetNestedField(created.Object,
+			map[string]interface{}{"containers": []interface{}{map[string]interface{}{"name": "ray-head", "image": "rayproject/ray"}}},
+			"spec", "headGroupSpec", "template", "spec")).To(Succeed())
+		Expect(unstructured.SetNestedSlice(created.Object, []interface{}{}, "spec", "workerGroupSpecs")).To(Succeed())
+		Expect(k8sClient.Create(context.Background(), created)).To(Succeed())
+
+		// A typed update drops the empty slice via omitempty, mirroring controller finalizer writes.
+		typed := &rayv1.RayCluster{}
+		Expect(k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: name}, typed)).To(Succeed())
+		typed.Labels = map[string]string{"foo": "bar"}
+		Expect(k8sClient.Update(context.Background(), typed)).To(Succeed())
+	})
+
+	It("rejects removing the only worker group", func() {
+		rayCluster := newRayClusterForCRDValidation("raycluster-drain-all", "small-group")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.WorkerGroupSpecs = nil
+		err := k8sClient.Update(context.Background(), rayCluster)
+		Expect(err).To(MatchError(ContainSubstring("workerGroupSpecs entries cannot be removed")))
+	})
+
+	It("rejects worker group removal through the served v1alpha1 version", func() {
+		rayCluster := newV1alpha1RayClusterForCRDValidation("raycluster-v1alpha1-remove", "small-group", "large-group")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.WorkerGroupSpecs = rayCluster.Spec.WorkerGroupSpecs[:1]
+		err := k8sClient.Update(context.Background(), rayCluster)
+		Expect(err).To(MatchError(ContainSubstring("workerGroupSpecs entries cannot be removed")))
+	})
+
+	It("allows updates to a head-only v1alpha1 cluster that has no worker groups", func() {
+		rayCluster := newV1alpha1RayClusterForCRDValidation("raycluster-v1alpha1-head-only")
+		Expect(k8sClient.Create(context.Background(), rayCluster)).To(Succeed())
+
+		rayCluster.Spec.RayVersion = "2.9.0"
+		Expect(k8sClient.Update(context.Background(), rayCluster)).To(Succeed())
+	})
+
+	It("allows worker group removal from a RayService cluster template", func() {
+		rayService := &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uniqueNameForCRDValidation("rayservice-remove"),
+				Namespace: "default",
+			},
+			Spec: rayv1.RayServiceSpec{
+				RayClusterSpec: newRayClusterSpecForCRDValidation("small-group", "large-group"),
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), rayService)).To(Succeed())
+
+		rayService.Spec.RayClusterSpec.WorkerGroupSpecs = rayService.Spec.RayClusterSpec.WorkerGroupSpecs[:1]
+		Expect(k8sClient.Update(context.Background(), rayService)).To(Succeed())
+	})
+})
+
+func newRayClusterForCRDValidation(name string, groupNames ...string) *rayv1.RayCluster {
+	return &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uniqueNameForCRDValidation(name),
+			Namespace: "default",
+		},
+		Spec: newRayClusterSpecForCRDValidation(groupNames...),
+	}
+}
+
+func newRayClusterSpecForCRDValidation(groupNames ...string) rayv1.RayClusterSpec {
+	workerGroups := make([]rayv1.WorkerGroupSpec, 0, len(groupNames))
+	for _, groupName := range groupNames {
+		workerGroups = append(workerGroups, newWorkerGroupForCRDValidation(groupName))
+	}
+	return rayv1.RayClusterSpec{
+		HeadGroupSpec: rayv1.HeadGroupSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{}},
+			},
+		},
+		WorkerGroupSpecs: workerGroups,
+	}
+}
+
+func newWorkerGroupForCRDValidation(groupName string) rayv1.WorkerGroupSpec {
+	return rayv1.WorkerGroupSpec{
+		GroupName: groupName,
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{}},
+		},
+	}
+}
+
+func uniqueNameForCRDValidation(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, rand.IntnRange(1000, 9000))
+}
+
+func newV1alpha1RayClusterForCRDValidation(name string, groupNames ...string) *rayv1alpha1.RayCluster {
+	minReplicas := int32(0)
+	maxReplicas := int32(1)
+	workerGroups := make([]rayv1alpha1.WorkerGroupSpec, 0, len(groupNames))
+	for _, groupName := range groupNames {
+		workerGroups = append(workerGroups, rayv1alpha1.WorkerGroupSpec{
+			GroupName:      groupName,
+			MinReplicas:    &minReplicas,
+			MaxReplicas:    &maxReplicas,
+			RayStartParams: map[string]string{},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{}},
+			},
+		})
+	}
+	return &rayv1alpha1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uniqueNameForCRDValidation(name),
+			Namespace: "default",
+		},
+		Spec: rayv1alpha1.RayClusterSpec{
+			HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
+				RayStartParams: map[string]string{},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{}},
+				},
+			},
+			WorkerGroupSpecs: workerGroups,
+		},
+	}
+}

--- a/ray-operator/pkg/webhooks/v1/raycluster_crd_validation_test.go
+++ b/ray-operator/pkg/webhooks/v1/raycluster_crd_validation_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1" //nolint:staticcheck // ray.io/v1alpha1 is still a served RayCluster version; this suite intentionally exercises it to prove the worker group removal guard also applies there.
 )
 
 var _ = Describe("RayCluster CRD validation", func() {
@@ -62,9 +62,9 @@ var _ = Describe("RayCluster CRD validation", func() {
 		created.SetNamespace("default")
 		created.SetName(name)
 		Expect(unstructured.SetNestedField(created.Object,
-			map[string]interface{}{"containers": []interface{}{map[string]interface{}{"name": "ray-head", "image": "rayproject/ray"}}},
+			map[string]any{"containers": []any{map[string]any{"name": "ray-head", "image": "rayproject/ray"}}},
 			"spec", "headGroupSpec", "template", "spec")).To(Succeed())
-		Expect(unstructured.SetNestedSlice(created.Object, []interface{}{}, "spec", "workerGroupSpecs")).To(Succeed())
+		Expect(unstructured.SetNestedSlice(created.Object, []any{}, "spec", "workerGroupSpecs")).To(Succeed())
 		Expect(k8sClient.Create(context.Background(), created)).To(Succeed())
 
 		// A typed update drops the empty slice via omitempty, mirroring controller finalizer writes.
@@ -155,7 +155,7 @@ func uniqueNameForCRDValidation(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, rand.IntnRange(1000, 9000))
 }
 
-func newV1alpha1RayClusterForCRDValidation(name string, groupNames ...string) *rayv1alpha1.RayCluster {
+func newV1alpha1RayClusterForCRDValidation(name string, groupNames ...string) *rayv1alpha1.RayCluster { //nolint:staticcheck // builds a v1alpha1 RayCluster on purpose to test the removal guard on the deprecated-but-served version.
 	minReplicas := int32(0)
 	maxReplicas := int32(1)
 	workerGroups := make([]rayv1alpha1.WorkerGroupSpec, 0, len(groupNames))
@@ -170,7 +170,7 @@ func newV1alpha1RayClusterForCRDValidation(name string, groupNames ...string) *r
 			},
 		})
 	}
-	return &rayv1alpha1.RayCluster{
+	return &rayv1alpha1.RayCluster{ //nolint:staticcheck // builds a v1alpha1 RayCluster on purpose to test the removal guard on the deprecated-but-served version.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      uniqueNameForCRDValidation(name),
 			Namespace: "default",

--- a/ray-operator/pkg/webhooks/v1/suite_test.go
+++ b/ray-operator/pkg/webhooks/v1/suite_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1" //nolint:staticcheck // ray.io/v1alpha1 is still a served RayCluster version; this suite must register it to exercise the worker group removal guard there.
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/ray-operator/pkg/webhooks/v1/suite_test.go
+++ b/ray-operator/pkg/webhooks/v1/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -64,6 +65,9 @@ var _ = BeforeSuite(func() {
 
 	scheme := runtime.NewScheme()
 	err = rayv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = rayv1alpha1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = admissionv1.AddToScheme(scheme)


### PR DESCRIPTION
## Why are these changes needed?

Removing a `RayCluster.spec.workerGroupSpecs` entry leaves the operator unable to reconcile the orphaned Pods, and the head autoscaler crash-loops, because `reconcilePods` only iterates worker groups still present in the spec (#1739). Default Helm installs do not enable the admission webhook, so nothing rejects this transition today.

This change adds a CRD CEL transition rule on `RayCluster.spec` that rejects removing a worker group, so the protection holds on default installs without relying on the webhook:

- Additions, in-place field updates, and reorder-only updates stay allowed.
- Removal remains legitimate through `RayService.spec.rayClusterConfig`, which provisions a replacement cluster instead of editing the existing one.
- Head-only clusters (no worker groups) are unaffected: the rule is guarded with `has()` so their updates are accepted, while removing the last worker group is still rejected. Both paths are covered by envtest.

`workerGroupSpecs` is bounded with `MaxItems=100` and `groupName` with `MaxLength=63`. Both bounds are load-bearing for installability: they keep the transition rule's estimated CEL cost under the apiserver per-expression cost limit, so the CRD is accepted at install time. Removing either bound makes the CRD fail to install (regressing #1739). The rationale is documented inline next to each bound in `raycluster_types.go`. Measured CEL cost of the rule is ~3.4% of the static per-expression budget and <0.5% at runtime.

## Related issue number

Fixes #1739

## Checks

- [x] Unit tests
- [x] Helm unit tests
- [ ] Manual tests

### Test plan

- `make sync`
- `make test WHAT=./pkg/webhooks/v1 ENVTEST_K8S_VERSION=1.29.0`
- `make helm-unittest`

envtest (Kubernetes 1.29) covers: add/modify allowed, reorder allowed, removal rejected on a standalone RayCluster, and removal allowed through a RayService cluster template.

