### PR TITLE
common: mirror Ray container cpu/memory to wait-gcs-ready init container

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -591,6 +591,26 @@ func getEnableProbesInjection() bool {
 	return true
 }
 
+func buildInitContainerResources(rayContainerResources corev1.ResourceRequirements) corev1.ResourceRequirements {
+	extractResource := func(resourceList corev1.ResourceList) corev1.ResourceList {
+		result := corev1.ResourceList{}
+		for _, key := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if value, ok := resourceList[key]; ok {
+				result[key] = value
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	}
+
+	return corev1.ResourceRequirements{
+		Limits:   extractResource(rayContainerResources.Limits),
+		Requests: extractResource(rayContainerResources.Requests),
+	}
+}
+
 // DefaultWorkerPodTemplate sets the config values
 func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, workerSpec rayv1.WorkerGroupSpec, podName string, fqdnRayIP string, headPort string, replicaGrpName string, replicaIndex int, numHostIndex int) corev1.PodTemplateSpec {
 	podTemplate := workerSpec.Template
@@ -639,20 +659,9 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 			Env:          deepCopyRayContainer.Env,
 			VolumeMounts: deepCopyRayContainer.VolumeMounts,
 			// If users specify a ResourceQuota for the namespace, the init container needs to specify resources explicitly.
-			// GKE's Autopilot does not support GPU-using init containers, so we explicitly specify the resources for the
-			// init container instead of reusing the resources of the Ray container.
-			Resources: corev1.ResourceRequirements{
-				// The init container's resource consumption remains constant, as it solely sends requests to check the GCS status at a fixed frequency.
-				// Therefore, hard-coding the resources is acceptable.
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
-				},
-			},
+			// GKE's Autopilot does not support GPU-using init containers, so we explicitly extract the needed resources from
+			// the Ray container and apply them to the init container.
+			Resources: buildInitContainerResources(deepCopyRayContainer.Resources),
 		}
 		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, initContainer)
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1616,6 +1616,123 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	require.NoError(t, containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, customMetricsPort))
 }
 
+func TestBuildInitContainerResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    corev1.ResourceRequirements
+		expected corev1.ResourceRequirements
+	}{
+		{
+			name: "cpu and memory only, no GPU",
+			input: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+		{
+			name: "cpu, memory, and GPU set -> GPU should be dropped",
+			input: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+					"nvidia.com/gpu":      resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+					"nvidia.com/gpu":      resource.MustParse("1"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+		{
+			name:     "no resources set at all -> result stays nil",
+			input:    corev1.ResourceRequirements{},
+			expected: corev1.ResourceRequirements{},
+		},
+		{
+			name: "only cpu set, memory missing -> asymmetric case",
+			input: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expected: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildInitContainerResources(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDefaultWorkerPodTemplate_InitContainerResourcesWiring(t *testing.T) {
+	ctx := context.Background()
+	cluster := instance.DeepCopy()
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+			"nvidia.com/gpu":      resource.MustParse("1"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+			"nvidia.com/gpu":      resource.MustParse("1"),
+		},
+	}
+
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
+	podTemplateSpec := DefaultWorkerPodTemplate(ctx, *cluster, worker, podName, fqdnRayIP, "6379", "", 0, 0)
+
+	var gcsReadyContainer *corev1.Container
+	for i := range podTemplateSpec.Spec.InitContainers {
+		if podTemplateSpec.Spec.InitContainers[i].Name == "wait-gcs-ready" {
+			gcsReadyContainer = &podTemplateSpec.Spec.InitContainers[i]
+			break
+		}
+	}
+	require.NotNil(t, gcsReadyContainer, "worker pod should have wait-gcs-ready init container")
+
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+	assert.Equal(t, expected, gcsReadyContainer.Resources)
+}
+
 func TestDefaultWorkerPodTemplate_Autoscaling(t *testing.T) {
 	clusterNoAutoscaling := instance.DeepCopy()
 	clusterAutoscalingV1 := instance.DeepCopy()


### PR DESCRIPTION
## Summary

- The `wait-gcs-ready` init container used a fixed `200m` cpu / `256Mi` memory limit.
- On some images (no precompiled Python bytecode), this limit makes `ray health-check` very slow. It can add up to ~55 seconds to worker startup. This is bad for autoscaling, because new workers must wait for it.
- This PR changes the init container to copy cpu and memory from the Ray container instead of using a fixed value. GPU and other extra resources are not copied (GKE Autopilot does not allow GPU on init containers). If the Ray container has no cpu/memory set, the init container also has none set.

## Why

- Full analysis is in #5138.
- The old fixed value assumed the init container is always cheap and constant. That is not true - `ray health-check` starts Python and imports the whole `ray` CLI, which is not cheap on every image.
- This PR only does the small, safe fix (right-size the resources). The issue also talks about a bigger idea (move the health check into Ray Core itself), but that needs changes in the `ray-project/ray` repo, so it is out of scope here.

## Test plan

- [x] Added `TestBuildInitContainerResources`: unit tests for the new helper function (cpu/mem only, GPU dropped, no resources set, and an asymmetric case where only cpu is set).
- [x] Added `TestDefaultWorkerPodTemplate_InitContainerResourcesWiring`: checks that the `wait-gcs-ready` init container really gets the right resources after `DefaultWorkerPodTemplate` runs.
- [x] `go build`, `go vet`, `gofmt`, and `golangci-lint` all pass.
- [x] Full test suite for `controllers/ray/common` passes.

Related to #5138.