### PR TITLE
[Bug][kubectl-plugin] Check hosted KubeRay operator when no in-cluster Deployment exists

### DIFF
--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -59,10 +60,13 @@ func (options *VersionOptions) Run(ctx context.Context, k8sClient client.Client,
 	fmt.Fprintln(writer, "kubectl ray plugin version:", Version)
 
 	operatorVersion, err := k8sClient.GetKubeRayOperatorVersion(ctx)
-	if err != nil {
+	switch {
+	case errors.Is(err, client.ErrHostedOperator):
+		fmt.Fprintln(writer, "KubeRay operator version:", err.Error())
+	case err != nil:
 		wrappedError := fmt.Errorf(`warning: KubeRay operator installation cannot be found: %w. Did you install it with the name "kuberay-operator"?`, err)
 		fmt.Fprintln(writer, wrappedError)
-	} else {
+	default:
 		fmt.Fprintln(writer, "KubeRay operator version:", operatorVersion)
 	}
 	return nil

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -65,6 +65,12 @@ func TestRayVersionRun(t *testing.T) {
 				"Did you install it with the name \"kuberay-operator\"?\n", Version),
 		},
 		{
+			name:                "Test when the operator is hosted outside the cluster",
+			kuberayImageVersion: "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster",
+			expected: fmt.Sprintf("kubectl ray plugin version: %s\n"+
+				"KubeRay operator version: hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster\n", Version),
+		},
+		{
 			name:                "Test when build info is included",
 			kuberayImageVersion: "v0.0.1",
 			pluginCommit:        "abcdefg",

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	clientfake "github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client/fake"
 )
 
@@ -65,8 +66,8 @@ func TestRayVersionRun(t *testing.T) {
 				"Did you install it with the name \"kuberay-operator\"?\n", Version),
 		},
 		{
-			name:                "Test when the operator is hosted outside the cluster",
-			kuberayImageVersion: "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster",
+			name:                           "Test when the operator is hosted outside the cluster",
+			getKubeRayOperatorVersionError: client.ErrHostedOperator,
 			expected: fmt.Sprintf("kubectl ray plugin version: %s\n"+
 				"KubeRay operator version: hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster\n", Version),
 		},
@@ -93,14 +94,14 @@ func TestRayVersionRun(t *testing.T) {
 			testVersion := Version                   // Store the global Version value
 			defer func() { Version = testVersion }() // Restore after the test
 
-			client := clientfake.NewFakeClient().WithKubeRayImageVersion(tc.kuberayImageVersion).WithKubeRayOperatorVersionError(tc.getKubeRayOperatorVersionError)
+			fakeClient := clientfake.NewFakeClient().WithKubeRayImageVersion(tc.kuberayImageVersion).WithKubeRayOperatorVersionError(tc.getKubeRayOperatorVersionError)
 
 			fakeBuildInfo := func() (*debug.BuildInfo, bool) {
 				return createBuildInfo(tc.pluginCommit, tc.pluginBuildTime), !tc.buildInfoErr
 			}
 
 			var buf bytes.Buffer
-			err := fakeVersionOptions.Run(context.Background(), client, fakeBuildInfo, &buf)
+			err := fakeVersionOptions.Run(context.Background(), fakeClient, fakeBuildInfo, &buf)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, buf.String())

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -19,6 +20,9 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
 )
