### PR TITLE
[Docs] Fix DeletionStrategy godoc rendering in the generated API reference

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -216,8 +216,8 @@ _Appears in:_
 DeletionStrategy configures automated cleanup after the RayJob reaches a terminal state.
 Two mutually exclusive styles are supported:
 
-	Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
-	Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
+  - Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
+  - Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
 
 Semantics:
   - A non-empty deletionRules selects rules mode; empty lists are treated as unset.

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -89,8 +89,8 @@ const (
 // DeletionStrategy configures automated cleanup after the RayJob reaches a terminal state.
 // Two mutually exclusive styles are supported:
 //
-//	Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
-//	Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
+//   - Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
+//   - Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
 //
 // Semantics:
 //   - A non-empty deletionRules selects rules mode; empty lists are treated as unset.

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/deletionstrategy.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/deletionstrategy.go
@@ -8,8 +8,8 @@ package v1
 // DeletionStrategy configures automated cleanup after the RayJob reaches a terminal state.
 // Two mutually exclusive styles are supported:
 //
-// Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
-// Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
+// - Legacy: provide both onSuccess and onFailure (deprecated; removal planned for 1.6.0). May be combined with shutdownAfterJobFinishes and (optionally) global TTLSecondsAfterFinished.
+// - Rules: provide deletionRules (non-empty list). Rules mode is incompatible with shutdownAfterJobFinishes, legacy fields, and the global TTLSecondsAfterFinished (use per‑rule condition.ttlSeconds instead).
 //
 // Semantics:
 // - A non-empty deletionRules selects rules mode; empty lists are treated as unset.


### PR DESCRIPTION
## Why are these changes needed?

The `Legacy:`/`Rules:` lines in the `DeletionStrategy` comment block use godoc tab indentation, which crd-ref-docs renders as a preformatted code block in the generated `docs/reference/api.md` (and downstream in the API reference vendored into the Ray docs). This reflows the two lines to the same three-space bullet style already used by the neighboring Semantics/Validation lists, and commits the `make api-docs` regeneration. Comment content is unchanged.

## Related issue number

Fixes #5146

## Checks

- `make api-docs` run and the regenerated `docs/reference/api.md` committed (the two lines now render as list items instead of a code block); `gofmt` clean; `go vet ./apis/ray/v1/` clean.
- AI tooling was used in preparing this change. I have reviewed it and can explain every line.
