### PR TITLE
[History Server] Add --mode=snapshot to collector for one-shot Dashboard API capture

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -19,13 +20,16 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/collector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/logcollector/runtime"
+	"github.com/ray-project/kuberay/historyserver/pkg/collector/snapshot"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
 const defaultDashboardAddress = "http://localhost:8265"
 
 func main() {
+	mode := "sidecar"
 	role := ""
 	storageBackend := ""
 	rayClusterName := ""
@@ -48,6 +52,7 @@ func main() {
 	eventMaxDiskMB := 200
 	eventCompressionEnabled := false
 
+	flag.StringVar(&mode, "mode", "sidecar", "Execution mode: sidecar (default, long-running) or snapshot (one-shot scrape)")
 	flag.BoolVar(&enableEventCollector, "enable-event-collector", true, "Enable event collector")
 	flag.BoolVar(&enableLogCollector, "enable-log-collector", true, "Enable log collector")
 	flag.StringVar(&role, "role", "Worker", "Role of the collector node: Head or Worker")
@@ -120,14 +125,24 @@ func main() {
 	if val := os.Getenv("RAY_DASHBOARD_ADDRESS"); val != "" {
 		dashboardAddress = val
 	}
+	if val := os.Getenv("COLLECTOR_MODE"); val != "" {
+		mode = val
+	}
 
-	role = strings.TrimSpace(role)
-	if strings.EqualFold(role, "head") {
-		role = "Head"
-	} else if strings.EqualFold(role, "worker") {
-		role = "Worker"
-	} else {
-		logrus.Fatalf("Invalid role: %s, must be Head or Worker", role)
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode != "sidecar" && mode != "snapshot" {
+		logrus.Fatalf("Invalid mode: %s, must be sidecar or snapshot", mode)
+	}
+
+	if mode == "sidecar" {
+		role = strings.TrimSpace(role)
+		if strings.EqualFold(role, "head") {
+			role = "Head"
+		} else if strings.EqualFold(role, "worker") {
+			role = "Worker"
+		} else {
+			logrus.Fatalf("Invalid role: %s, must be Head or Worker", role)
+		}
 	}
 
 	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName, enableEventCollector, enableLogCollector); err != nil {
@@ -209,9 +224,59 @@ func main() {
 	registry := collector.GetWriterRegistry()
 	factory, ok := registry[storageBackend]
 	if !ok {
-		logrus.Fatalf("Not supported storage backend: %s for role: %s.", storageBackend, role)
+		logrus.Fatalf("Not supported storage backend: %s.", storageBackend)
 	}
 
+	switch mode {
+	case "snapshot":
+		runSnapshot(factory, jsonData, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, additionalEndpoints)
+	case "sidecar":
+		runSidecar(factory, jsonData, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role, logBatching, eventsPort, pushInterval, enableEventCollector, enableLogCollector, additionalEndpoints, endpointPollInterval, eventDataDir, eventRotationInterval, eventMaxFileSizeMB, eventMaxDiskMB, eventCompressionEnabled)
+	}
+}
+
+func runSnapshot(factory func(*types.RayCollectorConfig, map[string]interface{}) (storage.StorageWriter, error), jsonData map[string]interface{}, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName string, additionalEndpoints []string) {
+	cfg := types.RayCollectorConfig{
+		RootDir:             storageRootDir,
+		RayClusterName:      rayClusterName,
+		RayClusterNamespace: rayClusterNamespace,
+		DashboardAddress:    dashboardAddress,
+		OwnerKind:           ownerKind,
+		OwnerName:           ownerName,
+	}
+
+	writer, err := factory(&cfg, jsonData)
+	if err != nil {
+		logrus.Fatalf("Failed to create storage writer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		logrus.Info("Received shutdown signal, canceling snapshot...")
+		cancel()
+	}()
+
+	snapshotCfg := snapshot.Config{
+		DashboardAddress:    dashboardAddress,
+		StorageRootDir:      storageRootDir,
+		RayClusterName:      rayClusterName,
+		RayClusterNamespace: rayClusterNamespace,
+		OwnerKind:           ownerKind,
+		OwnerName:           ownerName,
+		AdditionalEndpoints: additionalEndpoints,
+	}
+
+	if err := snapshot.Run(ctx, snapshotCfg, writer); err != nil {
+		logrus.Fatalf("Snapshot failed: %v", err)
+	}
+}
+
+func runSidecar(factory func(*types.RayCollectorConfig, map[string]interface{}) (storage.StorageWriter, error), jsonData map[string]interface{}, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role string, logBatching, eventsPort int, pushInterval time.Duration, enableEventCollector, enableLogCollector bool, additionalEndpoints []string, endpointPollInterval time.Duration, eventDataDir string, eventRotationInterval time.Duration, eventMaxFileSizeMB, eventMaxDiskMB int, eventCompressionEnabled bool) {
 	rayNodeId, err := utils.GetNodeRayIDWithFQIP()
 	if err != nil {
 		logrus.Fatalf("Failed to get ray node id via HTTP endpoint: %v", err)
@@ -261,7 +326,7 @@ func main() {
 
 	writer, err := factory(&globalConfig, jsonData)
 	if err != nil {
-		logrus.Fatalf("Failed to create writer for storage backend: %s for role: %s, err: %v", storageBackend, role, err)
+		logrus.Fatalf("Failed to create storage writer for role %s: %v", role, err)
 	}
 
 	var wg sync.WaitGroup

--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -145,7 +145,7 @@ func main() {
 		}
 	}
 
-	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName, enableEventCollector, enableLogCollector); err != nil {
+	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName, enableEventCollector, enableLogCollector, mode); err != nil {
 		logrus.Fatalf("Failed to validate flags: %v", err)
 	}
 
@@ -229,13 +229,13 @@ func main() {
 
 	switch mode {
 	case "snapshot":
-		runSnapshot(factory, jsonData, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, additionalEndpoints)
+		runSnapshot(factory, jsonData, storageBackend, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, additionalEndpoints)
 	case "sidecar":
-		runSidecar(factory, jsonData, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role, logBatching, eventsPort, pushInterval, enableEventCollector, enableLogCollector, additionalEndpoints, endpointPollInterval, eventDataDir, eventRotationInterval, eventMaxFileSizeMB, eventMaxDiskMB, eventCompressionEnabled)
+		runSidecar(factory, jsonData, storageBackend, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role, logBatching, eventsPort, pushInterval, enableEventCollector, enableLogCollector, additionalEndpoints, endpointPollInterval, eventDataDir, eventRotationInterval, eventMaxFileSizeMB, eventMaxDiskMB, eventCompressionEnabled)
 	}
 }
 
-func runSnapshot(factory func(*types.RayCollectorConfig, map[string]interface{}) (storage.StorageWriter, error), jsonData map[string]interface{}, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName string, additionalEndpoints []string) {
+func runSnapshot(factory func(*types.RayCollectorConfig, map[string]any) (storage.StorageWriter, error), jsonData map[string]any, storageBackend, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName string, additionalEndpoints []string) {
 	cfg := types.RayCollectorConfig{
 		RootDir:             storageRootDir,
 		RayClusterName:      rayClusterName,
@@ -247,7 +247,7 @@ func runSnapshot(factory func(*types.RayCollectorConfig, map[string]interface{})
 
 	writer, err := factory(&cfg, jsonData)
 	if err != nil {
-		logrus.Fatalf("Failed to create storage writer: %v", err)
+		logrus.Fatalf("Failed to create storage writer for backend %s: %v", storageBackend, err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -276,7 +276,7 @@ func runSnapshot(factory func(*types.RayCollectorConfig, map[string]interface{})
 	}
 }
 
-func runSidecar(factory func(*types.RayCollectorConfig, map[string]interface{}) (storage.StorageWriter, error), jsonData map[string]interface{}, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role string, logBatching, eventsPort int, pushInterval time.Duration, enableEventCollector, enableLogCollector bool, additionalEndpoints []string, endpointPollInterval time.Duration, eventDataDir string, eventRotationInterval time.Duration, eventMaxFileSizeMB, eventMaxDiskMB int, eventCompressionEnabled bool) {
+func runSidecar(factory func(*types.RayCollectorConfig, map[string]any) (storage.StorageWriter, error), jsonData map[string]any, storageBackend, storageRootDir, dashboardAddress, rayClusterName, rayClusterNamespace, ownerKind, ownerName, role string, logBatching, eventsPort int, pushInterval time.Duration, enableEventCollector, enableLogCollector bool, additionalEndpoints []string, endpointPollInterval time.Duration, eventDataDir string, eventRotationInterval time.Duration, eventMaxFileSizeMB, eventMaxDiskMB int, eventCompressionEnabled bool) {
 	rayNodeId, err := utils.GetNodeRayIDWithFQIP()
 	if err != nil {
 		logrus.Fatalf("Failed to get ray node id via HTTP endpoint: %v", err)
@@ -326,7 +326,7 @@ func runSidecar(factory func(*types.RayCollectorConfig, map[string]interface{}) 
 
 	writer, err := factory(&globalConfig, jsonData)
 	if err != nil {
-		logrus.Fatalf("Failed to create storage writer for role %s: %v", role, err)
+		logrus.Fatalf("Failed to create storage writer for backend %s, role %s: %v", storageBackend, role, err)
 	}
 
 	var wg sync.WaitGroup
@@ -373,8 +373,8 @@ func runSidecar(factory func(*types.RayCollectorConfig, map[string]interface{}) 
 	logrus.Info("Graceful shutdown complete")
 }
 
-func validateFlags(rayClusterName, rayClusterNamespace, ownerKind, ownerName *string, enableEventCollector, enableLogCollector bool) error {
-	if !enableEventCollector && !enableLogCollector {
+func validateFlags(rayClusterName, rayClusterNamespace, ownerKind, ownerName *string, enableEventCollector, enableLogCollector bool, mode string) error {
+	if mode == "sidecar" && !enableEventCollector && !enableLogCollector {
 		return fmt.Errorf("at least one of --enable-event-collector or --enable-log-collector must be enabled")
 	}
 	*rayClusterName = strings.TrimSpace(*rayClusterName)

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
@@ -199,6 +199,7 @@ func TestScanAndProcess(t *testing.T) {
 	// Signal the background goroutine to exit gracefully
 	close(handler.ShutdownChan)
 }
+
 // TestProcessLogs_SkipSymlinks verifies that symlinks are skipped during directory scanning in prev-logs (processPrevLogsDir).
 func TestProcessLogs_SkipSymlinks(t *testing.T) {
 	baseDir, cleanup := setupRayTestEnvironment(t)

--- a/historyserver/pkg/collector/snapshot/snapshot.go
+++ b/historyserver/pkg/collector/snapshot/snapshot.go
@@ -1,0 +1,237 @@
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+type Config struct {
+	DashboardAddress    string
+	StorageRootDir      string
+	RayClusterName      string
+	RayClusterNamespace string
+	OwnerKind           string
+	OwnerName           string
+	AdditionalEndpoints []string
+}
+
+// Endpoints whose stored responses the history server serves via its
+// catch-all getFetchedEndpoint handler.
+var servedEndpoints = []string{
+	"/api/v0/cluster_metadata",
+	"/timezone",
+	"/api/serve/applications/",
+	"/api/v0/placement_groups?detail=1&limit=10000",
+}
+
+// Endpoints stored for data preservation. The history server has specific
+// handlers for these paths that currently read from event JSONL, so the
+// stored responses are not served yet but the data is preserved.
+var preservationEndpoints = []string{
+	"/api/jobs/",
+}
+
+const (
+	jobsEndpoint               = "/api/jobs/"
+	dataDatasetsEndpointPrefix = "/api/data/datasets/"
+	requestTimeout             = 30 * time.Second
+)
+
+// Run performs a one-shot scrape of the Ray Dashboard API and writes all
+// responses to object storage. It returns nil on full success, or an error
+// describing which endpoints failed.
+func Run(ctx context.Context, cfg Config, writer storage.StorageWriter) error {
+	client := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        10,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	}
+
+	sessionName, err := discoverSessionName(ctx, client, cfg.DashboardAddress)
+	if err != nil {
+		return fmt.Errorf("failed to discover session name: %w", err)
+	}
+	logrus.Infof("Using session name: %s", sessionName)
+
+	clusterDir := clusterlogs.Prefix(cfg.StorageRootDir, cfg.OwnerKind, cfg.OwnerName, cfg.RayClusterNamespace, cfg.RayClusterName)
+
+	endpoints := dedup(servedEndpoints, preservationEndpoints, cfg.AdditionalEndpoints)
+
+	var fetchErrors []string
+	for _, endpoint := range endpoints {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := fetchAndStore(ctx, client, cfg.DashboardAddress, endpoint, clusterDir, sessionName, writer); err != nil {
+			logrus.Warnf("Failed to fetch endpoint %s: %v", endpoint, err)
+			fetchErrors = append(fetchErrors, fmt.Sprintf("%s: %v", endpoint, err))
+		}
+	}
+
+	if err := fetchDataDatasets(ctx, client, cfg.DashboardAddress, clusterDir, sessionName, writer); err != nil {
+		logrus.Warnf("Failed to fetch data datasets: %v", err)
+	}
+
+	info := utils.ClusterInfo{
+		Name:      cfg.RayClusterName,
+		Namespace: cfg.RayClusterNamespace,
+		OwnerKind: cfg.OwnerKind,
+		OwnerName: cfg.OwnerName,
+	}
+	markerPath := clustermetadata.EncodePath(info, cfg.StorageRootDir, sessionName)
+	if err := writer.WriteFile(markerPath, bytes.NewReader([]byte{})); err != nil {
+		return fmt.Errorf("failed to write cluster metadata marker at %s: %w", markerPath, err)
+	}
+	logrus.Infof("Wrote cluster metadata marker at %s", markerPath)
+
+	if len(fetchErrors) > 0 {
+		return fmt.Errorf("snapshot completed with %d endpoint errors: %s", len(fetchErrors), strings.Join(fetchErrors, "; "))
+	}
+
+	logrus.Info("Snapshot completed successfully")
+	return nil
+}
+
+func discoverSessionName(ctx context.Context, client *http.Client, dashboardAddress string) (string, error) {
+	body, err := fetchEndpoint(ctx, client, dashboardAddress, "/api/v0/cluster_metadata")
+	if err != nil {
+		return generateSessionName(), nil
+	}
+
+	var resp struct {
+		Data struct {
+			SessionName string `json:"session_name"`
+			SessionDir  string `json:"session_dir"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err == nil {
+		if resp.Data.SessionName != "" {
+			return resp.Data.SessionName, nil
+		}
+		if resp.Data.SessionDir != "" {
+			name := filepath.Base(resp.Data.SessionDir)
+			if strings.HasPrefix(name, "session_") {
+				return name, nil
+			}
+		}
+	}
+
+	return generateSessionName(), nil
+}
+
+func generateSessionName() string {
+	now := time.Now()
+	return fmt.Sprintf("session_%s_%06d", now.Format("2006-01-02_15-04-05"), now.Nanosecond()/1000)
+}
+
+func fetchAndStore(ctx context.Context, client *http.Client, dashboardAddress, endpoint, clusterDir, sessionName string, writer storage.StorageWriter) error {
+	body, err := fetchEndpoint(ctx, client, dashboardAddress, endpoint)
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 {
+		logrus.Debugf("Skipping empty response from %s", endpoint)
+		return nil
+	}
+
+	storageKey := utils.EndpointPathToStorageKey(endpoint)
+	objectKey := path.Join(clusterlogs.FetchedEndpointsDir(clusterDir, sessionName), storageKey)
+	if err := writer.WriteFile(objectKey, bytes.NewReader(body)); err != nil {
+		return fmt.Errorf("failed to store at %s: %w", objectKey, err)
+	}
+	logrus.Infof("Stored %s at %s (%d bytes)", endpoint, objectKey, len(body))
+	return nil
+}
+
+func fetchDataDatasets(ctx context.Context, client *http.Client, dashboardAddress, clusterDir, sessionName string, writer storage.StorageWriter) error {
+	body, err := fetchEndpoint(ctx, client, dashboardAddress, jobsEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s: %w", jobsEndpoint, err)
+	}
+
+	var jobs []struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(body, &jobs); err != nil {
+		return fmt.Errorf("failed to parse %s response: %w", jobsEndpoint, err)
+	}
+
+	for _, job := range jobs {
+		if job.JobID == "" {
+			continue
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		endpoint := dataDatasetsEndpointPrefix + job.JobID
+		if err := fetchAndStore(ctx, client, dashboardAddress, endpoint, clusterDir, sessionName, writer); err != nil {
+			logrus.Warnf("Failed to fetch dataset for job %s: %v", job.JobID, err)
+		}
+	}
+	return nil
+}
+
+func fetchEndpoint(ctx context.Context, client *http.Client, dashboardAddress, endpoint string) ([]byte, error) {
+	url := dashboardAddress + endpoint
+
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if err := utils.SetRayAuthHeader(req); err != nil {
+		return nil, fmt.Errorf("failed to authenticate request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if utils.IsAuthFailure(resp.StatusCode) {
+		return nil, fmt.Errorf("authentication failed with status %d", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, endpoint)
+	}
+	return body, nil
+}
+
+func dedup(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, list := range lists {
+		for _, s := range list {
+			if _, ok := seen[s]; !ok {
+				seen[s] = struct{}{}
+				result = append(result, s)
+			}
+		}
+	}
+	return result
+}

--- a/historyserver/pkg/collector/snapshot/snapshot.go
+++ b/historyserver/pkg/collector/snapshot/snapshot.go
@@ -43,7 +43,10 @@ var servedEndpoints = []string{
 // handlers for these paths that currently read from event JSONL, so the
 // stored responses are not served yet but the data is preserved.
 var preservationEndpoints = []string{
-	"/api/jobs/",
+	jobsEndpoint,
+	"/api/v0/tasks?detail=1&limit=10000",
+	"/logical/actors",
+	"/nodes",
 }
 
 const (
@@ -58,8 +61,8 @@ const (
 func Run(ctx context.Context, cfg Config, writer storage.StorageWriter) error {
 	client := &http.Client{
 		Transport: &http.Transport{
-			MaxIdleConns:        10,
-			IdleConnTimeout:     30 * time.Second,
+			MaxIdleConns:    10,
+			IdleConnTimeout: 30 * time.Second,
 		},
 	}
 
@@ -74,6 +77,7 @@ func Run(ctx context.Context, cfg Config, writer storage.StorageWriter) error {
 	endpoints := dedup(servedEndpoints, preservationEndpoints, cfg.AdditionalEndpoints)
 
 	var fetchErrors []string
+	storedCount := 0
 	for _, endpoint := range endpoints {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -81,11 +85,25 @@ func Run(ctx context.Context, cfg Config, writer storage.StorageWriter) error {
 		if err := fetchAndStore(ctx, client, cfg.DashboardAddress, endpoint, clusterDir, sessionName, writer); err != nil {
 			logrus.Warnf("Failed to fetch endpoint %s: %v", endpoint, err)
 			fetchErrors = append(fetchErrors, fmt.Sprintf("%s: %v", endpoint, err))
+		} else {
+			storedCount++
 		}
 	}
 
 	if err := fetchDataDatasets(ctx, client, cfg.DashboardAddress, clusterDir, sessionName, writer); err != nil {
 		logrus.Warnf("Failed to fetch data datasets: %v", err)
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if storedCount == 0 {
+		return fmt.Errorf("snapshot failed: no endpoints were stored successfully (errors: %s)", strings.Join(fetchErrors, "; "))
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	info := utils.ClusterInfo{
@@ -111,7 +129,7 @@ func Run(ctx context.Context, cfg Config, writer storage.StorageWriter) error {
 func discoverSessionName(ctx context.Context, client *http.Client, dashboardAddress string) (string, error) {
 	body, err := fetchEndpoint(ctx, client, dashboardAddress, "/api/v0/cluster_metadata")
 	if err != nil {
-		return generateSessionName(), nil
+		return "", fmt.Errorf("dashboard unreachable: %w", err)
 	}
 
 	var resp struct {
@@ -120,24 +138,19 @@ func discoverSessionName(ctx context.Context, client *http.Client, dashboardAddr
 			SessionDir  string `json:"session_dir"`
 		} `json:"data"`
 	}
-	if err := json.Unmarshal(body, &resp); err == nil {
-		if resp.Data.SessionName != "" {
-			return resp.Data.SessionName, nil
-		}
-		if resp.Data.SessionDir != "" {
-			name := filepath.Base(resp.Data.SessionDir)
-			if strings.HasPrefix(name, "session_") {
-				return name, nil
-			}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse cluster_metadata response: %w", err)
+	}
+	if resp.Data.SessionName != "" {
+		return resp.Data.SessionName, nil
+	}
+	if resp.Data.SessionDir != "" {
+		name := filepath.Base(resp.Data.SessionDir)
+		if strings.HasPrefix(name, "session_") {
+			return name, nil
 		}
 	}
-
-	return generateSessionName(), nil
-}
-
-func generateSessionName() string {
-	now := time.Now()
-	return fmt.Sprintf("session_%s_%06d", now.Format("2006-01-02_15-04-05"), now.Nanosecond()/1000)
+	return "", fmt.Errorf("cluster_metadata response missing session_name and usable session_dir")
 }
 
 func fetchAndStore(ctx context.Context, client *http.Client, dashboardAddress, endpoint, clusterDir, sessionName string, writer storage.StorageWriter) error {

--- a/historyserver/pkg/collector/snapshot/snapshot_test.go
+++ b/historyserver/pkg/collector/snapshot/snapshot_test.go
@@ -1,0 +1,368 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type memWriter struct {
+	files map[string][]byte
+	dirs  map[string]bool
+}
+
+func newMemWriter() *memWriter {
+	return &memWriter{
+		files: make(map[string][]byte),
+		dirs:  make(map[string]bool),
+	}
+}
+
+func (m *memWriter) WriteFile(file string, reader io.ReadSeeker) error {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	m.files[file] = data
+	return nil
+}
+
+func (m *memWriter) CreateDirectory(path string) error {
+	m.dirs[path] = true
+	return nil
+}
+
+func TestRunSnapshot(t *testing.T) {
+	clusterMetadata := map[string]any{
+		"result": true,
+		"data": map[string]any{
+			"ray_version":    "2.54.0",
+			"python_version": "3.11.0",
+			"session_name":   "session_2026-08-17_10-30-00_123456",
+		},
+	}
+	timezone := map[string]any{"timezone": "UTC"}
+	serveApps := map[string]any{"applications": map[string]any{}}
+	placementGroups := map[string]any{"result": []any{}}
+	jobs := []map[string]any{
+		{"job_id": "01000000", "status": "SUCCEEDED"},
+		{"job_id": "02000000", "status": "RUNNING"},
+	}
+	datasets01 := map[string]any{"datasets": []any{map[string]any{"id": "ds1"}}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		query := r.URL.RawQuery
+		full := path
+		if query != "" {
+			full = path + "?" + query
+		}
+
+		var resp interface{}
+		switch {
+		case full == "/api/v0/cluster_metadata":
+			resp = clusterMetadata
+		case full == "/timezone":
+			resp = timezone
+		case full == "/api/serve/applications/":
+			resp = serveApps
+		case full == "/api/v0/placement_groups?detail=1&limit=10000":
+			resp = placementGroups
+		case full == "/api/jobs/":
+			resp = jobs
+		case strings.HasPrefix(path, "/api/data/datasets/"):
+			jobID := strings.TrimPrefix(path, "/api/data/datasets/")
+			if jobID == "01000000" {
+				resp = datasets01
+			} else {
+				resp = map[string]any{"datasets": []any{}}
+			}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+	}
+
+	err := Run(context.Background(), cfg, writer)
+	require.NoError(t, err)
+
+	sessionName := "session_2026-08-17_10-30-00_123456"
+
+	// Verify served endpoints are stored
+	assertStoredEndpoint(t, writer, "root", sessionName, "/api/v0/cluster_metadata")
+	assertStoredEndpoint(t, writer, "root", sessionName, "/timezone")
+	assertStoredEndpoint(t, writer, "root", sessionName, "/api/serve/applications/")
+	assertStoredEndpoint(t, writer, "root", sessionName, "/api/v0/placement_groups?detail=1&limit=10000")
+
+	// Verify preservation endpoints are stored
+	assertStoredEndpoint(t, writer, "root", sessionName, "/api/jobs/")
+
+	// Verify per-job datasets are stored
+	assertStoredEndpoint(t, writer, "root", sessionName, "/api/data/datasets/01000000")
+
+	// Verify cluster metadata marker exists
+	markerPath := "root/cluster-metadata/raycluster/default_my-cluster/" + sessionName
+	_, markerExists := writer.files[markerPath]
+	assert.True(t, markerExists, "cluster metadata marker should exist at %s; files: %v", markerPath, keys(writer.files))
+}
+
+func TestRunSnapshotFallbackSessionName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch path {
+		case "/api/v0/cluster_metadata":
+			// Return metadata without session_name
+			json.NewEncoder(w).Encode(map[string]any{"result": true, "data": map[string]any{}})
+		case "/timezone":
+			json.NewEncoder(w).Encode(map[string]any{"timezone": "UTC"})
+		case "/api/serve/applications/":
+			json.NewEncoder(w).Encode(map[string]any{})
+		case "/api/jobs/":
+			json.NewEncoder(w).Encode([]any{})
+		default:
+			json.NewEncoder(w).Encode(map[string]any{})
+		}
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+	}
+
+	err := Run(context.Background(), cfg, writer)
+	require.NoError(t, err)
+
+	// Verify a session name was generated (should start with "session_")
+	foundSession := false
+	for path := range writer.files {
+		if strings.Contains(path, "session_") {
+			foundSession = true
+			break
+		}
+	}
+	assert.True(t, foundSession, "should have generated a session name starting with session_")
+}
+
+func TestRunSnapshotWithOwner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch path {
+		case "/api/v0/cluster_metadata":
+			json.NewEncoder(w).Encode(map[string]any{
+				"result": true,
+				"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
+			})
+		case "/api/jobs/":
+			json.NewEncoder(w).Encode([]any{})
+		default:
+			json.NewEncoder(w).Encode(map[string]any{})
+		}
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+		OwnerKind:           "rayjob",
+		OwnerName:           "my-job",
+	}
+
+	err := Run(context.Background(), cfg, writer)
+	require.NoError(t, err)
+
+	sessionName := "session_2026-08-17_10-30-00_123456"
+
+	// Verify the cluster metadata marker uses owner path
+	markerPath := "root/cluster-metadata/rayjob/default_my-job_my-cluster/" + sessionName
+	_, markerExists := writer.files[markerPath]
+	assert.True(t, markerExists, "cluster metadata marker with owner should exist at %s; files: %v", markerPath, keys(writer.files))
+
+	// Verify fetched_endpoints use owner path in cluster dir
+	expectedPrefix := "root/cluster-history/rayjob/default/my-job/my-cluster/" + sessionName + "/fetched_endpoints/"
+	foundFetched := false
+	for path := range writer.files {
+		if strings.HasPrefix(path, expectedPrefix) {
+			foundFetched = true
+			break
+		}
+	}
+	assert.True(t, foundFetched, "fetched endpoints should be under owner cluster dir %s; files: %v", expectedPrefix, keys(writer.files))
+}
+
+func TestRunSnapshotCancelation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"result": true,
+			"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
+		})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+	}
+
+	err := Run(ctx, cfg, writer)
+	assert.Error(t, err, "should fail when context is canceled")
+}
+
+func TestDiscoverSessionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		response map[string]any
+		wantName string
+	}{
+		{
+			name: "from session_name field",
+			response: map[string]any{
+				"data": map[string]any{
+					"session_name": "session_2026-01-01_12-00-00_000000",
+				},
+			},
+			wantName: "session_2026-01-01_12-00-00_000000",
+		},
+		{
+			name: "from session_dir field",
+			response: map[string]any{
+				"data": map[string]any{
+					"session_dir": "/tmp/ray/session_2026-02-01_13-00-00_111111",
+				},
+			},
+			wantName: "session_2026-02-01_13-00-00_111111",
+		},
+		{
+			name: "session_name takes precedence over session_dir",
+			response: map[string]any{
+				"data": map[string]any{
+					"session_name": "session_2026-01-01_12-00-00_000000",
+					"session_dir":  "/tmp/ray/session_2026-02-01_13-00-00_111111",
+				},
+			},
+			wantName: "session_2026-01-01_12-00-00_000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer srv.Close()
+
+			client := &http.Client{}
+			name, err := discoverSessionName(context.Background(), client, srv.URL)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, name)
+		})
+	}
+}
+
+func TestDiscoverSessionNameFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{}
+	name, err := discoverSessionName(context.Background(), client, srv.URL)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(name, "session_"), "generated session name should start with session_")
+}
+
+func TestDedup(t *testing.T) {
+	result := dedup(
+		[]string{"/a", "/b", "/c"},
+		[]string{"/b", "/d"},
+		[]string{"/a", "/e"},
+	)
+	assert.Equal(t, []string{"/a", "/b", "/c", "/d", "/e"}, result)
+}
+
+func TestFetchAndStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"key":"value"}`))
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	err := fetchAndStore(context.Background(), &http.Client{}, srv.URL, "/api/v0/cluster_metadata", "root/cluster-history/raycluster/default/my-cluster", "session_2026-01-01_12-00-00_000000", writer)
+	require.NoError(t, err)
+
+	expectedKey := "root/cluster-history/raycluster/default/my-cluster/session_2026-01-01_12-00-00_000000/fetched_endpoints/restful__api__v0__cluster_metadata"
+	data, ok := writer.files[expectedKey]
+	require.True(t, ok, "expected file at %s; files: %v", expectedKey, keys(writer.files))
+	assert.Equal(t, `{"key":"value"}`, string(data))
+}
+
+func TestFetchAndStoreSkipsEmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty body
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	err := fetchAndStore(context.Background(), &http.Client{}, srv.URL, "/api/v0/cluster_metadata", "root/cluster-history/raycluster/default/my-cluster", "session_2026-01-01_12-00-00_000000", writer)
+	require.NoError(t, err)
+	assert.Empty(t, writer.files, "should not store empty responses")
+}
+
+func TestFetchEndpointAuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := fetchEndpoint(context.Background(), &http.Client{}, srv.URL, "/api/v0/cluster_metadata")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func assertStoredEndpoint(t *testing.T, writer *memWriter, rootDir, sessionName, endpoint string) {
+	t.Helper()
+	storageKey := "restful__" + strings.ReplaceAll(strings.Trim(endpoint, "/"), "/", "__")
+	prefix := rootDir + "/cluster-history/raycluster/default/my-cluster/" + sessionName + "/fetched_endpoints/" + storageKey
+	_, ok := writer.files[prefix]
+	assert.True(t, ok, "endpoint %s should be stored at %s; files: %v", endpoint, prefix, keys(writer.files))
+}
+
+func keys(m map[string][]byte) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}
+

--- a/historyserver/pkg/collector/snapshot/snapshot_test.go
+++ b/historyserver/pkg/collector/snapshot/snapshot_test.go
@@ -39,6 +39,12 @@ func (m *memWriter) CreateDirectory(path string) error {
 	return nil
 }
 
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
 func TestRunSnapshot(t *testing.T) {
 	clusterMetadata := map[string]any{
 		"result": true,
@@ -56,6 +62,9 @@ func TestRunSnapshot(t *testing.T) {
 		{"job_id": "02000000", "status": "RUNNING"},
 	}
 	datasets01 := map[string]any{"datasets": []any{map[string]any{"id": "ds1"}}}
+	tasks := map[string]any{"result": []any{}}
+	actors := []any{}
+	nodes := []any{}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -65,7 +74,7 @@ func TestRunSnapshot(t *testing.T) {
 			full = path + "?" + query
 		}
 
-		var resp interface{}
+		var resp any
 		switch {
 		case full == "/api/v0/cluster_metadata":
 			resp = clusterMetadata
@@ -77,6 +86,12 @@ func TestRunSnapshot(t *testing.T) {
 			resp = placementGroups
 		case full == "/api/jobs/":
 			resp = jobs
+		case full == "/api/v0/tasks?detail=1&limit=10000":
+			resp = tasks
+		case full == "/logical/actors":
+			resp = actors
+		case full == "/nodes":
+			resp = nodes
 		case strings.HasPrefix(path, "/api/data/datasets/"):
 			jobID := strings.TrimPrefix(path, "/api/data/datasets/")
 			if jobID == "01000000" {
@@ -89,8 +104,7 @@ func TestRunSnapshot(t *testing.T) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		writeJSON(t, w, resp)
 	}))
 	defer srv.Close()
 
@@ -107,39 +121,25 @@ func TestRunSnapshot(t *testing.T) {
 
 	sessionName := "session_2026-08-17_10-30-00_123456"
 
-	// Verify served endpoints are stored
-	assertStoredEndpoint(t, writer, "root", sessionName, "/api/v0/cluster_metadata")
-	assertStoredEndpoint(t, writer, "root", sessionName, "/timezone")
-	assertStoredEndpoint(t, writer, "root", sessionName, "/api/serve/applications/")
-	assertStoredEndpoint(t, writer, "root", sessionName, "/api/v0/placement_groups?detail=1&limit=10000")
+	assertStoredEndpoint(t, writer, sessionName, "/api/v0/cluster_metadata")
+	assertStoredEndpoint(t, writer, sessionName, "/timezone")
+	assertStoredEndpoint(t, writer, sessionName, "/api/serve/applications/")
+	assertStoredEndpoint(t, writer, sessionName, "/api/v0/placement_groups?detail=1&limit=10000")
+	assertStoredEndpoint(t, writer, sessionName, "/api/jobs/")
+	assertStoredEndpoint(t, writer, sessionName, "/api/data/datasets/01000000")
 
-	// Verify preservation endpoints are stored
-	assertStoredEndpoint(t, writer, "root", sessionName, "/api/jobs/")
-
-	// Verify per-job datasets are stored
-	assertStoredEndpoint(t, writer, "root", sessionName, "/api/data/datasets/01000000")
-
-	// Verify cluster metadata marker exists
 	markerPath := "root/cluster-metadata/raycluster/default_my-cluster/" + sessionName
 	_, markerExists := writer.files[markerPath]
 	assert.True(t, markerExists, "cluster metadata marker should exist at %s; files: %v", markerPath, keys(writer.files))
 }
 
-func TestRunSnapshotFallbackSessionName(t *testing.T) {
+func TestRunSnapshotMissingSessionInfo(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		switch path {
+		switch r.URL.Path {
 		case "/api/v0/cluster_metadata":
-			// Return metadata without session_name
-			json.NewEncoder(w).Encode(map[string]any{"result": true, "data": map[string]any{}})
-		case "/timezone":
-			json.NewEncoder(w).Encode(map[string]any{"timezone": "UTC"})
-		case "/api/serve/applications/":
-			json.NewEncoder(w).Encode(map[string]any{})
-		case "/api/jobs/":
-			json.NewEncoder(w).Encode([]any{})
+			writeJSON(t, w, map[string]any{"result": true, "data": map[string]any{}})
 		default:
-			json.NewEncoder(w).Encode(map[string]any{})
+			writeJSON(t, w, map[string]any{})
 		}
 	}))
 	defer srv.Close()
@@ -153,32 +153,22 @@ func TestRunSnapshotFallbackSessionName(t *testing.T) {
 	}
 
 	err := Run(context.Background(), cfg, writer)
-	require.NoError(t, err)
-
-	// Verify a session name was generated (should start with "session_")
-	foundSession := false
-	for path := range writer.files {
-		if strings.Contains(path, "session_") {
-			foundSession = true
-			break
-		}
-	}
-	assert.True(t, foundSession, "should have generated a session name starting with session_")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to discover session name")
 }
 
 func TestRunSnapshotWithOwner(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		switch path {
+		switch r.URL.Path {
 		case "/api/v0/cluster_metadata":
-			json.NewEncoder(w).Encode(map[string]any{
+			writeJSON(t, w, map[string]any{
 				"result": true,
 				"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
 			})
 		case "/api/jobs/":
-			json.NewEncoder(w).Encode([]any{})
+			writeJSON(t, w, []any{})
 		default:
-			json.NewEncoder(w).Encode(map[string]any{})
+			writeJSON(t, w, map[string]any{})
 		}
 	}))
 	defer srv.Close()
@@ -198,12 +188,10 @@ func TestRunSnapshotWithOwner(t *testing.T) {
 
 	sessionName := "session_2026-08-17_10-30-00_123456"
 
-	// Verify the cluster metadata marker uses owner path
 	markerPath := "root/cluster-metadata/rayjob/default_my-job_my-cluster/" + sessionName
 	_, markerExists := writer.files[markerPath]
 	assert.True(t, markerExists, "cluster metadata marker with owner should exist at %s; files: %v", markerPath, keys(writer.files))
 
-	// Verify fetched_endpoints use owner path in cluster dir
 	expectedPrefix := "root/cluster-history/rayjob/default/my-job/my-cluster/" + sessionName + "/fetched_endpoints/"
 	foundFetched := false
 	for path := range writer.files {
@@ -216,8 +204,8 @@ func TestRunSnapshotWithOwner(t *testing.T) {
 }
 
 func TestRunSnapshotCancelation(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
 			"result": true,
 			"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
 		})
@@ -225,7 +213,7 @@ func TestRunSnapshotCancelation(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
+	cancel()
 
 	writer := newMemWriter()
 	cfg := Config{
@@ -277,8 +265,8 @@ func TestDiscoverSessionName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				json.NewEncoder(w).Encode(tt.response)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(t, w, tt.response)
 			}))
 			defer srv.Close()
 
@@ -290,16 +278,96 @@ func TestDiscoverSessionName(t *testing.T) {
 	}
 }
 
-func TestDiscoverSessionNameFallback(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestDiscoverSessionNameDashboardUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
 	}))
 	defer srv.Close()
 
 	client := &http.Client{}
-	name, err := discoverSessionName(context.Background(), client, srv.URL)
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(name, "session_"), "generated session name should start with session_")
+	_, err := discoverSessionName(context.Background(), client, srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dashboard unreachable")
+}
+
+func TestDiscoverSessionNameNoSessionInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"result": true, "data": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	client := &http.Client{}
+	_, err := discoverSessionName(context.Background(), client, srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing session_name and usable session_dir")
+}
+
+func TestRunSnapshotTotalScrapeFailure(t *testing.T) {
+	metadataCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/cluster_metadata" {
+			metadataCalls++
+			if metadataCalls == 1 {
+				writeJSON(t, w, map[string]any{
+					"result": true,
+					"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
+				})
+				return
+			}
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+	}
+
+	err := Run(context.Background(), cfg, writer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no endpoints were stored successfully")
+
+	for path := range writer.files {
+		assert.NotContains(t, path, "cluster-metadata", "no marker should be written when all endpoints fail")
+	}
+}
+
+func TestRunSnapshotLateCancelation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/cluster_metadata":
+			writeJSON(t, w, map[string]any{
+				"result": true,
+				"data":   map[string]any{"session_name": "session_2026-08-17_10-30-00_123456"},
+			})
+		case "/api/jobs/":
+			cancel()
+			writeJSON(t, w, []any{})
+		default:
+			writeJSON(t, w, map[string]any{})
+		}
+	}))
+	defer srv.Close()
+
+	writer := newMemWriter()
+	cfg := Config{
+		DashboardAddress:    srv.URL,
+		StorageRootDir:      "root",
+		RayClusterName:      "my-cluster",
+		RayClusterNamespace: "default",
+	}
+
+	err := Run(ctx, cfg, writer)
+	require.Error(t, err)
+
+	for path := range writer.files {
+		assert.NotContains(t, path, "cluster-metadata", "no marker should be written after late cancellation")
+	}
 }
 
 func TestDedup(t *testing.T) {
@@ -312,8 +380,8 @@ func TestDedup(t *testing.T) {
 }
 
 func TestFetchAndStore(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"key":"value"}`))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"key":"value"}`))
 	}))
 	defer srv.Close()
 
@@ -324,12 +392,11 @@ func TestFetchAndStore(t *testing.T) {
 	expectedKey := "root/cluster-history/raycluster/default/my-cluster/session_2026-01-01_12-00-00_000000/fetched_endpoints/restful__api__v0__cluster_metadata"
 	data, ok := writer.files[expectedKey]
 	require.True(t, ok, "expected file at %s; files: %v", expectedKey, keys(writer.files))
-	assert.Equal(t, `{"key":"value"}`, string(data))
+	assert.JSONEq(t, `{"key":"value"}`, string(data))
 }
 
 func TestFetchAndStoreSkipsEmptyResponse(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Return empty body
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 	}))
 	defer srv.Close()
 
@@ -340,7 +407,7 @@ func TestFetchAndStoreSkipsEmptyResponse(t *testing.T) {
 }
 
 func TestFetchEndpointAuthFailure(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer srv.Close()
@@ -350,12 +417,12 @@ func TestFetchEndpointAuthFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "authentication failed")
 }
 
-func assertStoredEndpoint(t *testing.T, writer *memWriter, rootDir, sessionName, endpoint string) {
+func assertStoredEndpoint(t *testing.T, writer *memWriter, sessionName, endpoint string) { //nolint:unparam // sessionName is conceptually variable; helper exists for readability
 	t.Helper()
 	storageKey := "restful__" + strings.ReplaceAll(strings.Trim(endpoint, "/"), "/", "__")
-	prefix := rootDir + "/cluster-history/raycluster/default/my-cluster/" + sessionName + "/fetched_endpoints/" + storageKey
-	_, ok := writer.files[prefix]
-	assert.True(t, ok, "endpoint %s should be stored at %s; files: %v", endpoint, prefix, keys(writer.files))
+	filePath := "root/cluster-history/raycluster/default/my-cluster/" + sessionName + "/fetched_endpoints/" + storageKey
+	_, ok := writer.files[filePath]
+	assert.True(t, ok, "endpoint %s should be stored at %s; files: %v", endpoint, filePath, keys(writer.files))
 }
 
 func keys(m map[string][]byte) []string {
@@ -365,4 +432,3 @@ func keys(m map[string][]byte) []string {
 	}
 	return result
 }
-

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata.go
@@ -13,7 +13,7 @@ const (
 	// Without owner: cluster-metadata/raycluster/{namespace}_{cluster_name}/{session_id}
 	metaPartsCountWithoutOwner = 2
 	// With owner:    cluster-metadata/{rayjob|rayservice}/{namespace}_{owner_name}_{cluster_name}/{session_id}
-	metaPartsCountWithOwner    = 3
+	metaPartsCountWithOwner = 3
 )
 
 // EncodePath builds the hierarchical path for a given session ID.

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
@@ -9,16 +9,16 @@ import (
 
 func TestDecodePath(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePath    string
-		rootDir     string
-		expectErr   bool
-		expected    utils.ClusterInfo
+		name      string
+		filePath  string
+		rootDir   string
+		expectErr bool
+		expected  utils.ClusterInfo
 	}{
 		{
-			name:        "valid hierarchical path job",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid hierarchical path job",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				OwnerKind:       "rayjob",
@@ -30,9 +30,9 @@ func TestDecodePath(t *testing.T) {
 			},
 		},
 		{
-			name:        "valid hierarchical path standalone",
-			filePath:    "cluster-metadata/raycluster/defaultns_mycluster1/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid hierarchical path standalone",
+			filePath:  "cluster-metadata/raycluster/defaultns_mycluster1/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				Name:            "mycluster1",
@@ -42,40 +42,40 @@ func TestDecodePath(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid path prefix",
-			filePath:    "wrong-prefix/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid path prefix",
+			filePath:  "wrong-prefix/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path prefix with custom rootDir",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			rootDir:     "custom-root",
-			expectErr:   true,
+			name:      "invalid path prefix with custom rootDir",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			rootDir:   "custom-root",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path structure - missing session",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3",
-			expectErr:   true,
+			name:      "invalid path structure - missing session",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path structure - too many parts",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session/extra",
-			expectErr:   true,
+			name:      "invalid path structure - too many parts",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session/extra",
+			expectErr: true,
 		},
 		{
-			name:        "invalid metadir segment - only one part",
-			filePath:    "cluster-metadata/raycluster/defaultns/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid metadir segment - only one part",
+			filePath:  "cluster-metadata/raycluster/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "invalid metadir segment with owner - too few parts",
-			filePath:    "cluster-metadata/rayjob/defaultns/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid metadir segment with owner - too few parts",
+			filePath:  "cluster-metadata/rayjob/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "session id with bad timestamp pattern",
-			filePath:    "cluster-metadata/raycluster/defaultns_mycluster/session_not-a-real-timestamp",
-			expectErr:   true,
+			name:      "session id with bad timestamp pattern",
+			filePath:  "cluster-metadata/raycluster/defaultns_mycluster/session_not-a-real-timestamp",
+			expectErr: true,
 		},
 		{
 			name:      "invalid decode - raycluster with 3 meta parts",
@@ -83,9 +83,9 @@ func TestDecodePath(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:        "valid owner kind - mixed case",
-			filePath:    "cluster-metadata/RaYSerVice/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid owner kind - mixed case",
+			filePath:  "cluster-metadata/RaYSerVice/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				OwnerKind:       "rayservice",


### PR DESCRIPTION
Introduces a new execution mode for the collector binary that connects to a remote Ray Dashboard, scrapes all available endpoint state in a single pass, writes the responses to object storage as fetched_endpoints, creates a cluster-metadata session marker, and exits.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Issue: #4998 

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