+
+// ErrHostedOperator means Ray APIs are served but no in-cluster operator Deployment exists.
+var ErrHostedOperator = errors.New("hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster")
 
 type Client interface {
 	KubernetesClient() kubernetes.Interface
@@ -86,7 +90,7 @@ func (c *k8sClient) GetKubeRayOperatorVersion(ctx context.Context) (string, erro
 		if installed {
 			// Hosted operators (e.g. GKE Ray Operator add-on) install
 			// Ray CRDs without running a Deployment in the user cluster.
-			return "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster", nil
+			return "", ErrHostedOperator
 		}
 		return "", fmt.Errorf("no KubeRay operator deployments found in any namespace")
 	}
@@ -111,21 +115,16 @@ func (c *k8sClient) GetKubeRayOperatorVersion(ctx context.Context) (string, erro
 	return ref.Tag(), nil
 }
 
-// hasRayClusterAPI checks whether the ray.io/v1 RayCluster API is served.
+// hasRayClusterAPI checks whether the ray.io/v1 API group/version is served.
 func (c *k8sClient) hasRayClusterAPI() (bool, error) {
-	apiResourceList, err := c.kubeClient.Discovery().ServerResourcesForGroupVersion(rayv1.GroupVersion.String())
+	_, err := c.kubeClient.Discovery().ServerResourcesForGroupVersion(rayv1.GroupVersion.String())
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to discover Ray APIs: %w", err)
 	}
-	for _, resource := range apiResourceList.APIResources {
-		if resource.Name == "rayclusters" || resource.Kind == "RayCluster" {
-			return true, nil
-		}
-	}
-	return false, nil
+	return true, nil
 }
 
 func (c *k8sClient) GetRayHeadSvcName(ctx context.Context, namespace string, resourceType util.ResourceType, name string) (string, error) {

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	dockerparser "github.com/novln/docker-parser"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -78,6 +79,15 @@ func (c *k8sClient) GetKubeRayOperatorVersion(ctx context.Context) (string, erro
 	}
 
 	if len(deployment.Items) == 0 {
+		installed, crdErr := c.hasRayClusterAPI()
+		if crdErr != nil {
+			return "", fmt.Errorf("no KubeRay operator deployments found in any namespace: %w", crdErr)
+		}
+		if installed {
+			// Hosted operators (e.g. GKE Ray Operator add-on) install
+			// Ray CRDs without running a Deployment in the user cluster.
+			return "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster", nil
+		}
 		return "", fmt.Errorf("no KubeRay operator deployments found in any namespace")
 	}
 
@@ -99,6 +109,23 @@ func (c *k8sClient) GetKubeRayOperatorVersion(ctx context.Context) (string, erro
 	}
 
 	return ref.Tag(), nil
+}
+
+// hasRayClusterAPI checks whether the ray.io/v1 RayCluster API is served.
+func (c *k8sClient) hasRayClusterAPI() (bool, error) {
+	apiResourceList, err := c.kubeClient.Discovery().ServerResourcesForGroupVersion(rayv1.GroupVersion.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to discover Ray APIs: %w", err)
+	}
+	for _, resource := range apiResourceList.APIResources {
+		if resource.Name == "rayclusters" || resource.Kind == "RayCluster" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (c *k8sClient) GetRayHeadSvcName(ctx context.Context, namespace string, resourceType util.ResourceType, name string) (string, error) {

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -188,9 +188,9 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 
 func TestHasRayClusterAPI(t *testing.T) {
 	tests := []struct {
-		name               string
-		resources          []*metav1.APIResourceList
-		expectedInstalled  bool
+		name              string
+		resources         []*metav1.APIResourceList
+		expectedInstalled bool
 	}{
 		{
 			name: "RayCluster API is served",

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -126,8 +126,8 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 		},
 		{
 			name:            "Hosted operator with CRDs, no in-cluster Deployment",
-			expectedVersion: "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster",
-			expectedError:   "",
+			expectedVersion: "",
+			expectedError:   ErrHostedOperator.Error(),
 			kubeObjects:     nil,
 			rayCRDsPresent:  true,
 		},
@@ -176,11 +176,15 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 
 			version, err := client.GetKubeRayOperatorVersion(context.Background())
 
-			if tc.expectedVersion != "" {
-				assert.Equal(t, tc.expectedVersion, version)
-				require.NoError(t, err)
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+				assert.Empty(t, version)
+				if tc.expectedError == ErrHostedOperator.Error() {
+					require.ErrorIs(t, err, ErrHostedOperator)
+				}
 			} else {
-				assert.EqualError(t, err, tc.expectedError)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedVersion, version)
 			}
 		})
 	}
@@ -207,14 +211,9 @@ func TestHasRayClusterAPI(t *testing.T) {
 			expectedInstalled: false,
 		},
 		{
-			name: "ray.io/v1 is served without RayCluster",
-			resources: []*metav1.APIResourceList{{
-				GroupVersion: rayv1.GroupVersion.String(),
-				APIResources: []metav1.APIResource{
-					{Name: "rayjobs", Kind: "RayJob", SingularName: "rayjob", Namespaced: true},
-				},
-			}},
-			expectedInstalled: false,
+			name:              "ray.io/v1 is served",
+			resources:         []*metav1.APIResourceList{{GroupVersion: rayv1.GroupVersion.String()}},
+			expectedInstalled: true,
 		},
 	}
 

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubeFake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -115,12 +116,20 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 		expectedVersion string
 		expectedError   string
 		kubeObjects     []runtime.Object
