### PR TITLE
[Bug][kubectl-plugin] Check RayJob status after port-forward loss

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -594,10 +594,10 @@ func runPortForward(
 	streams *genericiooptions.IOStreams,
 	svcName string,
 ) {
-    args := []string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)}
+	args := []string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)}
 	opts := portforward.NewDefaultPortForwardOptions(*streams)
 	opts.Address = []string{"localhost"}
-	portForwardCmd := portforward.NewCmdPortForward(factory, *streams) 
+	portForwardCmd := portforward.NewCmdPortForward(factory, *streams)
 
 	fmt.Printf("Port forwarding service %s\n", svcName)
 	if err := opts.Complete(factory, portForwardCmd, args); err != nil {

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"log"
 	"math/big"
 	"net/http"
 	"os"
@@ -438,25 +437,17 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		return fmt.Errorf("Timed out waiting for cluster")
 	}
 
-	if options.address == "" {
+	usingPortForward := options.address == ""
+	if usingPortForward {
 		svcName, err := k8sClients.GetRayHeadSvcName(ctx, options.namespace, util.RayCluster, options.cluster)
 		if err != nil {
 			return fmt.Errorf("Failed to find service name: %w", err)
 		}
 
-		// start port forward section
-		portForwardCmd := portforward.NewCmdPortForward(factory, *options.ioStreams)
-		portForwardCmd.SetArgs([]string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)})
-
 		// create new context for port-forwarding so we can cancel the context to stop the port forwarding only
 		portForwardCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		go func() {
-			fmt.Printf("Port forwarding service %s\n", svcName)
-			if err := portForwardCmd.ExecuteContext(portForwardCtx); err != nil {
-				log.Fatalf("Error occurred while port-forwarding Ray dashboard: %v", err)
-			}
-		}()
+		go runPortForward(portForwardCtx, factory, options.ioStreams, svcName)
 
 		// Wait for port forward to be ready
 		var portForwardReady bool
@@ -515,7 +506,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 
 	fmt.Printf("Running Ray submit job command...\n")
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("error occurred while running command %s: %v", fmt.Sprint(raySubmitCmd), err)
+		return fmt.Errorf("error occurred while running command %s: %w", fmt.Sprint(raySubmitCmd), err)
 	}
 
 	rayJobID := options.submissionID
