### PR TITLE
[RayJob] Align existing RayCluster sample name

### DIFF
--- a/ray-operator/config/samples/ray-job.use-existing-raycluster.yaml
+++ b/ray-operator/config/samples/ray-job.use-existing-raycluster.yaml
@@ -4,6 +4,6 @@ metadata:
   name: rayjob-use-existing-raycluster
 spec:
   entrypoint: python -c "import ray; ray.init(); print(ray.cluster_resources())"
-  # Select an existing RayCluster called "ray-cluster-kuberay" instead of creating a new one.
+  # Select an existing RayCluster called "raycluster-kuberay" instead of creating a new one.
   clusterSelector:
-    ray.io/cluster: ray-cluster-kuberay
+    ray.io/cluster: raycluster-kuberay

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -45,6 +46,16 @@ func TestRayJob(t *testing.T) {
 			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 		})
 	}
+}
+
+func TestRayJobUseExistingRayClusterSampleConsistency(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+	sampleYAMLDir := GetSampleYAMLDir(test)
+	rayCluster := DeserializeRayClusterYAML(test, path.Join(sampleYAMLDir, "ray-cluster.sample.yaml"))
+	rayJob := DeserializeRayJobYAML(test, path.Join(sampleYAMLDir, "ray-job.use-existing-raycluster.yaml"))
+
+	g.Expect(rayJob.Spec.ClusterSelector).To(HaveKeyWithValue(utils.RayJobClusterSelectorKey, rayCluster.Name))
 }
 
 func TestRayJobInteractiveMode(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

`ray-job.use-existing-raycluster.yaml` selects a RayCluster named `ray-cluster-kuberay`, while `ray-cluster.sample.yaml` creates a RayCluster named `raycluster-kuberay`. As a result, applying the two samples together does not allow the RayJob to find the intended existing RayCluster.

This change aligns the `clusterSelector` value and its comment with the RayCluster sample name. It also adds a focused consistency test that compares the selector with the RayCluster's `metadata.name` to prevent the samples from drifting apart again.

## Related issue number

Closes #5160

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Validation performed:

```shell
cd ray-operator
go test -count=1 -v ./test/sampleyaml -run '^TestRayJobUseExistingRayClusterSampleConsistency$'
```
