### PR TITLE
[history server] rename session-cache-max-bytes to session-cache-max-memory

### DIFF
--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 	sessionCacheMaxBytes, err := historyserver.ParseSessionCacheMaxMemory(sessionCacheMaxMemory)
 	if err != nil {
-		logrus.Fatalf("--session-cache-max-memory: %v", err)
+		logrus.Fatalf("--session-cache-max-memory %q: %v", sessionCacheMaxMemory, err)
 	}
 	if sessionCacheTTL < 0 {
 		logrus.Fatalf("--session-cache-ttl must be >= 0, got %s", sessionCacheTTL)

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -29,7 +29,7 @@ func main() {
 	burst := historyserver.DefaultKubeAPIBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
 	sessionCacheSize := historyserver.DefaultSessionCacheSize
-	sessionCacheMaxBytes := historyserver.DefaultSessionCacheMaxBytes
+	sessionCacheMaxMemory := historyserver.DefaultSessionCacheMaxMemory
 	sessionCacheTTL := historyserver.DefaultSessionCacheTTL
 	flag.StringVar(&storageBackend, "storage-backend", "", "Storage backend: s3 / gcs / azureblob / aliyunoss / localtest")
 	flag.StringVar(&storageRootDir, "storage-root-dir", "", "The root dir inside the bucket")
@@ -42,7 +42,7 @@ func main() {
 	flag.IntVar(&burst, "kube-api-burst", historyserver.DefaultKubeAPIBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.IntVar(&sessionCacheSize, "session-cache-size", historyserver.DefaultSessionCacheSize, "Max number of dead-session snapshots held in the LRU cache.")
-	flag.IntVar(&sessionCacheMaxBytes, "session-cache-max-bytes", historyserver.DefaultSessionCacheMaxBytes, "Soft cap on cached snapshot bytes; tune under pod memory. 0 disables the byte bound.")
+	flag.StringVar(&sessionCacheMaxMemory, "session-cache-max-memory", historyserver.DefaultSessionCacheMaxMemory, `Soft cap on memory held by cached snapshots, as a Kubernetes quantity (e.g. "1Gi"); tune under pod memory. "0" disables the bound.`)
 	flag.DurationVar(&sessionCacheTTL, "session-cache-ttl", historyserver.DefaultSessionCacheTTL, "How long a dead-session snapshot stays cached after last access. 0 disables TTL.")
 	flag.Parse()
 
@@ -67,8 +67,9 @@ func main() {
 	if sessionCacheSize <= 0 {
 		logrus.Fatalf("--session-cache-size must be > 0, got %d", sessionCacheSize)
 	}
-	if sessionCacheMaxBytes < 0 {
-		logrus.Fatalf("--session-cache-max-bytes must be >= 0, got %d", sessionCacheMaxBytes)
+	sessionCacheMaxBytes, err := historyserver.ParseSessionCacheMaxMemory(sessionCacheMaxMemory)
+	if err != nil {
+		logrus.Fatalf("--session-cache-max-memory: %v", err)
 	}
 	if sessionCacheTTL < 0 {
 		logrus.Fatalf("--session-cache-ttl must be >= 0, got %s", sessionCacheTTL)

--- a/historyserver/config/historyserver-azureblob.yaml
+++ b/historyserver/config/historyserver-azureblob.yaml
@@ -48,7 +48,7 @@ spec:
         # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-bytes=8589934592
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -47,7 +47,7 @@ spec:
         # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-bytes=8589934592
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -66,7 +66,7 @@ spec:
         # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-bytes=8589934592
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/pkg/historyserver/byte_cache_integration_test.go
+++ b/historyserver/pkg/historyserver/byte_cache_integration_test.go
@@ -53,7 +53,7 @@ func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
 			return SessionStatusProcessed, richSnapshot(key), nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	routerNodes(handler)

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -112,7 +112,7 @@ func TestEnterCluster(t *testing.T) {
 			return SessionStatusEventsErr, nil, fmt.Errorf("unknown session")
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	// Register actual router
 	routerRayClusterSet(handler)
@@ -275,7 +275,7 @@ func TestEnterClusterLatestFromStorage(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -340,7 +340,7 @@ func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
 			return SessionStatusLive, nil, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -392,7 +392,7 @@ func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -450,7 +450,7 @@ func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer
@@ -508,7 +508,7 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	routerRayClusterSet(handler)
 	container := restful.DefaultContainer

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
@@ -23,16 +26,32 @@ const (
 	// DefaultSessionCacheTTL is how long a dead-session snapshot stays cached after last access.
 	// 0 disables expiry.
 	DefaultSessionCacheTTL time.Duration = 0
-	// DefaultSessionCacheMaxBytes bounds the total bytes of cached dead-session snapshots.
-	// 0 disables the byte bound.
+	// DefaultSessionCacheMaxMemory bounds the memory held by cached dead-session
+	// snapshots, as a Kubernetes quantity. "0" disables the bound.
 	//
 	// This is a soft bound on the idle resident cache, not a hard cap on process memory.
 	// Real usage can exceed it in three ways:
 	//   - add-then-evict: cache momentarily holds oldTotal + newEntry
 	//   - one large session: a single snapshot bigger than the whole budget is kept
 	//   - per-request decode: every GET unmarshals cached bytes into a full *SessionSnapshot
-	DefaultSessionCacheMaxBytes = 2 << 30
+	DefaultSessionCacheMaxMemory = "2Gi"
 )
+
+// ParseSessionCacheMaxMemory converts a Kubernetes quantity into a
+// byte count.
+func ParseSessionCacheMaxMemory(s string) (int, error) {
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a valid resource quantity: %w", s, err)
+	}
+	if q.Sign() < 0 {
+		return 0, fmt.Errorf("%q cannot be negative", s)
+	}
+	if q.CmpInt64(math.MaxInt) > 0 {
+		return 0, fmt.Errorf("%q exceeds the maximum of %d bytes", s, math.MaxInt)
+	}
+	return int(q.Value()), nil
+}
 
 // processor is an interface to enable mocking SessionProcessor in tests.
 type processor interface {

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -35,7 +35,7 @@ func TestParseSessionCacheMaxMemory(t *testing.T) {
 		{name: "decimal suffix", input: "8G", want: 8000000000},
 		{name: "plain byte count", input: "8589934592", want: 8589934592},
 		{name: "exponent", input: "2e9", want: 2000000000},
-		{name: "fractional rounds up", input: "8.5Gi", want: 9126805504},
+		{name: "fractional binary suffix", input: "8.5Gi", want: 9126805504},
 		{name: "zero disables the bound", input: "0", want: 0},
 		{name: "default", input: DefaultSessionCacheMaxMemory, want: 2 << 30},
 		{name: "negative", input: "-1", wantErr: true},

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -15,6 +15,53 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
+// defaultSessionCacheMaxBytes is DefaultSessionCacheMaxMemory expressed in bytes.
+var defaultSessionCacheMaxBytes = func() int {
+	b, err := ParseSessionCacheMaxMemory(DefaultSessionCacheMaxMemory)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+func TestParseSessionCacheMaxMemory(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{name: "binary suffix", input: "8Gi", want: 8589934592},
+		{name: "decimal suffix", input: "8G", want: 8000000000},
+		{name: "plain byte count", input: "8589934592", want: 8589934592},
+		{name: "exponent", input: "2e9", want: 2000000000},
+		{name: "fractional rounds up", input: "8.5Gi", want: 9126805504},
+		{name: "zero disables the bound", input: "0", want: 0},
+		{name: "default", input: DefaultSessionCacheMaxMemory, want: 2 << 30},
+		{name: "negative", input: "-1", wantErr: true},
+		{name: "unsupported suffix", input: "8GiB", wantErr: true},
+		{name: "not a quantity", input: "lots", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSessionCacheMaxMemory(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSessionCacheMaxMemory(%q) = %d, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSessionCacheMaxMemory(%q) returned unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSessionCacheMaxMemory(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // fakeProcessor is a configurable test double for processor.
 type fakeProcessor struct {
 	calls int32


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

According to https://github.com/ray-project/kuberay/pull/5095/changes#r3758468097, we decide to rename `session-cache-max-bytes` to `--session-cache-max-memory` and accept a Kubernetes resource quantity instead. 

Before:
```
DefaultSessionCacheMaxBytes = 2 << 30
```

After:
```
DefaultSessionCacheMaxMemory = "2Gi"
```



## Related issue number

https://github.com/ray-project/kuberay/pull/5095/changes#r3758468097

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
