### PR TITLE
[History Server] Add aliyunoss History Server deployment and proxy head samples

### DIFF
--- a/historyserver/config/historyserver-aliyunoss.yaml
+++ b/historyserver/config/historyserver-aliyunoss.yaml
@@ -1,0 +1,90 @@
+# History Server deployment reading from Alibaba Cloud OSS via RRSA.
+#
+# Prerequisites (on ACK):
+#   1. Enable RRSA (RAM Roles for Service Accounts) on the ACK cluster and create a
+#      RAM role whose trust policy allows the cluster's OIDC provider.
+#      NOTE: the trust policy Action must be "sts:AssumeRole" (not
+#      "sts:AssumeRoleWithOIDC"), with condition StringEquals oidc:aud=sts.aliyuncs.com.
+#   2. Grant the RAM role read access to the OSS bucket.
+#   3. Install the ack-pod-identity-webhook, then apply service_account.yaml and
+#      annotate the ServiceAccount with the RAM role so the ALIBABA_CLOUD_*
+#      credential env vars are injected automatically:
+#        kubectl apply -f historyserver/config/service_account.yaml
+#        kubectl annotate sa historyserver \
+#          pod-identity.alibabacloud.com/role-name=${RAM_ROLE_NAME} --overwrite
+#
+# Apply with envsubst to substitute environment variables:
+#   envsubst < historyserver/config/historyserver-aliyunoss.yaml | kubectl apply -f -
+#
+# Example values used for validation:
+#   HISTORYSERVER_IMAGE=quay.io/kuberay/historyserver:v1.7.0-rc.0
+#   OSS_REGION=cn-hongkong
+#   OSS_BUCKET=my-bucket
+#   OSS_ENDPOINT=oss-cn-hongkong-internal.aliyuncs.com
+apiVersion: v1
+kind: Service
+metadata:
+  name: historyserver
+  labels:
+    app: historyserver
+spec:
+  selector:
+    app: historyserver
+  ports:
+  - protocol: TCP
+    name: http
+    port: 30080
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: historyserver-demo
+  labels:
+    app: historyserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: historyserver
+  template:
+    metadata:
+      labels:
+        app: historyserver
+        # Lets the ack-pod-identity-webhook inject the RRSA credential env vars.
+        pod-identity.alibabacloud.com/injection: "on"
+    spec:
+      serviceAccountName: historyserver
+      containers:
+      - name: historyserver
+        env:
+          # Region such as cn-hangzhou.
+          - name: OSS_REGION
+            value: "${OSS_REGION}"
+          - name: OSS_BUCKET
+            value: "${OSS_BUCKET}"
+          # Endpoint such as oss-cn-hangzhou-internal.aliyuncs.com.
+          - name: OSS_ENDPOINT
+            value: "${OSS_ENDPOINT}"
+          - name: STORAGE_BACKEND
+            value: "aliyunoss"
+          # Root dir inside the bucket. Must match the collector's RAY_ROOT_DIR.
+          # NOTE: releases up to v1.7.0-rc.0 ignore this env var and read from the
+          # bucket root (fixed cluster-history/ prefix); master supports it.
+          - name: RAY_ROOT_DIR
+            value: "ray-history"
+        image: ${HISTORYSERVER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
+        # The 2 GiB request keeps examples schedulable; size production requests to residency.
+        args:
+        - --session-cache-max-memory=8Gi
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "2Gi"
+          limits:
+            memory: "12Gi"

--- a/historyserver/config/historyserver-aliyunoss.yaml
+++ b/historyserver/config/historyserver-aliyunoss.yaml
@@ -69,10 +69,11 @@ spec:
             value: "${OSS_ENDPOINT}"
           - name: STORAGE_BACKEND
             value: "aliyunoss"
-          # Root dir inside the bucket. Must match the collector's RAY_ROOT_DIR.
-          # NOTE: releases up to v1.7.0-rc.0 ignore this env var and read from the
-          # bucket root (fixed cluster-history/ prefix); master supports it.
-          - name: RAY_ROOT_DIR
+          # Root dir inside the bucket; must match the collector's STORAGE_ROOT_DIR.
+          # NOTE: images up to v1.7.0-rc.0 do not read this env var (the option was
+          # added after v1.7.0-rc.0, initially as RAY_ROOT_DIR, later renamed) and
+          # use the bucket root (fixed cluster-history/ prefix).
+          - name: STORAGE_ROOT_DIR
             value: "ray-history"
         image: ${HISTORYSERVER_IMAGE}
         imagePullPolicy: IfNotPresent

--- a/historyserver/config/ray-proxy-head.yaml
+++ b/historyserver/config/ray-proxy-head.yaml
@@ -1,0 +1,49 @@
+# Proxy Ray head pod: its dashboard routes non-dashboard requests to the History
+# Server via `ray start --proxy-server-url` (in-cluster alternative to the local
+# `ray start` flow in DEVELOPMENT.md Step 6).
+#
+# Usage:
+#   kubectl apply -f historyserver/config/ray-proxy-head.yaml
+#   kubectl wait pod/ray-proxy-head --for=condition=Ready --timeout=5m
+#   kubectl port-forward pod/ray-proxy-head 8265:8265
+#
+# Then browse the History Server through the Ray Dashboard:
+#   http://localhost:8265/clusters
+#   http://localhost:8265/enter_cluster/<namespace>/<owner-kind>/<owner-name>/<session-id>
+#   http://localhost:8265/#/cluster
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-proxy-head
+  labels:
+    app: ray-proxy-head
+spec:
+  containers:
+  - name: ray-head
+    image: rayproject/ray:2.56.0
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/bash", "-lc"]
+    args:
+    # Point --proxy-server-url at the History Server service; adjust the
+    # namespace if the History Server is not deployed in `default`.
+    - >-
+      ray start --head --num-cpus=1
+      --dashboard-host=0.0.0.0
+      --proxy-server-url=http://historyserver.default.svc.cluster.local:30080
+      --block
+    ports:
+    - containerPort: 8265
+      name: dashboard
+    readinessProbe:
+      httpGet:
+        path: /api/gcs_healthz
+        port: 8265
+      initialDelaySeconds: 10
+      periodSeconds: 5
+    resources:
+      requests:
+        cpu: "500m"
+        memory: 2G
+      limits:
+        cpu: "2"
+        memory: 4G

--- a/historyserver/config/ray-proxy-head.yaml
+++ b/historyserver/config/ray-proxy-head.yaml
@@ -42,8 +42,8 @@ spec:
       periodSeconds: 5
     resources:
       requests:
+        cpu: "100m"
+        memory: 1G
+      limits:
         cpu: "500m"
         memory: 2G
-      limits:
-        cpu: "2"
-        memory: 4G


### PR DESCRIPTION
## Why are these changes needed?

#5150 adds collector-side (write path) samples for the Alibaba Cloud OSS storage backend, but there is no read-side sample showing how to deploy the History Server against the same OSS bucket, and no in-cluster way to browse it without a local Ray installation. This PR adds two manifests under `historyserver/config/`:

1. **`historyserver-aliyunoss.yaml`** -- History Server Service + Deployment reading from OSS via RRSA (credentials injected by ack-pod-identity-webhook). The header documents the full prerequisites, including a pitfall that costs real debugging time: the RAM role trust policy `Action` must be `sts:AssumeRole` (NOT `sts:AssumeRoleWithOIDC`), and `oidc:iss` is not a valid condition key -- both mistakes fail with an opaque `AuthenticationFail.NoPermission (ImplicitDeny)` from STS.
2. **`ray-proxy-head.yaml`** -- a single proxy Ray head pod wired to the History Server service via `ray start --proxy-server-url`, an in-cluster alternative to the local `ray start` flow in `DEVELOPMENT.md` Step 6. Browsing the History Server UI then only requires `kubectl port-forward pod/ray-proxy-head 8265:8265`.

Note on `STORAGE_ROOT_DIR`: the manifest sets it and documents that images up to v1.7.0-rc.0 do not read this env var (support was added after v1.7.0-rc.0, initially as `RAY_ROOT_DIR`, since renamed to `STORAGE_ROOT_DIR`); it must match the collector-side setting.

## Related issue number

Closes #5155

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Validated end to end on an ACK managed cluster (cn-hongkong), KubeRay operator 1.6.2, images `quay.io/kuberay/{historyserver,collector}:v1.7.0-rc.0`:

1. Enabled RRSA on the cluster, created the RAM role with the trust policy documented in the manifest header, granted it OSS read/write on the test bucket, and installed ack-pod-identity-webhook.
2. Applied `service_account.yaml`, annotated the `historyserver` ServiceAccount with the RAM role, then applied `historyserver-aliyunoss.yaml` (via `envsubst`) and the `rayjob-aliyunoss.yaml` sample from #5150.
3. After the RayJob succeeded, the collector wrote 276 objects to OSS under `cluster-history/rayjob/default/...`, and the History Server `/clusters` endpoint listed the dead sessions.
4. Applied `ray-proxy-head.yaml`, ran `kubectl port-forward pod/ray-proxy-head 8265:8265`, and verified in the browser:
   - `http://localhost:8265/clusters` lists sessions through the proxy head (HTTP 200);
   - `http://localhost:8265/enter_cluster/default/rayjob/rayjob-historyserver-aliyunoss/<session-id>` replays the dead session; `/api/v0/cluster_metadata` and `/api/jobs/` return the recorded data.
