### PR TITLE
[HistoryServer] List Ray event files recursively

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,6 +37,14 @@ var eventFilePattern = regexp.MustCompile(`-\d{4}-\d{2}-\d{2}-\d{2}(-\d+)?(\.jso
 
 // taskPrefix is extracted to avoid hard-coded "task::" usage
 const taskPrefix = "task::"
+
+type rayEventFileKind int
+
+const (
+	invalidRayEventFile rayEventFileKind = iota
+	jobEventFile
+	nodeEventFile
+)
 
 func isValidEventFile(fileName string) bool {
 	// Skip directories
@@ -100,6 +109,43 @@ func DecodeEventFileBytes(fileName string, raw []byte) ([]map[string]any, error)
 		return nil, fmt.Errorf("scan JSONL %s: %w", fileName, err)
 	}
 	return out, nil
+}
+
+func classifyRayEventFile(relativePath string) rayEventFileKind {
+	cleanPath := path.Clean(relativePath)
+	if cleanPath != relativePath || path.IsAbs(cleanPath) || strings.HasPrefix(cleanPath, "../") {
+		return invalidRayEventFile
+	}
+
+	nodeName, remainingPath, found := strings.Cut(cleanPath, "/")
+	if !found || nodeName == "" {
+		return invalidRayEventFile
+	}
+
+	eventDir, remainingPath, found := strings.Cut(remainingPath, "/")
+	if !found {
+		return invalidRayEventFile
+	}
+
+	switch eventDir {
+	case clusterlogs.JobEventsSubDir:
+		jobID, fileName, found := strings.Cut(remainingPath, "/")
+		if !found || jobID == "" || strings.Contains(fileName, "/") {
+			return invalidRayEventFile
+		}
+		if isValidEventFile(fileName) {
+			return jobEventFile
+		}
+	case clusterlogs.NodeEventsSubDir:
+		if strings.Contains(remainingPath, "/") {
+			return invalidRayEventFile
+		}
+		if isValidEventFile(remainingPath) {
+			return nodeEventFile
+		}
+	}
+
+	return invalidRayEventFile
 }
 
 func NewEventHandler(reader storage.StorageReader) *EventHandler {
@@ -525,62 +571,27 @@ func (h *EventHandler) getClusterLogPathPrefix(clusterInfo utils.ClusterInfo) st
 	return clusterlogs.Prefix("", clusterInfo.OwnerKind, clusterInfo.OwnerName, clusterInfo.Namespace, clusterInfo.Name)
 }
 
-// getAllJobEventFiles get all the job event files for the given cluster.
-func (h *EventHandler) getAllJobEventFiles(clusterInfo utils.ClusterInfo) []string {
-	var allJobFiles []string
+// getAllRayEventFiles retrieves all job and node event files for the given cluster session.
+func (h *EventHandler) getAllRayEventFiles(ctx context.Context, clusterInfo utils.ClusterInfo) ([]string, error) {
 	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
-
-	// Check candidate prefixes under each node (<sessionName>/<nodeName>/job_events/)
-	var candidatePrefixes []string
-	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
-		if strings.HasSuffix(rawEntry, "/") {
-			nodeName := strings.TrimSuffix(rawEntry, "/")
-			candidatePrefixes = append(candidatePrefixes, clusterlogs.RelJobEventsDir(clusterInfo.SessionName, nodeName, "")+"/")
-		}
+	sessionFiles, err := h.reader.ListFilesRecursive(ctx, clusterLogPathPrefix, clusterInfo.SessionName)
+	if err != nil {
+		return nil, fmt.Errorf("list Ray event files for session %s: %w", clusterInfo.SessionName, err)
 	}
 
-	for _, jobEventDirPrefix := range candidatePrefixes {
-		jobDirList := h.reader.ListFiles(clusterLogPathPrefix, jobEventDirPrefix)
-		for _, jobDir := range jobDirList {
-			if !strings.HasSuffix(jobDir, "/") {
-				continue
-			}
-			jobDirPath := jobEventDirPrefix + jobDir
-			jobFiles := h.reader.ListFiles(clusterLogPathPrefix, jobDirPath)
-			for _, jobFile := range jobFiles {
-				if isValidEventFile(jobFile) {
-					allJobFiles = append(allJobFiles, jobDirPath+jobFile)
-				}
-			}
-		}
-	}
-	return allJobFiles
-}
-
-// getAllNodeEventFiles retrieves all node event files for the given cluster
-func (h *EventHandler) getAllNodeEventFiles(clusterInfo utils.ClusterInfo) []string {
-	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
-
-	// Check candidate prefixes under each node (<sessionName>/<nodeName>/node_events/)
-	var candidatePrefixes []string
-	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
-		if strings.HasSuffix(rawEntry, "/") {
-			nodeName := strings.TrimSuffix(rawEntry, "/")
-			candidatePrefixes = append(candidatePrefixes, clusterlogs.RelNodeEventsDir(clusterInfo.SessionName, nodeName)+"/")
-		}
-	}
-
+	var jobEventFiles []string
 	var nodeEventFiles []string
-	for _, nodeEventDirPrefix := range candidatePrefixes {
-		nodeEventFileNames := h.reader.ListFiles(clusterLogPathPrefix, nodeEventDirPrefix)
-		for _, fileName := range nodeEventFileNames {
-			if isValidEventFile(fileName) {
-				fullPath := nodeEventDirPrefix + fileName
-				nodeEventFiles = append(nodeEventFiles, fullPath)
-			}
+	for _, relativePath := range sessionFiles {
+		fullPath := path.Join(clusterInfo.SessionName, relativePath)
+		switch classifyRayEventFile(relativePath) {
+		case jobEventFile:
+			jobEventFiles = append(jobEventFiles, fullPath)
+		case nodeEventFile:
+			nodeEventFiles = append(nodeEventFiles, fullPath)
 		}
 	}
-	return nodeEventFiles
+
+	return append(jobEventFiles, nodeEventFiles...), nil
 }
 
 // GetTasks returns a slice of thread-safe deep copies of all task attempts for a given cluster session.
@@ -1143,9 +1154,6 @@ func (h *EventHandler) getNodeMap(clusterSessionID string) map[string]types.Node
 
 // ProcessSingleSession reads all event files for a single session synchronously
 // and populates the handler's in-memory maps.
-//
-// TODO(jiangjiawei1103): Empty event file list vs ListFiles outage is ambiguous without
-// StorageReader interface surfacing errors.
 func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo utils.ClusterInfo) error {
 	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 	clusterSessionKey := utils.BuildClusterSessionKey(clusterInfo.Name, clusterInfo.Namespace, clusterInfo.SessionName)
@@ -1158,7 +1166,10 @@ func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo uti
 			clusterSessionKey, err)
 	}
 
-	eventFileList := append(h.getAllJobEventFiles(clusterInfo), h.getAllNodeEventFiles(clusterInfo)...)
+	eventFileList, err := h.getAllRayEventFiles(ctx, clusterInfo)
+	if err != nil {
+		return err
+	}
 	logrus.Debugf("current eventFileList for cluster %s is: %v", clusterInfo.Name, eventFileList)
 
 	rayEventsTotal := len(eventFileList)

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -1096,8 +1097,48 @@ func TestNormalizeActorIDsToHex(t *testing.T) {
 	}
 }
 
+func TestGetAllRayEventFiles(t *testing.T) {
+	const clusterID = "cluster-history/raycluster/ns/cluster"
+	mock := newLogEventMockReader()
+	mock.addDir(clusterID, "session1/node-a/job_events/job-1", []string{
+		"job-1-2026-01-01-00.gz",
+		"not-an-event.txt",
+	})
+	mock.addDir(clusterID, "session1", []string{"job-1-2026-01-01-00.gz"})
+	mock.addDir(clusterID, "session1/node-a/node_events", []string{"node-a-2026-01-01-00.gz"})
+	mock.addDir(clusterID, "session1/node-a/logs", []string{"worker-2026-01-01-00.gz"})
+	mock.addDir(clusterID, "session1/node-a/job_events/job-1/nested", []string{"nested-2026-01-01-00.gz"})
+
+	h := NewEventHandler(mock)
+	got, err := h.getAllRayEventFiles(context.Background(), utils.ClusterInfo{
+		Name:        "cluster",
+		Namespace:   "ns",
+		SessionName: "session1",
+	})
+	require.NoError(t, err)
+	want := []string{
+		"session1/node-a/job_events/job-1/job-1-2026-01-01-00.gz",
+		"session1/node-a/node_events/node-a-2026-01-01-00.gz",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("getAllRayEventFiles() returned diff (-want +got):\n%s", diff)
+	}
+	assert.Equal(t, []listFilesCall{{clusterID: clusterID, dir: "session1"}}, mock.recursiveListCalls)
+}
+
 func TestProcessSingleSession(t *testing.T) {
 	clusterInfo := utils.ClusterInfo{Name: "cluster", Namespace: "ns", SessionName: "session1"}
+
+	t.Run("returns recursive listing errors", func(t *testing.T) {
+		mock := newLogEventMockReader()
+		mock.recursiveListErr = errors.New("storage listing failed")
+
+		h := NewEventHandler(mock)
+		err := h.ProcessSingleSession(context.Background(), clusterInfo)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "storage listing failed")
+	})
 
 	t.Run("returns error when every listed file fails I/O", func(t *testing.T) {
 		mock := newLogEventMockReader()

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -1097,6 +1097,78 @@ func TestNormalizeActorIDsToHex(t *testing.T) {
 	}
 }
 
+func TestClassifyRayEventFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		relativePath string
+		want         rayEventFileKind
+	}{
+		{
+			name:         "canonical job event",
+			relativePath: "node-a/job_events/job-1/node-a-2026-01-01-00.gz",
+			want:         jobEventFile,
+		},
+		{
+			name:         "canonical node event",
+			relativePath: "node-a/node_events/node-a-2026-01-01-00.jsonl.gz",
+			want:         nodeEventFile,
+		},
+		{
+			name:         "absolute path",
+			relativePath: "/node-a/node_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "parent traversal",
+			relativePath: "../node-a/node_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "double slash",
+			relativePath: "node-a//node_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "dot component",
+			relativePath: "node-a/./node_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "empty node ID",
+			relativePath: "/node_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "empty job ID",
+			relativePath: "node-a/job_events//node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "missing job ID",
+			relativePath: "node-a/job_events/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "nested below node events",
+			relativePath: "node-a/node_events/nested/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+		{
+			name:         "nested below job directory",
+			relativePath: "node-a/job_events/job-1/nested/node-a-2026-01-01-00.gz",
+			want:         invalidRayEventFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyRayEventFile(tt.relativePath); got != tt.want {
+				t.Errorf("classifyRayEventFile(%q) = %v, want %v", tt.relativePath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetAllRayEventFiles(t *testing.T) {
 	const clusterID = "cluster-history/raycluster/ns/cluster"
 	mock := newLogEventMockReader()

--- a/historyserver/pkg/eventserver/log_event_reader_test.go
+++ b/historyserver/pkg/eventserver/log_event_reader_test.go
@@ -2,7 +2,9 @@ package eventserver
 
 import (
 	"bufio"
+	"context"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 
@@ -15,8 +17,15 @@ import (
 // --- Test-local mock reader for LogEventReader tests ---
 
 type logEventMockReader struct {
-	files map[string]map[string]string
-	dirs  map[string]map[string][]string
+	files              map[string]map[string]string
+	dirs               map[string]map[string][]string
+	recursiveListCalls []listFilesCall
+	recursiveListErr   error
+}
+
+type listFilesCall struct {
+	clusterID string
+	dir       string
 }
 
 func newLogEventMockReader() *logEventMockReader {
@@ -58,6 +67,32 @@ func (m *logEventMockReader) ListFiles(clusterID string, dir string) []string {
 		}
 	}
 	return []string{}
+}
+
+func (m *logEventMockReader) ListFilesRecursive(ctx context.Context, clusterID string, dir string) ([]string, error) {
+	m.recursiveListCalls = append(m.recursiveListCalls, listFilesCall{clusterID: clusterID, dir: dir})
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if m.recursiveListErr != nil {
+		return nil, m.recursiveListErr
+	}
+
+	prefix := strings.TrimSuffix(dir, "/") + "/"
+	var files []string
+	for dirPath, entries := range m.dirs[clusterID] {
+		dirPath = strings.TrimSuffix(dirPath, "/") + "/"
+		if !strings.HasPrefix(dirPath, prefix) {
+			continue
+		}
+		for _, entry := range entries {
+			if !strings.HasSuffix(entry, "/") {
+				files = append(files, strings.TrimPrefix(dirPath, prefix)+entry)
+			}
+		}
+	}
+	sort.Strings(files)
+	return files, nil
 }
 
 // --- Tests ---

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -37,6 +37,10 @@ func (m *mockStorageReader) ListFiles(clusterId string, dir string) []string {
 	return nil
 }
 
+func (m *mockStorageReader) ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error) {
+	return nil, nil
+}
+
 func TestEnterCluster(t *testing.T) {
 	// Reset default container to avoid polluting or using duplicate services across runs
 	restful.DefaultContainer = restful.NewContainer()

--- a/historyserver/pkg/historyserver/tasks_test.go
+++ b/historyserver/pkg/historyserver/tasks_test.go
@@ -1,6 +1,7 @@
 package historyserver
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -26,6 +27,10 @@ func (r *taskLogStorageReader) GetContent(_ string, filename string) io.Reader {
 }
 
 func (r *taskLogStorageReader) ListFiles(_, _ string) []string { return r.files }
+
+func (*taskLogStorageReader) ListFilesRecursive(context.Context, string, string) ([]string, error) {
+	return nil, nil
+}
 
 func TestTaskLogBasename(t *testing.T) {
 	tests := map[string]struct {

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -138,6 +138,30 @@ func (r *RayLogsHandler) ListFiles(clusterId string, dir string) []string {
 	return nodes
 }
 
+// ListFilesRecursive returns all files under dir, relative to dir.
+func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error) {
+	prefix := path.Join(r.OssRootDir, clusterId, dir)
+	paginator := r.OssClient.NewListObjectsV2Paginator(&oss.ListObjectsV2Request{
+		Bucket:    oss.Ptr(r.OssBucket),
+		Prefix:    oss.Ptr(prefix + "/"),
+		Delimiter: oss.Ptr(""),
+		MaxKeys:   100,
+	})
+
+	var objectPaths []string
+	for paginator.HasNext() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list objects under %s: %w", prefix, err)
+		}
+		for _, object := range page.Contents {
+			objectPaths = append(objectPaths, *object.Key)
+		}
+	}
+
+	return storage.RelativeFilePaths(prefix, objectPaths), nil
+}
+
 func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -145,7 +145,7 @@ func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId strin
 		Bucket:    oss.Ptr(r.OssBucket),
 		Prefix:    oss.Ptr(prefix + "/"),
 		Delimiter: oss.Ptr(""),
-		MaxKeys:   100,
+		MaxKeys:   1000,
 	})
 
 	var objectPaths []string

--- a/historyserver/pkg/storage/azureblob/azureblob.go
+++ b/historyserver/pkg/storage/azureblob/azureblob.go
@@ -152,6 +152,29 @@ func (r *RayLogsHandler) ListFiles(clusterId string, dir string) []string {
 	return r.listBlobs(prefix, "/", true)
 }
 
+// ListFilesRecursive returns all files under dir, relative to dir.
+func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error) {
+	prefix := path.Join(r.RootDir, clusterId, dir)
+	prefixWithSlash := prefix + "/"
+	pager := r.ContainerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Prefix:     &prefixWithSlash,
+		MaxResults: to32(100),
+	})
+
+	var objectPaths []string
+	for pager.More() {
+		resp, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list blobs under %s: %w", prefix, err)
+		}
+		for _, blob := range resp.Segment.BlobItems {
+			objectPaths = append(objectPaths, *blob.Name)
+		}
+	}
+
+	return storage.RelativeFilePaths(prefix, objectPaths), nil
+}
+
 func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/historyserver/pkg/storage/azureblob/azureblob.go
+++ b/historyserver/pkg/storage/azureblob/azureblob.go
@@ -157,8 +157,7 @@ func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId strin
 	prefix := path.Join(r.RootDir, clusterId, dir)
 	prefixWithSlash := prefix + "/"
 	pager := r.ContainerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
-		Prefix:     &prefixWithSlash,
-		MaxResults: to32(100),
+		Prefix: &prefixWithSlash,
 	})
 
 	var objectPaths []string

--- a/historyserver/pkg/storage/gcs/gcs_handler.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler.go
@@ -134,6 +134,29 @@ func (h *RayLogsHandler) ListFiles(clusterId string, directory string) []string 
 	return fileList
 }
 
+// ListFilesRecursive returns all files under directory, relative to directory.
+func (h *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId string, directory string) ([]string, error) {
+	pathPrefix := strings.TrimPrefix(path.Join(h.RootDir, clusterId, directory), "/")
+	query := &gstorage.Query{Prefix: pathPrefix + "/"}
+	fileIterator := h.StorageClient.Bucket(h.GCSBucket).Objects(ctx, query)
+
+	var objectPaths []string
+	for {
+		attrs, err := fileIterator.Next()
+		if err == gIterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("list objects in bucket %q under %s: %w", h.GCSBucket, pathPrefix, err)
+		}
+		if attrs.Name != "" {
+			objectPaths = append(objectPaths, attrs.Name)
+		}
+	}
+
+	return storage.RelativeFilePaths(pathPrefix, objectPaths), nil
+}
+
 // List will return a list of ClusterInfo
 func (h *RayLogsHandler) List() []utils.ClusterInfo {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/historyserver/pkg/storage/gcs/gcs_handler_test.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler_test.go
@@ -1,6 +1,7 @@
 package gcs
 
 import (
+	"context"
 	"io"
 	"sort"
 	"strings"
@@ -210,6 +211,57 @@ func TestListFiles(t *testing.T) {
 				t.Errorf("ListFiles(%q, %q) returned diff (-want +got):\n%s", tc.clusterID, tc.directory, diff)
 			}
 		})
+	}
+}
+
+func TestListFilesRecursive(t *testing.T) {
+	initialObjects := []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster1/session1/",
+			},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster1/session1/node-a/job_events/job-1/events.gz",
+			},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster1/session1/node-b/node_events/events.gz",
+			},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster1/session2/node-c/node_events/events.gz",
+			},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster2/session1/node-d/node_events/events.gz",
+			},
+		},
+	}
+	_, client, bucketName := setupFakeGCS(t, initialObjects...)
+	handler := createRayLogsHandler(client, bucketName)
+
+	got, err := handler.ListFilesRecursive(context.Background(), "cluster1", "session1")
+	if err != nil {
+		t.Fatalf("ListFilesRecursive() failed: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{
+		"node-a/job_events/job-1/events.gz",
+		"node-b/node_events/events.gz",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("ListFilesRecursive() returned diff (-want +got):\n%s", diff)
 	}
 }
 

--- a/historyserver/pkg/storage/interface.go
+++ b/historyserver/pkg/storage/interface.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
@@ -22,5 +23,8 @@ type StorageReader interface {
 	//
 	GetContent(clusterId string, fileName string) io.Reader
 
+	// ListFiles returns the immediate files and directories under dir.
 	ListFiles(clusterId string, dir string) []string
+	// ListFilesRecursive returns paths relative to dir and propagates listing errors.
+	ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error)
 }

--- a/historyserver/pkg/storage/listing.go
+++ b/historyserver/pkg/storage/listing.go
@@ -1,0 +1,21 @@
+package storage
+
+import "strings"
+
+// RelativeFilePaths converts object paths returned by a flat storage listing
+// into file paths relative to the listed prefix. Directory marker objects and
+// objects outside the prefix are omitted.
+func RelativeFilePaths(prefix string, objectPaths []string) []string {
+	prefix = strings.TrimSuffix(prefix, "/") + "/"
+	relativePaths := make([]string, 0, len(objectPaths))
+
+	for _, objectPath := range objectPaths {
+		relativePath, found := strings.CutPrefix(objectPath, prefix)
+		if !found || relativePath == "" || strings.HasSuffix(relativePath, "/") {
+			continue
+		}
+		relativePaths = append(relativePaths, relativePath)
+	}
+
+	return relativePaths
+}

--- a/historyserver/pkg/storage/listing_test.go
+++ b/historyserver/pkg/storage/listing_test.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRelativeFilePaths(t *testing.T) {
+	prefix := "root/cluster/session"
+	objectPaths := []string{
+		"root/cluster/session/",
+		"root/cluster/session/node-a/",
+		"root/cluster/session/node-a/job_events/job-1/events.gz",
+		"root/cluster/session/node-b/node_events/events.gz",
+		"root/cluster/session-old/node-c/node_events/events.gz",
+	}
+
+	want := []string{
+		"node-a/job_events/job-1/events.gz",
+		"node-b/node_events/events.gz",
+	}
+
+	if diff := cmp.Diff(want, RelativeFilePaths(prefix, objectPaths)); diff != "" {
+		t.Fatalf("RelativeFilePaths() returned diff (-want +got):\n%s", diff)
+	}
+}

--- a/historyserver/pkg/storage/localtest/reader.go
+++ b/historyserver/pkg/storage/localtest/reader.go
@@ -1,7 +1,9 @@
 package localtest
 
 import (
+	"context"
 	"io"
+	"path"
 	"strings"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
@@ -73,6 +75,31 @@ func (r *MockReader) ListFiles(clusterId string, dir string) []string {
 		return files
 	}
 	return []string{}
+}
+
+func (r *MockReader) ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	clusterData, ok := r.data[clusterId]
+	if !ok {
+		return []string{}, nil
+	}
+
+	cleanDir := strings.Trim(path.Clean(dir), "/")
+	prefix := cleanDir + "/"
+	files := make([]string, 0, len(clusterData))
+	for fileName := range clusterData {
+		relativePath := fileName
+		found := cleanDir == "" || cleanDir == "."
+		if !found {
+			relativePath, found = strings.CutPrefix(fileName, prefix)
+		}
+		if found && relativePath != "" && !strings.HasSuffix(relativePath, "/") {
+			files = append(files, relativePath)
+		}
+	}
+	return files, nil
 }
 
 // NewReader creates a new StorageReader

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -18,6 +18,7 @@ package s3
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -141,6 +142,31 @@ func (r *RayLogsHandler) ListFiles(clusterId string, dir string) []string {
 	nodes := r._listFiles(prefix, "/", true)
 	// Note: clusters is not defined in this scope, removed sorting
 	return nodes
+}
+
+// ListFilesRecursive returns all files under dir, relative to dir.
+func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId string, dir string) ([]string, error) {
+	prefix := path.Join(r.S3RootDir, clusterId, dir)
+	listInput := &s3.ListObjectsV2Input{
+		Bucket:    aws.String(r.S3Bucket),
+		Prefix:    aws.String(prefix + "/"),
+		MaxKeys:   aws.Int64(100),
+		Delimiter: aws.String(""),
+	}
+
+	var objectPaths []string
+	err := r.S3Client.ListObjectsV2PagesWithContext(ctx, listInput,
+		func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+			for _, object := range page.Contents {
+				objectPaths = append(objectPaths, aws.StringValue(object.Key))
+			}
+			return true
+		})
+	if err != nil {
+		return nil, fmt.Errorf("list objects under %s: %w", prefix, err)
+	}
+
+	return storage.RelativeFilePaths(prefix, objectPaths), nil
 }
 
 func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -150,7 +150,6 @@ func (r *RayLogsHandler) ListFilesRecursive(ctx context.Context, clusterId strin
 	listInput := &s3.ListObjectsV2Input{
 		Bucket:    aws.String(r.S3Bucket),
 		Prefix:    aws.String(prefix + "/"),
-		MaxKeys:   aws.Int64(100),
 		Delimiter: aws.String(""),
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

Ray event discovery previously required `1 + N + N*M` storage listing requests, where `N` is the number of nodes and `M` is the number of jobs per node.

This change performs one recursive listing under the session prefix and filters job and node event files locally.

Recursive listing is implemented for S3, Azure Blob Storage, GCS, Aliyun OSS, and the local test reader.

## Related issue number

Related to #5065 (Item 4).

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

The recursive listing was tested against:

- S3 using MinIO
- Azure Blob Storage using Azurite
- Aliyun OSS using a real OSS bucket

Steps:
1. Configure the History Server with a supported object storage backend.
2. Upload valid job and node event files under a session:
   - `<session>/<node>/job_events/<job>/<event-file>`
   - `<session>/<node>/node_events/<event-file>`
3. Upload unrelated files under `<session>/<node>/logs/` and another session prefix.
4. Upload more than 100 objects under the target session to exercise pagination.
5. Delete the corresponding RayCluster, start the History Server, and request the stored session.
6. Verify that:
   - All job and node events are loaded.
   - Nested event files across multiple nodes and jobs are discovered.
   - Log files and objects from other sessions are ignored.
   - No events are missing across listing pages.