### PR TITLE
helm-chart: add hostUsers to the kuberay-operator chart

### DIFF
--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -212,6 +212,7 @@ spec:
 | readinessProbe.initialDelaySeconds | int | `10` |  |
 | readinessProbe.periodSeconds | int | `5` |  |
 | readinessProbe.failureThreshold | int | `5` |  |
+| hostUsers | bool | `nil` | Specifies if controller pod should use hostUsers or not. Only available in Kubernetes ≥ 1.33. See <https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/> |
 | podSecurityContext | object | `{}` | Set up `securityContext` to improve Pod security. |
 | service.type | string | `"ClusterIP"` | Service type. |
 | service.port | int | `8080` | Service port. |

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
             name: {{ include "kuberay-operator.deployment.name" . }}-config
       {{- end }}
       {{- end }}
+      {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+      {{- if kindIs "bool" .Values.hostUsers }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/kuberay-operator/tests/deployment_test.yaml
+++ b/helm-chart/kuberay-operator/tests/deployment_test.yaml
@@ -88,6 +88,43 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: test-service-account
 
+  - it: Should not set hostUsers if `hostUsers` is not set
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should not set hostUsers if Kubernetes version is less than 1.33
+    capabilities:
+      majorVersion: 1
+      minorVersion: 32
+    set:
+      hostUsers: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers
+
+  - it: Should disable hostUsers if `hostUsers` is false
+    capabilities:
+      majorVersion: 1
+      minorVersion: 33
+    set:
+      hostUsers: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false
+
+  - it: Should enable hostUsers if `hostUsers` is true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 33
+    set:
+      hostUsers: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
   - it: Should use the specified pod security context if `podSecurityContext` is set
     set:
       podSecurityContext:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -316,6 +316,10 @@ readinessProbe:
   periodSeconds: 5
   failureThreshold: 5
 
+# -- (bool) Specifies if controller pod should use hostUsers or not. Only available in Kubernetes ≥ 1.33.
+# See <https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/>
+hostUsers:
+
 # -- Set up `securityContext` to improve Pod security.
 podSecurityContext: {}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The operator Deployment has no passthrough for the pod-level hostUsers field, so the chart cannot run the operator in its own user namespace. Clusters that require user-namespace isolation would have to patch the rendered Deployment with a post-renderer or a mutating webhook instead.

Add an optional `hostUsers` value, rendered onto the pod spec next to `podSecurityContext`.

The value defaults to unset, so rendered output is byte-identical for existing users. It is guarded with `kindIs "bool"` rather than the chart's usual `hasKey` idiom because the key is declared in values.yaml with a null value: `hasKey` would always be true and would render `hostUsers: null`. `kindIs "bool"` also preserves an explicit `false`, the value most operators actually want, which `with` and `default` would discard. Rendering is additionally gated on Kubernetes >= 1.33.

Unit tests cover unset, `true`, `false`, and a pre-1.33 cluster. README.md is regenerated with helm-docs v1.14.2, as pinned in .pre-commit-config.yaml.

Refs: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/

## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
