### PR TITLE
[Dashboard] Fix enter_cluster URL missing the kind segment

### DIFF
--- a/dashboard/src/hooks/api/useHistoryClusters.ts
+++ b/dashboard/src/hooks/api/useHistoryClusters.ts
@@ -23,8 +23,11 @@ export const useHistoryClusters = (refreshInterval: number = 5000) => {
     sessionName: string,
   ) => {
     const proxyEndpoint = (await config.getHistoryServerUrl()).proxyEndpoint;
+    // The enter_cluster route is /{namespace}/{kind}/{name}/{session}. Every
+    // row in the history table is a RayCluster, and the server resolves
+    // kind=raycluster by the cluster's own name regardless of its owner.
     const res = await fetch(
-      `${proxyEndpoint}/enter_cluster/${encodeURIComponent(namespace)}/${encodeURIComponent(cluster)}/${encodeURIComponent(sessionName)}`,
+      `${proxyEndpoint}/enter_cluster/${encodeURIComponent(namespace)}/raycluster/${encodeURIComponent(cluster)}/${encodeURIComponent(sessionName)}`,
       { method: "GET", credentials: "include" },
     );
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md before opening a pull request. -->

## Why are these changes needed?

The History tab's "enter cluster" action always fails with `400 unsupported resource kind`.

The frontend calls `/enter_cluster/{namespace}/{name}/{session}` (three segments), but the history server only registers `/{namespace}/{kind}/{name}` and `/{namespace}/{kind}/{name}/{session}` (`historyserver/pkg/historyserver/router.go`). The three-segment request therefore matches the first route with `{kind}` bound to the cluster name, which fails kind validation.

This change inserts the missing `raycluster` segment. Every row in the history table is a RayCluster, and `resolveSession` resolves `kind=raycluster` by the cluster's own name in both the live path (`GetRayCluster` by name) and the stored path (`c.Name == resourceName`), so clusters originated from RayJobs or RayServices resolve correctly as well, and the owner cookies are still populated server-side from the resolved `ClusterInfo`.

An alternative would be plumbing `ownerKind`/`ownerName` through the table and building kind-aware URLs; that isn't needed for correctness here, but happy to do it as a follow-up if kind-aware links are wanted.

## Related issue number

Fixes #5172

## Checks

- Verified with `yarn lint` (ESLint + Prettier clean), `npx tsc --noEmit` clean, and a successful `yarn build`. The dashboard has no unit-test harness; the route behavior was verified by tracing `router.go` and `reader.go:resolveSession`.
- AI tooling was used in preparing this change. I have reviewed it and can explain every line.
