### PR TITLE
[History Server] Add Kubernetes token auth collector e2e test

### DIFF
--- a/historyserver/test/e2e/collector_test.go
+++ b/historyserver/test/e2e/collector_test.go
@@ -94,6 +94,10 @@ func TestCollector(t *testing.T) {
 			name:     "Token auth: collector should authenticate against the Ray Dashboard instead of crash-looping",
 			testFunc: testCollectorWithTokenAuth,
 		},
+		{
+			name:     "Kubernetes token auth: collector should authenticate with a projected ServiceAccount token",
+			testFunc: testCollectorWithKubernetesTokenAuth,
+		},
 	}
 
 	for _, tt := range tests {
@@ -823,6 +827,58 @@ func testCollectorWithTokenAuth(test Test, g *WithT, namespace *corev1.Namespace
 	headPod, err := GetHeadPod(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	assertDashboardRejectsUnauthenticatedRequest(test, g, headPod)
+
+	// Data in storage is the real proof: the collector only writes the timezone object after an
+	// authenticated Dashboard call succeeds.
+	assertTimezoneStored(test, g, rayCluster, s3Client)
+
+	DeleteS3Bucket(test, g, s3Client)
+}
+
+func testCollectorWithKubernetesTokenAuth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
+	rayCluster := ApplyRayClusterWithCollectorKubernetesTokenAuth(test, g, namespace)
+
+	headPod, err := GetHeadPod(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var collector *corev1.Container
+	for i := range headPod.Spec.Containers {
+		if headPod.Spec.Containers[i].Name == "collector" {
+			collector = &headPod.Spec.Containers[i]
+			break
+		}
+	}
+	g.Expect(collector).NotTo(BeNil(), "Head pod should contain the collector sidecar")
+
+	k8sTokenAuthEnabled := false
+	hasStaticAuthToken := false
+	for _, env := range collector.Env {
+		switch env.Name {
+		case utils.RAY_ENABLE_K8S_TOKEN_AUTH_ENV_VAR:
+			k8sTokenAuthEnabled = env.Value == "true"
+		case utils.RAY_AUTH_TOKEN_ENV_VAR:
+			hasStaticAuthToken = true
+		}
+	}
+	g.Expect(k8sTokenAuthEnabled).To(BeTrue(), "Collector should enable Kubernetes token auth")
+	g.Expect(hasStaticAuthToken).To(BeFalse(), "Collector should not receive RAY_AUTH_TOKEN")
+
+	// Check only that the projected token is nonempty; never read or log the credential.
+	_, stderr := ExecPodCmd(test, headPod, collector.Name, []string{
+		"sh", "-c", "test -s " + utils.RayK8sTokenPath,
+	})
+	g.Expect(stderr.String()).To(BeEmpty())
+
+	assertDashboardRejectsUnauthenticatedRequest(test, g, headPod)
+	assertTimezoneStored(test, g, rayCluster, s3Client)
+
+	DeleteS3Bucket(test, g, s3Client)
+}
+
+func assertDashboardRejectsUnauthenticatedRequest(test Test, g *WithT, headPod *corev1.Pod) {
+	test.T().Helper()
+
 	// Guard against a vacuous pass: if the Dashboard served this cluster without credentials the
 	// rest of the assertions would hold even with the fix reverted. Probed with Python because
 	// the Ray images ship no curl.
@@ -837,10 +893,4 @@ PY`
 	stdout, stderr := ExecPodCmd(test, headPod, "ray-head", []string{"sh", "-c", probe})
 	g.Expect(stderr.String()).To(BeEmpty())
 	g.Expect(strings.TrimSpace(stdout.String())).To(Equal("401"))
-
-	// Data in storage is the real proof: the collector only writes the timezone object after an
-	// authenticated Dashboard call succeeds.
-	assertTimezoneStored(test, g, rayCluster, s3Client)
-
-	DeleteS3Bucket(test, g, s3Client)
 }

--- a/historyserver/test/support/raycluster.go
+++ b/historyserver/test/support/raycluster.go
@@ -1,6 +1,7 @@
 package support
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,7 +15,8 @@ import (
 )
 
 const (
-	RayClusterManifestPath = "../testdata/raycluster.yaml"
+	RayClusterManifestPath               = "../testdata/raycluster.yaml"
+	rayClusterKubernetesAuthManifestPath = "../../config/raycluster-kubernetes-auth.yaml"
 
 	// RayVersionForTokenAuth is the minimum rayVersion the operator accepts for token auth.
 	RayVersionForTokenAuth = "2.52.0"
@@ -55,6 +57,58 @@ func ApplyRayClusterWithCollectorTokenAuth(test Test, g *WithT, namespace *corev
 	})
 }
 
+// ApplyRayClusterWithCollectorKubernetesTokenAuth deploys the Kubernetes token auth sample
+// with namespace-isolated RBAC resources.
+func ApplyRayClusterWithCollectorKubernetesTokenAuth(test Test, g *WithT, namespace *corev1.Namespace) *rayv1.RayCluster {
+	resources := deserializeKubernetesTokenAuthYAML(test, rayClusterKubernetesAuthManifestPath)
+	namespaceName := namespace.Name
+
+	resources.rayCluster.Namespace = namespaceName
+	resources.serviceAccount.Namespace = namespaceName
+	resources.roleBinding.Namespace = namespaceName
+
+	resources.authenticatorClusterRole.Name = fmt.Sprintf("%s-%s", resources.authenticatorClusterRole.Name, namespaceName)
+	resources.writerClusterRole.Name = fmt.Sprintf("%s-%s", resources.writerClusterRole.Name, namespaceName)
+	resources.clusterRoleBinding.Name = fmt.Sprintf("%s-%s", resources.clusterRoleBinding.Name, namespaceName)
+	resources.clusterRoleBinding.RoleRef.Name = resources.authenticatorClusterRole.Name
+	resources.roleBinding.RoleRef.Name = resources.writerClusterRole.Name
+
+	for i := range resources.clusterRoleBinding.Subjects {
+		resources.clusterRoleBinding.Subjects[i].Namespace = namespaceName
+	}
+	for i := range resources.roleBinding.Subjects {
+		resources.roleBinding.Subjects[i].Namespace = namespaceName
+	}
+
+	coreClient := test.Client().Core()
+	test.T().Cleanup(func() {
+		_ = coreClient.RbacV1().ClusterRoleBindings().Delete(
+			context.Background(), resources.clusterRoleBinding.Name, metav1.DeleteOptions{})
+		_ = coreClient.RbacV1().ClusterRoles().Delete(
+			context.Background(), resources.authenticatorClusterRole.Name, metav1.DeleteOptions{})
+		_ = coreClient.RbacV1().ClusterRoles().Delete(
+			context.Background(), resources.writerClusterRole.Name, metav1.DeleteOptions{})
+	})
+
+	_, err := coreClient.CoreV1().ServiceAccounts(namespaceName).
+		Create(test.Ctx(), resources.serviceAccount, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	_, err = coreClient.RbacV1().ClusterRoles().
+		Create(test.Ctx(), resources.authenticatorClusterRole, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	_, err = coreClient.RbacV1().ClusterRoles().
+		Create(test.Ctx(), resources.writerClusterRole, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	_, err = coreClient.RbacV1().ClusterRoleBindings().
+		Create(test.Ctx(), resources.clusterRoleBinding, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	_, err = coreClient.RbacV1().RoleBindings(namespaceName).
+		Create(test.Ctx(), resources.roleBinding, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	return createRayClusterAndWait(test, g, namespace, resources.rayCluster)
+}
+
 func applyRayClusterWithCollector(test Test, g *WithT, namespace *corev1.Namespace, mutate func(*rayv1.RayCluster)) *rayv1.RayCluster {
 	rayClusterFromYaml := DeserializeRayClusterYAML(test, RayClusterManifestPath)
 	rayClusterFromYaml.Namespace = namespace.Name
@@ -69,6 +123,10 @@ func applyRayClusterWithCollector(test Test, g *WithT, namespace *corev1.Namespa
 		injectCollectorRayClusterNamespaceAndEnvVar(rayClusterFromYaml.Spec.WorkerGroupSpecs[wg].Template.Spec.Containers, rayClusterFromYaml.Name, namespace.Name)
 	}
 
+	return createRayClusterAndWait(test, g, namespace, rayClusterFromYaml)
+}
+
+func createRayClusterAndWait(test Test, g *WithT, namespace *corev1.Namespace, rayClusterFromYaml *rayv1.RayCluster) *rayv1.RayCluster {
 	rayCluster, err := test.Client().Ray().RayV1().
 		RayClusters(namespace.Name).
 		Create(test.Ctx(), rayClusterFromYaml, metav1.CreateOptions{})

--- a/historyserver/test/support/yaml.go
+++ b/historyserver/test/support/yaml.go
@@ -8,6 +8,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -37,4 +38,46 @@ func DeserializeRBACFromYAML(t Test, filename string) (*corev1.ServiceAccount, *
 	require.NoError(t.T(), err, "Failed to decode ClusterRoleBinding from %s", filename)
 
 	return ServiceAccount, ClusterRole, ClusterRoleBinding
+}
+
+type kubernetesTokenAuthResources struct {
+	rayCluster               *rayv1.RayCluster
+	serviceAccount           *corev1.ServiceAccount
+	authenticatorClusterRole *rbacv1.ClusterRole
+	writerClusterRole        *rbacv1.ClusterRole
+	clusterRoleBinding       *rbacv1.ClusterRoleBinding
+	roleBinding              *rbacv1.RoleBinding
+}
+
+func deserializeKubernetesTokenAuthYAML(t Test, filename string) *kubernetesTokenAuthResources {
+	t.T().Helper()
+
+	file, err := os.Open(filename)
+	require.NoError(t.T(), err, "Failed to open file %s", filename)
+	defer file.Close()
+
+	decoder := yaml.NewYAMLOrJSONDecoder(file, 4096)
+	resources := &kubernetesTokenAuthResources{
+		rayCluster:               &rayv1.RayCluster{},
+		serviceAccount:           &corev1.ServiceAccount{},
+		authenticatorClusterRole: &rbacv1.ClusterRole{},
+		writerClusterRole:        &rbacv1.ClusterRole{},
+		clusterRoleBinding:       &rbacv1.ClusterRoleBinding{},
+		roleBinding:              &rbacv1.RoleBinding{},
+	}
+
+	err = decoder.Decode(resources.rayCluster)
+	require.NoError(t.T(), err, "Failed to decode RayCluster from %s", filename)
+	err = decoder.Decode(resources.serviceAccount)
+	require.NoError(t.T(), err, "Failed to decode ServiceAccount from %s", filename)
+	err = decoder.Decode(resources.authenticatorClusterRole)
+	require.NoError(t.T(), err, "Failed to decode authenticator ClusterRole from %s", filename)
+	err = decoder.Decode(resources.writerClusterRole)
+	require.NoError(t.T(), err, "Failed to decode writer ClusterRole from %s", filename)
+	err = decoder.Decode(resources.clusterRoleBinding)
+	require.NoError(t.T(), err, "Failed to decode ClusterRoleBinding from %s", filename)
+	err = decoder.Decode(resources.roleBinding)
+	require.NoError(t.T(), err, "Failed to decode RoleBinding from %s", filename)
+
+	return resources
 }


### PR DESCRIPTION
## Why are these changes needed?

#5078 added Kubernetes-delegated token authentication for the history server collector and introduced `historyserver/config/raycluster-kubernetes-auth.yaml`. However, the existing collector e2e test only covers the secret-based `RAY_AUTH_TOKEN` path.

This PR:

- Adds a separate collector e2e subtest using the existing Kubernetes-auth sample.
- Adapts the sample's ServiceAccount and RBAC resources to each generated test namespace, gives cluster-scoped RBAC unique names, and cleans those resources up afterward.
- Verifies that the collector has Kubernetes token auth enabled without `RAY_AUTH_TOKEN`, receives a nonempty projected ServiceAccount token, encounters HTTP 401 without credentials, and stores authenticated timezone data in MinIO.

## Related issue number

Closes #5119

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Validated locally with:

- `go test ./test/e2e -run '^$'`
- `go test -race -v ./pkg/... ./cmd/... -parallel 4`
- `go vet ./...`

The targeted live Kind subtest was not run locally because no Kubernetes/Kind environment was available; the history-server e2e job will exercise it.
