### PR TITLE
[Feature] Surface orphaned worker group Pods via status condition and event

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -646,6 +646,8 @@ const (
 	RayClusterPodsProvisioning     = "RayClusterPodsProvisioning"
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
+	// OrphanedWorkerGroupPodsFound says that Pods exist for a worker group that is no longer in spec.workerGroupSpecs.
+	OrphanedWorkerGroupPodsFound = "OrphanedWorkerGroupPodsFound"
 	// UnknownReason says that the reason for the condition is unknown.
 	UnknownReason = "Unknown"
 )
@@ -662,6 +664,10 @@ const (
 	RayClusterSuspending RayClusterConditionType = "RayClusterSuspending"
 	// RayClusterSuspended is set to true when all Pods belonging to a suspending RayCluster are deleted. Note that RayClusterSuspending and RayClusterSuspended cannot both be true at the same time.
 	RayClusterSuspended RayClusterConditionType = "RayClusterSuspended"
+	// RayClusterOrphanedWorkerGroup is set to true when Pods exist whose ray.io/group label references a worker group
+	// that is no longer present in spec.workerGroupSpecs. The controller only reconciles worker groups still in the
+	// spec, so these Pods are never reconciled or scaled and can stall the head autoscaler.
+	RayClusterOrphanedWorkerGroup RayClusterConditionType = "OrphanedWorkerGroup"
 )
 
 // HeadInfo gives info about head

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -2008,6 +2008,10 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.MinWorkerReplicas = utils.CalculateMinReplicas(newInstance)
 	newInstance.Status.MaxWorkerReplicas = utils.CalculateMaxReplicas(newInstance)
 
+	if statusConditionGateEnabled {
+		r.reconcileOrphanedWorkerGroupCondition(instance, newInstance, runtimePods.Items)
+	}
+
 	totalResources := utils.CalculateDesiredResources(newInstance)
 	newInstance.Status.DesiredCPU = totalResources[corev1.ResourceCPU]
 	newInstance.Status.DesiredMemory = totalResources[corev1.ResourceMemory]
@@ -2134,6 +2138,77 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	}
 
 	return newInstance, nil
+}
+
+// reconcileOrphanedWorkerGroupCondition surfaces worker Pods whose ray.io/group label no longer maps to a
+// worker group in spec.workerGroupSpecs. reconcilePods only iterates groups still present in the spec, so
+// removing a workerGroupSpecs entry leaves its Pods unreconciled and can stall the head autoscaler (#1739).
+// This only reports the condition and emits an Event; it never deletes or mutates the orphaned Pods.
+func (r *RayClusterReconciler) reconcileOrphanedWorkerGroupCondition(instance, newInstance *rayv1.RayCluster, pods []corev1.Pod) {
+	orphanedGroups, orphanedPodCount := detectOrphanedWorkerGroups(newInstance, pods)
+	if len(orphanedGroups) == 0 {
+		meta.RemoveStatusCondition(&newInstance.Status.Conditions, string(rayv1.RayClusterOrphanedWorkerGroup))
+		return
+	}
+
+	message := fmt.Sprintf("Worker group(s) [%s] were removed from spec.workerGroupSpecs but still have %d Pod(s); "+
+		"the controller cannot reconcile them. Restore the group name(s) in the spec, or delete the Pods manually.",
+		strings.Join(orphanedGroups, ", "), orphanedPodCount)
+
+	// Emit the Event only on transition into the orphaned state to avoid emitting on every reconcile.
+	if !meta.IsStatusConditionTrue(instance.Status.Conditions, string(rayv1.RayClusterOrphanedWorkerGroup)) {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, string(utils.OrphanedWorkerGroupPodsDetected), string(utils.ReconcileAction),
+			"RayCluster %s/%s: %s", instance.Namespace, instance.Name, message)
+	}
+
+	meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+		Type:    string(rayv1.RayClusterOrphanedWorkerGroup),
+		Status:  metav1.ConditionTrue,
+		Reason:  rayv1.OrphanedWorkerGroupPodsFound,
+		Message: message,
+	})
+}
+
+// detectOrphanedWorkerGroups returns the sorted names of worker groups that still have Pods but are no longer
+// present in spec.workerGroupSpecs, together with the total number of such orphaned Pods. Pods that are already
+// being deleted are ignored.
+func detectOrphanedWorkerGroups(instance *rayv1.RayCluster, pods []corev1.Pod) ([]string, int) {
+	specGroups := make(map[string]struct{}, len(instance.Spec.WorkerGroupSpecs))
+	for _, worker := range instance.Spec.WorkerGroupSpecs {
+		specGroups[worker.GroupName] = struct{}{}
+	}
+
+	orphanedCounts := make(map[string]int)
+	for i := range pods {
+		pod := &pods[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Labels[utils.RayNodeTypeLabelKey] != string(rayv1.WorkerNode) {
+			continue
+		}
+		group, ok := pod.Labels[utils.RayNodeGroupLabelKey]
+		if !ok {
+			continue
+		}
+		if _, present := specGroups[group]; present {
+			continue
+		}
+		orphanedCounts[group]++
+	}
+
+	if len(orphanedCounts) == 0 {
+		return nil, 0
+	}
+
+	groups := make([]string, 0, len(orphanedCounts))
+	total := 0
+	for group, count := range orphanedCounts {
+		groups = append(groups, group)
+		total += count
+	}
+	slices.Sort(groups)
+	return groups, total
 }
 
 func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, instance *rayv1.RayCluster) (string, string, error) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1725,6 +1725,139 @@ func TestCalculateStatus(t *testing.T) {
 	assert.True(t, meta.IsStatusConditionPresentAndEqual(newInstance.Status.Conditions, string(rayv1.RayClusterReplicaFailure), metav1.ConditionTrue))
 }
 