@@ -550,7 +541,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	// Wait for Ray job submit to finish.
 	err = cmd.Wait()
 	if err != nil {
-		return fmt.Errorf("Error occurred with Ray job submit: %w", err)
+		return options.reconcileSubmitError(ctx, k8sClients, usingPortForward, err)
 	}
 	if options.noWait {
 		fmt.Printf("Ray job submitted with ID %s\n", rayJobID)
@@ -583,27 +574,101 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		fmt.Printf("Current status: %s (RayJob: %s, JobID: %s)\n",
 			status, job.GetName(), jobID)
 
-		if rayv1.IsJobTerminal(status) {
-			switch status {
-			case rayv1.JobStatusSucceeded, rayv1.JobStatusStopped:
+		terminal, terminalErr := rayJobTerminalResult(job)
+		if terminal {
+			if terminalErr == nil {
 				fmt.Printf("Job %s finished with status %s.\n", jobID, status)
-				return nil
-
-			case rayv1.JobStatusFailed:
-				if msg := job.Status.Message; msg != "" {
-					return fmt.Errorf("job %s failed: %s", jobID, msg)
-				}
-				return fmt.Errorf("job %s failed with status %s", jobID, status)
-
-			default:
-				return fmt.Errorf("job %s in unexpected terminal state %s", jobID, status)
 			}
+			return terminalErr
 		}
 	}
 
 	fmt.Fprintf(options.ioStreams.ErrOut,
 		"rayjob %s watch ended without a clear terminal state\n", options.RayJob.GetName())
 	return nil
+}
+
+func runPortForward(
+	ctx context.Context,
+	factory cmdutil.Factory,
+	streams *genericiooptions.IOStreams,
+	svcName string,
+) {
+	portForwardCmd := portforward.NewCmdPortForward(factory, *streams)
+	portForwardCmd.SetArgs([]string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)})
+
+	fmt.Printf("Port forwarding service %s\n", svcName)
+	if err := portForwardCmd.ExecuteContext(ctx); err != nil && ctx.Err() == nil {
+		// Restarting the port-forward cannot reconnect the Ray CLI's existing
+		// log stream. Let the Ray CLI exit, then reconcile its result against
+		// the RayJob status in reconcileSubmitError.
+		fmt.Fprintf(streams.ErrOut, "Port-forward to Ray dashboard ended: %v\n", err)
+	}
+}
+
+func (options *SubmitJobOptions) reconcileSubmitError(
+	ctx context.Context,
+	k8sClients client.Client,
+	usingPortForward bool,
+	submitErr error,
+) error {
+	wrappedSubmitErr := fmt.Errorf("Error occurred with Ray job submit: %w", submitErr)
+	if !usingPortForward {
+		return wrappedSubmitErr
+	}
+
+	// A locally managed port-forward can disappear after a TTL=0 RayJob
+	// succeeds because the operator immediately deletes the RayCluster. In
+	// that case, the Ray CLI reports a connection error even though the job
+	// completed successfully. The persisted RayJob status is the source of
+	// truth for the job result.
+	jobName := options.RayJob.GetName()
+	job, err := k8sClients.RayClient().RayV1().RayJobs(options.namespace).Get(
+		ctx,
+		jobName,
+		v1.GetOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"%w; failed to get RayJob %s/%s while reconciling the result: %v",
+			wrappedSubmitErr, options.namespace, jobName, err,
+		)
+	}
+
+	terminal, terminalErr := rayJobTerminalResult(job)
+	if !terminal {
+		return wrappedSubmitErr
+	}
+	if terminalErr == nil {
+		fmt.Fprintf(options.ioStreams.ErrOut,
+			"Ray CLI exited after RayJob %s reached status %s; treating the submission as successful.\n",
+			job.GetName(), job.Status.JobStatus)
+	}
+	return terminalErr
+}
+
+func rayJobTerminalResult(job *rayv1.RayJob) (bool, error) {
+	status := job.Status.JobStatus
+	if !rayv1.IsJobTerminal(status) {
+		return false, nil
+	}
+
+	jobID := job.Status.JobId
+	if jobID == "" {
+		jobID = "unknown"
+	}
+
+	switch status {
+	case rayv1.JobStatusSucceeded, rayv1.JobStatusStopped:
+		return true, nil
+	case rayv1.JobStatusFailed:
+		if msg := job.Status.Message; msg != "" {
+			return true, fmt.Errorf("job %s failed: %s", jobID, msg)
+		}
+		return true, fmt.Errorf("job %s failed with status %s", jobID, status)
+	default:
+		return true, fmt.Errorf("job %s in unexpected terminal state %s", jobID, status)
+	}
 }
 
 func (options *SubmitJobOptions) raySubmitCmd() ([]string, error) {

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -600,7 +600,15 @@ func runPortForward(
 	portForwardCmd := portforward.NewCmdPortForward(factory, *streams) 
 
 	fmt.Printf("Port forwarding service %s\n", svcName)
-	if err := portForwardCmd.ExecuteContext(ctx); err != nil && ctx.Err() == nil {
+	if err := opts.Complete(factory, portForwardCmd, args); err != nil {
+		fmt.Fprintf(streams.ErrOut, "Port-forward setup failed: %v\n", err)
+		return
+	}
+	if err := opts.Validate(); err != nil {
+		fmt.Fprintf(streams.ErrOut, "Port-forward validation failed: %v\n", err)
+		return
+	}
+	if err := opts.RunPortForwardContext(ctx); err != nil && ctx.Err() == nil {
 		// Restarting the port-forward cannot reconnect the Ray CLI's existing
 		// log stream. Let the Ray CLI exit, then check the RayJob status in
 		// checkJobStatusOnSubmitError.

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -541,7 +541,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	// Wait for Ray job submit to finish.
 	err = cmd.Wait()
 	if err != nil {
-		return options.reconcileSubmitError(ctx, k8sClients, usingPortForward, err)
+		return options.checkJobStatusOnSubmitError(ctx, k8sClients, usingPortForward, err)
 	}
 	if options.noWait {
 		fmt.Printf("Ray job submitted with ID %s\n", rayJobID)
@@ -600,13 +600,13 @@ func runPortForward(
 	fmt.Printf("Port forwarding service %s\n", svcName)
 	if err := portForwardCmd.ExecuteContext(ctx); err != nil && ctx.Err() == nil {
 		// Restarting the port-forward cannot reconnect the Ray CLI's existing
-		// log stream. Let the Ray CLI exit, then reconcile its result against
-		// the RayJob status in reconcileSubmitError.
+		// log stream. Let the Ray CLI exit, then check the RayJob status in
+		// checkJobStatusOnSubmitError.
 		fmt.Fprintf(streams.ErrOut, "Port-forward to Ray dashboard ended: %v\n", err)
 	}
 }
 
-func (options *SubmitJobOptions) reconcileSubmitError(
+func (options *SubmitJobOptions) checkJobStatusOnSubmitError(
 	ctx context.Context,
 	k8sClients client.Client,
 	usingPortForward bool,
@@ -630,7 +630,7 @@ func (options *SubmitJobOptions) reconcileSubmitError(
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"%w; failed to get RayJob %s/%s while reconciling the result: %w",
+			"%w; failed to get RayJob %s/%s while checking job status: %w",
 			wrappedSubmitErr, options.namespace, jobName, err,
 		)
 	}

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -594,8 +594,10 @@ func runPortForward(
 	streams *genericiooptions.IOStreams,
 	svcName string,
 ) {
-	portForwardCmd := portforward.NewCmdPortForward(factory, *streams)
-	portForwardCmd.SetArgs([]string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)})
+    args := []string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)}
+	opts := portforward.NewDefaultPortForwardOptions(*streams)
+	opts.Address = []string{"localhost"}
+	portForwardCmd := portforward.NewCmdPortForward(factory, *streams) 
 
 	fmt.Printf("Port forwarding service %s\n", svcName)
 	if err := portForwardCmd.ExecuteContext(ctx); err != nil && ctx.Err() == nil {

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -630,7 +630,7 @@ func (options *SubmitJobOptions) reconcileSubmitError(
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"%w; failed to get RayJob %s/%s while reconciling the result: %v",
+			"%w; failed to get RayJob %s/%s while reconciling the result: %w",
 			wrappedSubmitErr, options.namespace, jobName, err,
 		)
 	}

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -1,6 +1,8 @@
 package job
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,9 +12,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	pluginclient "github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	clienttesting "github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client/testing"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -191,6 +196,191 @@ func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestRayJobTerminalResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       rayv1.JobStatus
+		jobID        string
+		message      string
+		wantTerminal bool
+		wantError    string
+	}{
+		{
+			name:   "pending job is not terminal",
+			status: rayv1.JobStatusPending,
+		},
+		{
+			name:         "succeeded job is successful",
+			status:       rayv1.JobStatusSucceeded,
+			jobID:        "job-succeeded",
+			wantTerminal: true,
+		},
+		{
+			name:         "stopped job preserves existing successful behavior",
+			status:       rayv1.JobStatusStopped,
+			jobID:        "job-stopped",
+			wantTerminal: true,
+		},
+		{
+			name:         "failed job returns its message",
+			status:       rayv1.JobStatusFailed,
+			jobID:        "job-failed",
+			message:      "entrypoint failed",
+			wantTerminal: true,
+			wantError:    "job job-failed failed: entrypoint failed",
+		},
+		{
+			name:         "failed job without ID uses unknown",
+			status:       rayv1.JobStatusFailed,
+			wantTerminal: true,
+			wantError:    "job unknown failed with status FAILED",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &rayv1.RayJob{
+				Status: rayv1.RayJobStatus{
+					JobStatus: tc.status,
+					JobId:     tc.jobID,
+					Message:   tc.message,
+				},
+			}
+
+			terminal, err := rayJobTerminalResult(job)
+			assert.Equal(t, tc.wantTerminal, terminal)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestReconcileSubmitError(t *testing.T) {
+	const (
+		namespace = "test-namespace"
+		jobName   = "test-rayjob"
+		jobID     = "test-job-id"
+	)
+
+	tests := []struct {
+		name             string
+		usingPortForward bool
+		rayJobExists     bool
+		status           rayv1.JobStatus
+		message          string
+		wantError        string
+		wantErrorParts   []string
+		wantOriginal     bool
+		wantStderr       string
+	}{
+		{
+			name:             "port-forward with succeeded RayJob returns success",
+			usingPortForward: true,
+			rayJobExists:     true,
+			status:           rayv1.JobStatusSucceeded,
+			wantStderr:       "Ray CLI exited after RayJob test-rayjob reached status SUCCEEDED; treating the submission as successful.\n",
+		},
+		{
+			name:             "port-forward with failed RayJob returns job failure",
+			usingPortForward: true,
+			rayJobExists:     true,
+			status:           rayv1.JobStatusFailed,
+			message:          "entrypoint failed",
+			wantError:        "job test-job-id failed: entrypoint failed",
+		},
+		{
+			name:             "port-forward with running RayJob preserves submit error",
+			usingPortForward: true,
+			rayJobExists:     true,
+			status:           rayv1.JobStatusRunning,
+			wantError:        "Error occurred with Ray job submit: ray CLI exited",
+			wantOriginal:     true,
+		},
+		{
+			name:             "direct address preserves submit error without querying RayJob",
+			usingPortForward: false,
+			status:           rayv1.JobStatusSucceeded,
+			wantError:        "Error occurred with Ray job submit: ray CLI exited",
+			wantOriginal:     true,
+		},
+		{
+			name:             "RayJob get error preserves submit error and adds context",
+			usingPortForward: true,
+			wantErrorParts: []string{
+				"Error occurred with Ray job submit: ray CLI exited",
+				"failed to get RayJob test-namespace/test-rayjob while reconciling the result",
+				`rayjobs.ray.io "test-rayjob" not found`,
+			},
+			wantOriginal: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testStreams, _, _, stderr := genericclioptions.NewTestIOStreams()
+			submitErr := errors.New("ray CLI exited")
+
+			var k8sClient pluginclient.Client
+			if tc.usingPortForward {
+				rayClient := clienttesting.NewRayClientset()
+				if tc.rayJobExists {
+					rayClient = clienttesting.NewRayClientset(&rayv1.RayJob{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      jobName,
+							Namespace: namespace,
+						},
+						Status: rayv1.RayJobStatus{
+							JobStatus: tc.status,
+							JobId:     jobID,
+							Message:   tc.message,
+						},
+					})
+				}
+				k8sClient = pluginclient.NewClientForTesting(nil, rayClient)
+			} else {
+				// A nil Ray client makes this test panic if direct-address mode
+				// unexpectedly tries to reconcile through Kubernetes.
+				k8sClient = pluginclient.NewClientForTesting(nil, nil)
+			}
+
+			options := &SubmitJobOptions{
+				ioStreams: &testStreams,
+				namespace: namespace,
+				RayJob: &rayv1.RayJob{ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: namespace,
+				}},
+			}
+
+			err := options.reconcileSubmitError(
+				context.Background(),
+				k8sClient,
+				tc.usingPortForward,
+				submitErr,
+			)
+
+			if tc.wantError == "" && len(tc.wantErrorParts) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tc.wantError != "" {
+					require.EqualError(t, err, tc.wantError)
+				}
+				for _, part := range tc.wantErrorParts {
+					assert.ErrorContains(t, err, part)
+				}
+			}
+			if tc.wantOriginal {
+				assert.ErrorIs(t, err, submitErr)
+			}
+			assert.Equal(t, tc.wantStderr, stderr.String())
 		})
 	}
 }

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -262,7 +262,7 @@ func TestRayJobTerminalResult(t *testing.T) {
 	}
 }
 
