### PR TITLE
[Flaky Test] Apiserver flaky fix

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -190,7 +190,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - E2E_API_SERVER_URL="http://localhost:8888" go test -parallel 4 -timeout 60m -v ./test/e2e/... 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs -l app.kubernetes.io/component=kuberay-apiserver --namespace ray-system | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-apiserver.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-apiserver-log.tar -T - && exit 1)
+    - E2E_API_SERVER_URL="http://localhost:8888" go test -parallel 4 -timeout 60m -v ./test/e2e/... 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/component=kuberay-apiserver --namespace ray-system | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-apiserver.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-apiserver-log.tar -T - && exit 1)
     - echo "--- END:Apiserver e2e (nightly operator) tests finished"
 
 - label: 'Test RayJob Light Weight Submitter E2E (nightly operator)'

--- a/apiserver/test/e2e/apiserversdk/types.go
+++ b/apiserver/test/e2e/apiserversdk/types.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -218,7 +219,7 @@ func (e2etc *End2EndTestingContext) GetK8sClient() *kubernetes.Clientset {
 }
 
 func (e2etc *End2EndTestingContext) GetNextName() string {
-	e2etc.currentName = petnames.Name()
+	e2etc.currentName = fmt.Sprintf("%s-%s", petnames.Name(), rand.String(5))
 	return e2etc.currentName
 }
 

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -244,7 +245,7 @@ func (e2etc *End2EndTestingContext) GetRayAPIServerClient() *kuberayHTTP.Kuberay
 }
 
 func (e2etc *End2EndTestingContext) GetNextName() string {
-	e2etc.currentName = petnames.Name()
+	e2etc.currentName = fmt.Sprintf("%s-%s", petnames.Name(), rand.String(5))
 	return e2etc.currentName
 }
 


### PR DESCRIPTION
- Update `GetNextName()` to return name with random suffix
- Tested this fix 40 times in https://github.com/ray-project/kuberay/pull/5162, the only one failing is due to `ERROR: HTTP error 502`, which is a temporary infra error

## Why are these changes needed?

This PR is fixing this error from buildkite CI ([link](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/16447/list?sid=019fdc3a-ada9-43bd-a8f9-b53f960908d1&tab=output))

Ran apiserver e2e test 40 times in https://github.com/ray-project/kuberay/pull/5168, with result:
- 2 pypi 502 issue (2 & 21)
- 1 test failure (28):

```sh
RUN TestGetAllServicesWithPagination
--
  | [2026-08-19T08:16:19Z]     service_server_e2e_test.go:599:
  | [2026-08-19T08:16:19Z]         	Error Trace:	/workdir/apiserver/test/e2e/service_server_e2e_test.go:599
  | [2026-08-19T08:16:19Z]         	            				/workdir/apiserver/test/e2e/service_server_e2e_test.go:251
  | [2026-08-19T08:16:19Z]         	Error:      	Received unexpected error:
  | [2026-08-19T08:16:19Z]         	            	kuberay api server request failed with HTTP status (500: Internal Server Error)
  | [2026-08-19T08:16:19Z]         	Test:       	TestGetAllServicesWithPagination
  | [2026-08-19T08:16:19Z]         	Messages:   	No error expected
  | [2026-08-19T08:16:19Z]     types.go:387: Found service state of '' for ray service 'slug'
  | [2026-08-19T08:16:19Z] ### FAIL: TestGetAllServicesWithPagination
```

Log:

```sh
W0819 08:16:13.799442       1 interceptor.go:18] Create ray service failed.: InternalServerError: Failed to create service for (first-muskox-1787127372801075197/slug): rayservices.ray.io "slug" already exists
```

We can see that it's because rayservice name already exists.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/4005

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