+		rayCRDsPresent  bool
 	}{
 		{
 			name:            "KubeRay operator not found",
 			expectedVersion: "",
 			expectedError:   "no KubeRay operator deployments found in any namespace",
 			kubeObjects:     nil,
+		},
+		{
+			name:            "Hosted operator with CRDs, no in-cluster Deployment",
+			expectedVersion: "hosted outside the cluster (e.g. GKE Ray Operator add-on); version not available in-cluster",
+			expectedError:   "",
+			kubeObjects:     nil,
+			rayCRDsPresent:  true,
 		},
 		{
 			name:            "find KubeRay operator version for helm chart",
@@ -151,6 +160,18 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			kubeClientSet := kubeFake.NewClientset(tc.kubeObjects...)
+			if tc.rayCRDsPresent {
+				fakeDiscovery, ok := kubeClientSet.Discovery().(*fakediscovery.FakeDiscovery)
+				require.True(t, ok)
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: rayv1.GroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "rayclusters", Kind: "RayCluster", SingularName: "raycluster", Namespaced: true},
+						},
+					},
+				}
+			}
 			client := NewClientForTesting(kubeClientSet, nil)
 
 			version, err := client.GetKubeRayOperatorVersion(context.Background())
@@ -161,6 +182,52 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tc.expectedError)
 			}
+		})
+	}
+}
+
+func TestHasRayClusterAPI(t *testing.T) {
+	tests := []struct {
+		name               string
+		resources          []*metav1.APIResourceList
+		expectedInstalled  bool
+	}{
+		{
+			name: "RayCluster API is served",
+			resources: []*metav1.APIResourceList{{
+				GroupVersion: rayv1.GroupVersion.String(),
+				APIResources: []metav1.APIResource{
+					{Name: "rayclusters", Kind: "RayCluster", SingularName: "raycluster", Namespaced: true},
+				},
+			}},
+			expectedInstalled: true,
+		},
+		{
+			name:              "Ray APIs are not served",
+			expectedInstalled: false,
+		},
+		{
+			name: "ray.io/v1 is served without RayCluster",
+			resources: []*metav1.APIResourceList{{
+				GroupVersion: rayv1.GroupVersion.String(),
+				APIResources: []metav1.APIResource{
+					{Name: "rayjobs", Kind: "RayJob", SingularName: "rayjob", Namespaced: true},
+				},
+			}},
+			expectedInstalled: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClientSet := kubeFake.NewClientset()
+			fakeDiscovery, ok := kubeClientSet.Discovery().(*fakediscovery.FakeDiscovery)
+			require.True(t, ok)
+			fakeDiscovery.Resources = tc.resources
+
+			installed, err := (&k8sClient{kubeClient: kubeClientSet}).hasRayClusterAPI()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedInstalled, installed)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`kubectl ray version` currently treats "no kuberay-operator Deployment" as "KubeRay is not installed". That is a false warning on the GKE Ray Operator add-on: Google hosts the operator outside the user cluster, so there is no in-cluster Deployment, but Ray CRDs are still served and the rest of the plugin already works.

## Related issue number

#3115 

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
