### PR TITLE
[Bug] Validate that worker group names are valid label values

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -120,6 +120,15 @@ func ValidateRayClusterSpec(spec *rayv1.RayClusterSpec, annotations map[string]s
 			return fmt.Errorf("workerGroupSpec should have at least one container")
 		}
 
+		// GroupName is used verbatim as the value of the ray.io/group label on this group's Pods
+		// (see labelPod in common/pod.go). An invalid label value is only rejected by the apiserver
+		// at Pod creation time, so validate it up front to fail fast with a clear message instead of
+		// silently failing to create worker Pods.
+		if errs := validation.IsValidLabelValue(workerGroup.GroupName); len(errs) > 0 {
+			return fmt.Errorf("worker group name %q must be a valid value for the %q label set on its Pods: %s",
+				workerGroup.GroupName, RayNodeGroupLabelKey, strings.Join(errs, "; "))
+		}
+
 		// When autoscaling is enabled, MinReplicas and MaxReplicas are optional
 		// as users can manually update them and the autoscaler will handle the adjustment.
 		if !isAutoscalingEnabled && (workerGroup.MinReplicas == nil || workerGroup.MaxReplicas == nil) {
@@ -413,12 +422,11 @@ func validateNetworkPolicy(spec *rayv1.RayClusterSpec) error {
 	// an existing worker group.
 	//
 	// Group names are embedded in NetworkPolicy object names ({cluster}-workers-{group}),
-	// so they must be valid DNS1123 labels when NetworkPolicy is enabled. This is only
-	// enforced here to avoid breaking existing clusters that don't use NetworkPolicy.
-	//
-	// TODO(machichima): consider validating group name format for all clusters under
-	// ValidateRayClusterSpec. Note this is a breaking change: uppercase group names
-	// currently work because pod names are lowercased in PodName().
+	// so they must be valid DNS1123 labels when NetworkPolicy is enabled. ValidateRayClusterSpec
+	// already rejects group names that are not valid label values for all clusters; the DNS1123
+	// check below is stricter (it additionally forbids uppercase) and stays scoped to NetworkPolicy
+	// to avoid breaking existing clusters whose uppercase group names work because pod names are
+	// lowercased in PodName().
 	groupNames := make(map[string]struct{}, len(spec.WorkerGroupSpecs))
 	for i := range spec.WorkerGroupSpecs {
 		groupName := spec.WorkerGroupSpecs[i].GroupName

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -612,6 +612,47 @@ func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
 	}
 }
 
+func TestValidateRayClusterSpecWorkerGroupNameLabelValue(t *testing.T) {
+	headGroupSpec := rayv1.HeadGroupSpec{Template: podTemplateSpec(nil, nil)}
+	workerGroupWithName := func(groupName string) rayv1.WorkerGroupSpec {
+		return rayv1.WorkerGroupSpec{
+			GroupName:   groupName,
+			Template:    podTemplateSpec(nil, nil),
+			MinReplicas: new(int32(0)),
+			MaxReplicas: new(int32(5)),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		groupName   string
+		expectError bool
+	}{
+		{name: "valid lowercase group name", groupName: "small-group"},
+		// Uppercase is a valid label value; it must stay allowed so this does not become the
+		// breaking DNS1123 change that would reject existing clusters.
+		{name: "valid mixed-case group name", groupName: "MyGroup"},
+		{name: "invalid group name with a space", groupName: "small group", expectError: true},
+		{name: "invalid group name with a slash", groupName: "team/group", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := rayv1.RayClusterSpec{
+				HeadGroupSpec:    headGroupSpec,
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{workerGroupWithName(tt.groupName)},
+			}
+			err := ValidateRayClusterSpec(&spec, nil)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), RayNodeGroupLabelKey)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateRayClusterSpecSuspendingWorkerGroup(t *testing.T) {
 	headGroupSpec := rayv1.HeadGroupSpec{
 		Template: podTemplateSpec(nil, nil),


### PR DESCRIPTION
## Problem

`groupName` is used **verbatim** as the value of the `ray.io/group` label on a worker group's Pods:

```go
// ray-operator/controllers/ray/common/pod.go  (labelPod)
labels := map[string]string{
    ...
    utils.RayNodeGroupLabelKey: groupName,
    utils.RayIDLabelKey:        utils.CheckLabel(utils.GenerateIdentifier(rayClusterName, rayNodeType)),
    ...
}
```

Note `RayIDLabelKey` is passed through `CheckLabel`, but `groupName` is not — and `CheckLabel` only truncates to 63 chars and fixes a leading punctuation char anyway; it does not validate interior characters.

Nothing validates that `groupName` is a valid Kubernetes label value before the Pod is created:

- The admission webhook's `validateWorkerGroups` only checks that group names are **unique**.
- `ValidateRayClusterSpec` validates replicas, resources, labels, idle timeout, etc., but not the group name itself.
- `IsDNS1123Label(groupName)` is checked, but only when NetworkPolicy is enabled (because the name is embedded in the NetworkPolicy object name).

So a group name like `"small group"` (space) or `"team/group"` (slash) is accepted on the RayCluster, and the only symptom is repeated worker Pod creation failures from the apiserver (`metadata.labels: Invalid value ...`) — a confusing, deferred failure.

## Fix

Validate `GroupName` with `validation.IsValidLabelValue` inside `ValidateRayClusterSpec`, which the controller runs on every reconcile (so this protects default Helm installs that do not enable the admission webhook) and which RayJob/RayService validation also call. Invalid names now fail fast with a clear message naming the `ray.io/group` label.

This intentionally uses the **label-value** rules, not the stricter `IsDNS1123Label`. Label values allow uppercase, so existing clusters whose group names contain uppercase characters keep working (their pod *names* are lowercased in `PodName()`). This is exactly the breaking change flagged in the existing `TODO(machichima)` next to the NetworkPolicy check, which this PR resolves for label-value validity while leaving the stricter DNS1123 rule scoped to NetworkPolicy.

## Tests

`TestValidateRayClusterSpecWorkerGroupNameLabelValue` covers a valid lowercase name, a valid mixed-case name (to lock in that uppercase stays allowed), and invalid names containing a space and a slash.

`make test WHAT=./controllers/...`, `go vet`, and `golangci-lint run` are all green.