+func TestDetectOrphanedWorkerGroups(t *testing.T) {
+	makePod := func(name, group, nodeType string, deleting bool) corev1.Pod {
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeTypeLabelKey:  nodeType,
+					utils.RayNodeGroupLabelKey: group,
+				},
+			},
+		}
+		if deleting {
+			now := metav1.Now()
+			pod.DeletionTimestamp = &now
+			pod.Finalizers = []string{"ray.io/test"}
+		}
+		return pod
+	}
+
+	instance := &rayv1.RayCluster{
+		Spec: rayv1.RayClusterSpec{
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{{GroupName: "group1"}},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		pods         []corev1.Pod
+		wantGroups   []string
+		wantPodCount int
+	}{
+		{
+			name: "head and in-spec worker pods are not orphaned",
+			pods: []corev1.Pod{
+				makePod("head", utils.RayNodeHeadGroupLabelValue, string(rayv1.HeadNode), false),
+				makePod("w1", "group1", string(rayv1.WorkerNode), false),
+			},
+		},
+		{
+			name: "pods from removed groups are orphaned",
+			pods: []corev1.Pod{
+				makePod("w1", "group1", string(rayv1.WorkerNode), false),
+				makePod("orphan1", "removed", string(rayv1.WorkerNode), false),
+				makePod("orphan2", "removed", string(rayv1.WorkerNode), false),
+				makePod("orphan3", "removed-2", string(rayv1.WorkerNode), false),
+			},
+			wantGroups:   []string{"removed", "removed-2"},
+			wantPodCount: 3,
+		},
+		{
+			name: "terminating orphaned pods are ignored",
+			pods: []corev1.Pod{makePod("orphan1", "removed", string(rayv1.WorkerNode), true)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			groups, count := detectOrphanedWorkerGroups(instance, tc.pods)
+			assert.Equal(t, tc.wantGroups, groups)
+			assert.Equal(t, tc.wantPodCount, count)
+		})
+	}
+}
+
+func TestReconcileOrphanedWorkerGroupCondition(t *testing.T) {
+	newWorkerPod := func(name, group string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeTypeLabelKey:  string(rayv1.WorkerNode),
+					utils.RayNodeGroupLabelKey: group,
+				},
+			},
+		}
+	}
+	newCluster := func() *rayv1.RayCluster {
+		return &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: namespaceStr},
+			Spec:       rayv1.RayClusterSpec{WorkerGroupSpecs: []rayv1.WorkerGroupSpec{{GroupName: "group1"}}},
+		}
+	}
+
+	t.Run("sets condition and emits event once on transition", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		r := &RayClusterReconciler{Recorder: recorder}
+		instance := newCluster()
+		newInstance := instance.DeepCopy()
+		pods := []corev1.Pod{newWorkerPod("orphan1", "removed")}
+
+		r.reconcileOrphanedWorkerGroupCondition(instance, newInstance, pods)
+
+		cond := meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterOrphanedWorkerGroup))
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+		assert.Equal(t, rayv1.OrphanedWorkerGroupPodsFound, cond.Reason)
+		assert.Contains(t, cond.Message, "removed")
+
+		select {
+		case event := <-recorder.Events:
+			assert.Contains(t, event, string(utils.OrphanedWorkerGroupPodsDetected))
+		default:
+			t.Fatal("expected an orphaned worker group event, got none")
+		}
+
+		// The condition is already true, so a subsequent reconcile must not emit a duplicate event.
+		instance.Status.Conditions = newInstance.Status.Conditions
+		r.reconcileOrphanedWorkerGroupCondition(instance, newInstance, pods)
+		select {
+		case event := <-recorder.Events:
+			t.Fatalf("expected no repeat event, got %q", event)
+		default:
+		}
+	})
+
+	t.Run("clears condition when no orphaned pods remain", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		r := &RayClusterReconciler{Recorder: recorder}
+		instance := newCluster()
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:   string(rayv1.RayClusterOrphanedWorkerGroup),
+			Status: metav1.ConditionTrue,
+			Reason: rayv1.OrphanedWorkerGroupPodsFound,
+		})
+		newInstance := instance.DeepCopy()
+
+		r.reconcileOrphanedWorkerGroupCondition(instance, newInstance, []corev1.Pod{newWorkerPod("w1", "group1")})
+		assert.Nil(t, meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterOrphanedWorkerGroup)))
+	})
+}
+
 // TestCalculateStatusWithoutDesiredReplicas tests that the cluster CR should not be marked as Ready if
 // DesiredWorkerReplicas > 0 and DesiredWorkerReplicas != ReadyWorkerReplicas
 func TestCalculateStatusWithoutDesiredReplicas(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -443,6 +443,7 @@ const (
 	DeletedWorkerPod                  K8sEventType = "DeletedWorkerPod"
 	FailedToDeleteWorkerPod           K8sEventType = "FailedToDeleteWorkerPod"
 	FailedToDeleteWorkerPodCollection K8sEventType = "FailedToDeleteWorkerPodCollection"
+	OrphanedWorkerGroupPodsDetected   K8sEventType = "OrphanedWorkerGroupPodsDetected"
 
 	// Redis Cleanup Job event list
 	CreatedRedisCleanupJob        K8sEventType = "CreatedRedisCleanupJob"


### PR DESCRIPTION
## Why

Removing an entry from `RayCluster.spec.workerGroupSpecs` on a running cluster silently orphans that group's Pods. `reconcilePods` only iterates the worker groups still present in the spec:

```go
// ray-operator/controllers/ray/raycluster_controller.go
for _, worker := range instance.Spec.WorkerGroupSpecs {
    ...
    if err := r.List(ctx, &workerPods, common.RayClusterGroupPodsAssociationOptions(instance, worker.GroupName)...); err != nil {
```

and it lists Pods per still-existing group only, so the removed group's Pods are never reconciled, scaled, or cleaned up. This can stall the head autoscaler (#1739).

#5132 adds a CRD CEL rule that **rejects new removals**, protecting clusters going forward. But clusters that are **already** in this broken state (orphaned Pods already exist) still get no signal. This PR is the orthogonal, additive observability half.

## What

In `calculateStatus`, detect Pods whose `ray.io/group` label no longer maps to a worker group in `spec.workerGroupSpecs` and surface them:

- **Status condition** `OrphanedWorkerGroup` (status `True`, reason `OrphanedWorkerGroupPodsFound`) listing the affected group name(s) and orphaned Pod count.
- **Warning Event** `OrphanedWorkerGroupPodsDetected`, emitted once per transition into the orphaned state to avoid per-reconcile spam.

This is **signal only** — it never deletes or mutates the orphaned Pods. Draining/cleanup is intentionally out of scope. Pods already being deleted are ignored, and the condition is cleared automatically once the group is restored or the Pods are gone.

Gated behind the existing `RayClusterStatusConditions` feature gate (Beta, default on).

## Tests

- `TestDetectOrphanedWorkerGroups` — pure detection over head / in-spec / orphaned / terminating Pods.
- `TestReconcileOrphanedWorkerGroupCondition` — condition set plus a single Event on transition, and condition cleared when no orphans remain.

`make test WHAT=./controllers/ray/...`, `go vet`, and `golangci-lint run` are all green.

## Relationship to existing work

- Orthogonal to #5132: that PR blocks *new* removals at the CRD level; this PR reports clusters that are *already* broken.
- Additive to the observability direction raised by @omkar619-dev on #1739.

Related to #1739.