-func TestReconcileSubmitError(t *testing.T) {
+func TestCheckJobStatusOnSubmitError(t *testing.T) {
 	const (
 		namespace = "test-namespace"
 		jobName   = "test-rayjob"
@@ -272,25 +272,21 @@ func TestReconcileSubmitError(t *testing.T) {
 	tests := []struct {
 		name             string
 		usingPortForward bool
-		rayJobExists     bool
 		status           rayv1.JobStatus
 		message          string
 		wantError        string
 		wantErrorParts   []string
-		wantOriginal     bool
 		wantStderr       string
 	}{
 		{
 			name:             "port-forward with succeeded RayJob returns success",
 			usingPortForward: true,
-			rayJobExists:     true,
 			status:           rayv1.JobStatusSucceeded,
 			wantStderr:       "Ray CLI exited after RayJob test-rayjob reached status SUCCEEDED; treating the submission as successful.\n",
 		},
 		{
 			name:             "port-forward with failed RayJob returns job failure",
 			usingPortForward: true,
-			rayJobExists:     true,
 			status:           rayv1.JobStatusFailed,
 			message:          "entrypoint failed",
 			wantError:        "job test-job-id failed: entrypoint failed",
@@ -298,27 +294,23 @@ func TestReconcileSubmitError(t *testing.T) {
 		{
 			name:             "port-forward with running RayJob preserves submit error",
 			usingPortForward: true,
-			rayJobExists:     true,
 			status:           rayv1.JobStatusRunning,
 			wantError:        "Error occurred with Ray job submit: ray CLI exited",
-			wantOriginal:     true,
 		},
 		{
 			name:             "direct address preserves submit error without querying RayJob",
 			usingPortForward: false,
 			status:           rayv1.JobStatusSucceeded,
 			wantError:        "Error occurred with Ray job submit: ray CLI exited",
-			wantOriginal:     true,
 		},
 		{
 			name:             "RayJob get error preserves submit error and adds context",
 			usingPortForward: true,
 			wantErrorParts: []string{
 				"Error occurred with Ray job submit: ray CLI exited",
-				"failed to get RayJob test-namespace/test-rayjob while reconciling the result",
+				"failed to get RayJob test-namespace/test-rayjob while checking job status",
 				`rayjobs.ray.io "test-rayjob" not found`,
 			},
-			wantOriginal: true,
 		},
 	}
 
@@ -330,7 +322,7 @@ func TestReconcileSubmitError(t *testing.T) {
 			var k8sClient pluginclient.Client
 			if tc.usingPortForward {
 				rayClient := clienttesting.NewRayClientset()
-				if tc.rayJobExists {
+				if tc.status != "" {
 					rayClient = clienttesting.NewRayClientset(&rayv1.RayJob{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      jobName,
@@ -346,7 +338,7 @@ func TestReconcileSubmitError(t *testing.T) {
 				k8sClient = pluginclient.NewClientForTesting(nil, rayClient)
 			} else {
 				// A nil Ray client makes this test panic if direct-address mode
-				// unexpectedly tries to reconcile through Kubernetes.
+				// unexpectedly tries to check the job status through Kubernetes.
 				k8sClient = pluginclient.NewClientForTesting(nil, nil)
 			}
 
@@ -359,7 +351,7 @@ func TestReconcileSubmitError(t *testing.T) {
 				}},
 			}
 
-			err := options.reconcileSubmitError(
+			err := options.checkJobStatusOnSubmitError(
 				context.Background(),
 				k8sClient,
 				tc.usingPortForward,
@@ -376,9 +368,6 @@ func TestReconcileSubmitError(t *testing.T) {
 				for _, part := range tc.wantErrorParts {
 					require.ErrorContains(t, err, part)
 				}
-			}
-			if tc.wantOriginal {
-				require.ErrorIs(t, err, submitErr)
 			}
 			assert.Equal(t, tc.wantStderr, stderr.String())
 		})

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -300,7 +300,6 @@ func TestCheckJobStatusOnSubmitError(t *testing.T) {
 		{
 			name:             "direct address preserves submit error without querying RayJob",
 			usingPortForward: false,
-			status:           rayv1.JobStatusSucceeded,
 			wantError:        "Error occurred with Ray job submit: ray CLI exited",
 		},
 		{

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -374,11 +374,11 @@ func TestReconcileSubmitError(t *testing.T) {
 					require.EqualError(t, err, tc.wantError)
 				}
 				for _, part := range tc.wantErrorParts {
-					assert.ErrorContains(t, err, part)
+					require.ErrorContains(t, err, part)
 				}
 			}
 			if tc.wantOriginal {
-				assert.ErrorIs(t, err, submitErr)
+				require.ErrorIs(t, err, submitErr)
 			}
 			assert.Equal(t, tc.wantStderr, stderr.String())
 		})

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 			"--name", rayJobName,
 			"--runtime-env", runtimeEnvFilePath,
 			"--ttl-seconds-after-finished", "0",
+			"--no-wait",
 			"--head-cpu", "1",
 			"--head-memory", "2Gi",
 			"--worker-cpu", "1",
@@ -118,9 +119,22 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 			entrypointSampleFileName,
 		)
 		output, err := cmd.CombinedOutput()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), string(output))
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
+
+		// TTL 0 deletes the RayCluster as soon as the RayJob finishes. Do not tail
+		// logs through a port-forward that is expected to disappear during cleanup;
+		// wait for completion through the RayJob resource instead.
+		cmd = exec.Command(
+			"kubectl", "wait",
+			"--namespace", namespace,
+			"--timeout=300s",
+			"--for", "jsonpath={.status.jobDeploymentStatus}=Complete",
+			"rayjob/"+rayJobName,
+		)
+		output, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(output))
 
 		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
 		Expect(rayJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(0)))

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -109,7 +109,6 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 			"--name", rayJobName,
 			"--runtime-env", runtimeEnvFilePath,
 			"--ttl-seconds-after-finished", "0",
-			"--no-wait",
 			"--head-cpu", "1",
 			"--head-memory", "2Gi",
 			"--worker-cpu", "1",
@@ -122,19 +121,6 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		Expect(err).NotTo(HaveOccurred(), string(output))
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
-
-		// TTL 0 deletes the RayCluster as soon as the RayJob finishes. Do not tail
-		// logs through a port-forward that is expected to disappear during cleanup;
-		// wait for completion through the RayJob resource instead.
-		cmd = exec.Command(
-			"kubectl", "wait",
-			"--namespace", namespace,
-			"--timeout=300s",
-			"--for", "jsonpath={.status.jobDeploymentStatus}=Complete",
-			"rayjob/"+rayJobName,
-		)
-		output, err = cmd.CombinedOutput()
-		Expect(err).NotTo(HaveOccurred(), string(output))
 
 		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
 		Expect(rayJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(0)))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When `kubectl ray job submit` uses its locally managed port-forward, a RayJob with `--ttl-seconds-after-finished 0` may finish successfully and immediately delete its RayCluster. This closes the Ray CLI log connection before the CLI observes the terminal status, causing it to return an error even though the persisted RayJob status is `SUCCEEDED`.

This change reconciles Ray CLI errors against the RayJob status. A terminal `SUCCEEDED` RayJob is reported as successful, while failed, non-terminal, direct `--address`, and RayJob query error cases continue to return an error.

This failure mechanism is consistent with Buildkite build 15838. The original build did not retain the command output or RayJob status, so its exact historical connection error cannot be recovered.

### What's changed

- Reconciles Ray CLI errors only when using the locally managed port-forward.
- Returns success when the persisted RayJob has reached `SUCCEEDED`.
- Preserves the RayJob failure when it has reached `FAILED`.
- Preserves the original Ray CLI error for non-terminal RayJobs.
- Preserves the original behavior when the user provides `--address`.
- Includes both the original CLI error and reconciliation context when the RayJob query fails.
- Adds unit coverage for the reconciliation branches.
- Includes command output in the TTL=0 e2e assertion for future diagnostics.

### Validation

Ran 50 consecutive synchronous TTL=0 submissions using the PR branch at commit:

```text
4917dca4de66d3638d8c3ad90c9bd42fe3991717
```

Results:

```text
Total runs:                         50
Command exit=0:                     50/50
RayJob status=SUCCEEDED:            50/50
Normal Ray CLI completions:         19
Reconciled CLI connection failures: 31
  WebSocket close code 1006:        30
  RemoteDisconnected:                1
Total failures:                      0
```

All 31 connection failures exercised the new production reconciliation path:

```text
Ray CLI exited after RayJob <name> reached status SUCCEEDED;
treating the submission as successful.
```

The underlying port-forward/WebSocket race can still occur, but a successfully completed RayJob is no longer incorrectly reported as a failed submission.

## Related issue number

Buildkite failure: https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/15838/list?jid=019f65ce-9a9f-4f04-a81d-e987d440ad32&tab=output

Related issue: https://github.com/ray-project/kuberay/issues/2704

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(