### PR TITLE
[Flaky test] [History Server] Cache and retry for helm pull prometheus

### DIFF
--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -48,7 +48,23 @@ if [[ "$AUTO_LOAD_DASHBOARD" == "true" ]]; then
   done
 fi
 
-helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
+# Pull the chart to a local cache once (with retries) and install from the cached file instead.
+CHART_TGZ="/tmp/kube-prometheus-stack-48.2.1.tgz"
+if [[ ! -f "$CHART_TGZ" ]]; then
+  for attempt in 1 2 3; do
+    if helm pull prometheus-community/kube-prometheus-stack --version 48.2.1 -d /tmp; then
+      break
+    fi
+    if [[ "$attempt" == 3 ]]; then
+      echo "helm pull failed after ${attempt} attempts"
+      exit 1
+    fi
+    echo "helm pull failed (attempt ${attempt}/3), retrying in 5s..."
+    sleep 5
+  done
+fi
+
+helm --namespace prometheus-system install prometheus "$CHART_TGZ" -f "${DIR}"/overrides.yaml
 
 # set the place of monitor files
 monitor_dir="${DIR}"/../../config/prometheus


### PR DESCRIPTION
## Why are these changes needed?

There's flakiness on `TestHistoryServer/Live_cluster:_grafana_health_only`, with error:

```sh
[2026-08-12T03:15:19Z]         + helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f /workdir/install/prometheus/overrides.yaml
[2026-08-12T03:15:19Z]         Error: INSTALLATION FAILED: Get "https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-48.2.1/kube-prometheus-stack-48.2.1.tgz": dial tcp 20.29.134.23:443: connect: connection timed out
```

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/16589/list?jid=019ff3df-ed17-499b-a5f3-d3e56d4bbb38&tab=output

The very next subtest in the same CI run re-ran the same install script and succeeded, confirming this is a transient network issue rather than a code bug. Note that each e2e subtest runs `install.sh` independently, so the chart was previously downloaded from GitHub multiple times per CI run.

This PR adds:
1. Pulls the chart tgz to a local cache once per machine
2. Installs from the cached file, so later subtests in the same CI run skip the download entirely


## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
