### PR TITLE
[CI] Upgrade Go version compatibility baseline to 1.27 (#5178)

### DIFF
--- a/.buildkite/test-e2e-kubernetes-was-v1alpha3.yml
+++ b/.buildkite/test-e2e-kubernetes-was-v1alpha3.yml
@@ -1,6 +1,6 @@
 - label: 'Test Kubernetes WAS v1alpha3 E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
 

--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test RayCluster and GCS E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -20,7 +20,7 @@
 
 - label: 'Test RayJob E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -40,7 +40,7 @@
 
 - label: 'Test E2E rayservice (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -60,7 +60,7 @@
 
 - label: 'Test E2E rayservice suspend (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -80,7 +80,7 @@
 
 - label: 'Test RayService Incremental Upgrade E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -113,7 +113,7 @@
 
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -133,7 +133,7 @@
 
 - label: 'Test Autoscaler E2E Part 2 (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -153,7 +153,7 @@
 
 - label: 'Test E2E Operator Version Upgrade (v1.7.0)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -172,7 +172,7 @@
 
 - label: 'Test Apiserver E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -195,7 +195,7 @@
 
 - label: 'Test RayJob Light Weight Submitter E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -216,7 +216,7 @@
 
 - label: 'Test RayCluster mTLS E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -237,7 +237,7 @@
 
 - label: 'Test RayCronJob E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-historyserver-e2e.yml
+++ b/.buildkite/test-historyserver-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test History Server E2E (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test E2E (kubectl-plugin)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-python-client.yml
+++ b/.buildkite/test-python-client.yml
@@ -1,6 +1,6 @@
 - label: 'Test Python Client'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -1,6 +1,6 @@
 - label: 'Test Sample YAMLs (nightly operator)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -21,7 +21,7 @@
 
 - label: 'Test Sample YAMLs (latest release)'
   instance_size: large
-  image: golang:1.26-bookworm
+  image: golang:1.27-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Use the same go version with build job
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Use the same go version with build job
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # Use the same go version with build job
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Update CRD/RBAC YAML files
         working-directory: ./ray-operator

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: v1.26
+        go-version: v1.27
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
@@ -113,7 +113,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: v1.26
+        go-version: v1.27
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
@@ -266,7 +266,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: v1.26
+        go-version: v1.27
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
@@ -345,7 +345,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: v1.26
+        go-version: v1.27
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6

--- a/.github/workflows/kubectl-plugin-release.yaml
+++ b/.github/workflows/kubectl-plugin-release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27"
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
@@ -172,7 +172,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: v1.26
+        go-version: v1.27
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
@@ -285,7 +285,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
@@ -316,7 +316,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: v1.26
+          go-version: v1.27
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,9 @@ linters:
             - '**/kubectl-plugin/pkg/util/*.go'
     modernize:
       disable:
+        # Go 1.27's embedlit analyzer rewrites a large part of the existing codebase.
+        # Keep this version upgrade focused; enable it in a dedicated cleanup.
+        - embedlit
         - omitzero
   exclusions:
     # Suppress SA1019 for the project's own deprecated API fields that are

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: _generated.go$|\.svg$|^third_party/|^proto/swagger/|^apiserver/pkg/swagger/datafile.go$|^docs/reference/api.md$|^config/grafana/|^dashboard/\.yarn/releases/yarn-.*\.cjs$
 
 default_language_version:
-  golang: 1.26.0
+  golang: 1.27.0
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -47,7 +47,7 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+          - github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
       - id: generate-crd-schema
         name: generate CRD schemas for use of kubeconform
         entry: ./scripts/generate-crd-schema.sh

--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This guide covers the purpose, requirements, and deployment of the Kuberay API S
 | Software | Version  |                                                                Link |
 |:---------|:--------:|--------------------------------------------------------------------:|
 | kubectl  | v1.18.3+ | [Download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
-| Go       |  v1.26+  |                                  [Download](https://golang.org/dl/) |
+| Go       |  v1.27+  |                                  [Download](https://golang.org/dl/) |
 | Docker   |  19.03+  |                        [Download](https://docs.docker.com/install/) |
 | GNU Make |  3.81+   |                                                                     |
 | curl     |  7.88+   |                                                                     |
@@ -22,7 +22,7 @@ Typing `make dev-tools` will download and install all of them. The `make clean-d
 | Software      | Version  |                                                                    Link |
 | :-------      | :------: | -----------------------------------------------------------------------:|
 | kind          | v0.19.0  | [Install](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
-| golangci-lint | v2.11.4  | [Install](https://golangci-lint.run/docs/welcome/install/local/)        |
+| golangci-lint | v2.13.1  | [Install](https://golangci-lint.run/docs/welcome/install/local/)        |
 | kustomize     | v3.8.7   | [install](https://kubectl.docs.kubernetes.io/installation/kustomize/)   |
 | gofumpt       | v0.3.1   | To install `go install mvdan.cc/gofumpt@v0.3.1`                         |
 | goimports     | latest   | To install `go install golang.org/x/tools/cmd/goimports@latest`         |

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the backend service
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 
 WORKDIR /workspace
 

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -110,11 +110,6 @@ generate: mockgen # Generate code using command after //go:generate in each file
 
 ##@ Testing
 
-# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
-# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
-GOVERSION := $(shell go env GOVERSION)
-export GOTOOLCHAIN := $(GOVERSION)+auto
-
 .PHONY: test
 test: fmt vet fumpt imports generate ## Run all unit tests.
 	go test ./pkg/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out -parallel 4
@@ -260,7 +255,7 @@ MOCKGEN = $(REPO_ROOT_BIN)/mockgen
 KUSTOMIZE_VERSION ?= v5.4.3
 GOFUMPT_VERSION ?= v0.3.1
 GOIMPORTS_VERSION ?= v0.14.0
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.13.1
 KIND_VERSION ?= v0.19.0
 GOBINDATA_VERSION ?= v4.0.2
 MOCKGEN_VERSION ?= v1.6.0
@@ -284,7 +279,7 @@ $(GOFUMPT): $(REPO_ROOT_BIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci_lint locally if necessary.
 $(GOLANGCI_LINT): $(REPO_ROOT_BIN)
-	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
+	test -s $(GOLANGCI_LINT) || (curl -sSfL https://golangci-lint.run/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -230,7 +230,7 @@ func serveSwaggerFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p := strings.TrimPrefix(r.URL.Path, "/swagger/")
+	p := path.Base(r.URL.Path)
 	if strings.TrimSpace(*localSwaggerPath) != "" {
 		// use the specified path,  for development the is  `${REPO_ROOT}/proto/swagger`.
 		p = path.Join(*localSwaggerPath, "/", p)

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -670,7 +670,7 @@ func (krc *KuberayAPIServerClient) executeRequest(httpRequest *http.Request, URL
 			httpRequest.Body = io.NopCloser(bytes.NewBuffer(requestBodyBytes))
 		}
 
-		response, err := krc.httpClient.Do(httpRequest) //nolint:gosec // URL is constructed from internal config, not user input
+		response, err := krc.httpClient.Do(httpRequest)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to execute http request for url '%s': %w", URL, err)
 		}

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -557,7 +557,7 @@ func TestBuildHeadPodTemplate(t *testing.T) {
 	if podSpec.Spec.ImagePullSecrets[0].Name != "foo" {
 		t.Errorf("failed to propagate image pull secret")
 	}
-	if (string)(podSpec.Spec.Containers[0].ImagePullPolicy) != "Always" {
+	if string(podSpec.Spec.Containers[0].ImagePullPolicy) != "Always" {
 		t.Errorf("failed to propagate image pull policy")
 	}
 	if len(podSpec.Spec.Containers[0].Env) != 6 {
@@ -697,8 +697,8 @@ func TestConvertAutoscalerOptions(t *testing.T) {
 	options, err := buildAutoscalerOptions(&testAutoscalerOptions)
 	require.NoError(t, err)
 	assert.Equal(t, int32(25), *options.IdleTimeoutSeconds)
-	assert.Equal(t, (string)(*options.UpscalingMode), "Default")
-	assert.Equal(t, (string)(*options.ImagePullPolicy), "Always")
+	assert.Equal(t, "Default", string(*options.UpscalingMode))
+	assert.Equal(t, "Always", string(*options.ImagePullPolicy))
 	assert.Len(t, options.Env, 1)
 	assert.Len(t, options.EnvFrom, 2)
 	assert.Len(t, options.VolumeMounts, 2)

--- a/apiserversdk/Makefile
+++ b/apiserversdk/Makefile
@@ -6,7 +6,7 @@ $(LOCALBIN):
 REPO_ROOT := $(shell dirname ${PWD})
 REPO_ROOT_BIN := $(REPO_ROOT)/bin
 GOLANGCI_LINT ?= $(REPO_ROOT_BIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.13.1
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
@@ -22,16 +22,11 @@ vet: ## Run go vet against code.
 
 .PHONY: golangci-lint
 golangci-lint: ## Download golangci_lint locally if necessary.
-	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
+	test -s $(GOLANGCI_LINT) || (curl -sSfL https://golangci-lint.run/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
 
 .PHONY: lint
 lint: golangci-lint fmt vet ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --allow-parallel-runners)
-
-# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
-# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
-GOVERSION := $(shell go env GOVERSION)
-export GOTOOLCHAIN := $(GOVERSION)+auto
 
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: ENVTEST_K8S_VERSION ?= 1.37.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0

--- a/historyserver/DEVELOPMENT.md
+++ b/historyserver/DEVELOPMENT.md
@@ -21,7 +21,7 @@ S3-compatible object store, and browse the UI through the Ray Dashboard's middle
 ## Prerequisites
 
 - Kind, kubectl
-- Go v1.25+
+- Go v1.27+
 - Docker
 - GNU Make
 - K9s (optional)

--- a/historyserver/Dockerfile.collector
+++ b/historyserver/Dockerfile.collector
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 
 ARG GOPROXY=https://proxy.golang.org,direct
 ARG ENABLE_RACE=false

--- a/historyserver/Dockerfile.historyserver
+++ b/historyserver/Dockerfile.historyserver
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=${GOPROXY}

--- a/historyserver/Makefile
+++ b/historyserver/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-GOLANGCILINT_VERSION ?= v2.11.3
+GOLANGCILINT_VERSION ?= v2.13.1
 GOBIN := $(shell go env GOPATH)/bin
 GOBIN_GOLANGCILINT := $(GOBIN)/golangci-lint
 
@@ -130,11 +130,6 @@ ifeq ($(ENGINE),docker)
 	${ENGINE} buildx use $(DOCKERBUILDER_INSTANCE) || ${ENGINE} buildx create --name $(DOCKERBUILDER_INSTANCE)
 	${ENGINE} buildx use $(DOCKERBUILDER_INSTANCE)
 endif
-
-# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
-# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
-GOVERSION := $(shell go env GOVERSION)
-export GOTOOLCHAIN := $(GOVERSION)+auto
 
 # Run tests
 .PHONY: test

--- a/historyserver/README.md
+++ b/historyserver/README.md
@@ -17,7 +17,7 @@ The History Server consists of two main components:
 
 ### Prerequisites
 
-- Go 1.19 or higher
+- Go 1.27 or higher
 - Docker (for building container images)
 - Make
 

--- a/historyserver/docs/README.md
+++ b/historyserver/docs/README.md
@@ -38,7 +38,7 @@ The History Server supports multiple storage backends:
 
 ### Prerequisites
 
-- Go v1.24+
+- Go v1.27+
 - Docker
 - Kind
 - kubectl

--- a/historyserver/docs/set_up_collector.md
+++ b/historyserver/docs/set_up_collector.md
@@ -33,9 +33,9 @@ guideline to set up the Collector component for local development and testing.
 
 ### Prerequisites
 
-Please ensure your environment matches the version requirements specified in the [ray-operator development guide](https://github.com/ray-project/kuberay/blob/2959d7d8a4174eedbf7b4a71a79219547f62cc82/ray-operator/DEVELOPMENT.md):
+Please ensure your environment matches the version requirements specified in the [ray-operator development guide](../../ray-operator/DEVELOPMENT.md):
 
-- Go v1.24+
+- Go v1.27+
 - Docker: Engine for building the container image
 - GNU Make
 - K9s (optional)

--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -5,7 +5,7 @@
 - Kind
 - Docker
 - kubectl
-- Go 1.24+
+- Go 1.27+
 
 ## Setup Steps
 

--- a/historyserver/go.mod
+++ b/historyserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay/historyserver
 
-go 1.26.0
+go 1.27.0
 
 require (
 	cloud.google.com/go/storage v1.59.2
@@ -14,76 +14,18 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/fsouza/fake-gcs-server v1.53.1
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/onsi/gomega v1.39.0
 	github.com/ray-project/kuberay/ray-operator v1.6.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.22.0
 	google.golang.org/api v0.264.0
+	k8s.io/api v0.37.0
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
 	sigs.k8s.io/controller-runtime v0.24.1
-)
-
-require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
-	github.com/alibabacloud-go/debug v1.0.1 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-openapi/jsonpointer v1.0.0 // indirect
-	github.com/go-openapi/jsonreference v1.0.0 // indirect
-	github.com/go-openapi/swag v0.27.1 // indirect
-	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0
-	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.27.4 // indirect
-	github.com/openshift/api v0.0.0-20251214014457-bfa868a22401 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	go.opentelemetry.io/otel v1.41.0 // indirect
-	go.opentelemetry.io/otel/trace v1.41.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0
-	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.37.0
-	k8s.io/apiextensions-apiserver v0.36.0 // indirect
-	k8s.io/apiserver v0.36.0 // indirect
-	k8s.io/component-base v0.36.0 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
-	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
-	sigs.k8s.io/gateway-api v1.4.1 // indirect
-	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 require (
@@ -100,13 +42,25 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/alibabacloud-go/debug v1.0.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-openapi/jsonpointer v1.0.0 // indirect
+	github.com/go-openapi/jsonreference v1.0.0 // indirect
+	github.com/go-openapi/swag v0.27.1 // indirect
 	github.com/go-openapi/swag/cmdutils v0.27.1 // indirect
 	github.com/go-openapi/swag/conv v0.27.1 // indirect
 	github.com/go-openapi/swag/fileutils v0.27.1 // indirect
@@ -118,39 +72,82 @@ require (
 	github.com/go-openapi/swag/stringutils v0.27.1 // indirect
 	github.com/go-openapi/swag/typeutils v0.27.1 // indirect
 	github.com/go-openapi/swag/yamlutils v0.27.1 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
 	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/ginkgo/v2 v2.27.4 // indirect
+	github.com/openshift/api v0.0.0-20251214014457-bfa868a22401 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/xattr v0.4.12 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/smallnest/chanx v1.2.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
+	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.36.0 // indirect
+	k8s.io/apiserver v0.36.0 // indirect
+	k8s.io/component-base v0.36.0 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	k8s.io/streaming v0.37.0 // indirect
+	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
+	sigs.k8s.io/gateway-api v1.4.1 // indirect
+	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/kubectl-plugin/DEVELOPMENT.md
+++ b/kubectl-plugin/DEVELOPMENT.md
@@ -7,7 +7,7 @@ This section walks through how to build and test the plugin.
 | software | version  | link                         |
 |:---------|:---------|:-----------------------------|
 | kubectl  |  >= 1.23 | [download][download-kubectl] |
-| go       |  v1.26   | [download-go]                |
+| go       |  v1.27   | [download-go]                |
 
 ## IDE Setup (VS Code)
 

--- a/podpool/go.mod
+++ b/podpool/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay/podpool
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/sirupsen/logrus v1.9.4

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client code (go & json) from API protocol buffers
-FROM golang:1.26-bookworm AS generator
+FROM golang:1.27-bookworm AS generator
 
 ENV PROTOC_VERSION 29.2
 ENV GOLANG_PROTOBUF_VERSION v1.36.1

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This section walks through how to build and test the operator in a running Kuber
 | software | version  |                                                                link |
 |:---------|:--------:|--------------------------------------------------------------------:|
 | kubectl  | v1.23.0+ | [download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
-| go       |  v1.26   |                                  [download](https://golang.org/dl/) |
+| go       |  v1.27   |                                  [download](https://golang.org/dl/) |
 | docker   |  19.03+  |                        [download](https://docs.docker.com/install/) |
 
 Alternatively, you can use podman (version 4.5+) instead of docker. See [podman.io](https://podman.io/getting-started/installation) for installation instructions. The Makefile allows you to specify the container engine to use via the `ENGINE` variable. For example, to use podman, you can run `ENGINE=podman make docker-build`.
@@ -19,14 +19,14 @@ The instructions assume you have access to a running Kubernetes cluster via `kub
 
 For local development, we recommend using [Kind](https://kind.sigs.k8s.io/) to create a Kubernetes cluster.
 
-### Use go v1.26
+### Use go v1.27
 
-Currently, KubeRay uses go v1.26 for development.
+Currently, KubeRay uses go v1.27 for development.
 
 ```bash
-go install golang.org/dl/go1.26.0@latest
-go1.26.0 download
-export GOROOT=$(go1.26.0 env GOROOT)
+go install golang.org/dl/go1.27.0@latest
+go1.27.0 download
+export GOROOT=$(go1.27.0 env GOROOT)
 export PATH="$GOROOT/bin:$PATH"
 ```
 

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -62,11 +62,6 @@ vet: ## Run go vet against code.
 fumpt: gofumpt
 	$(GOFUMPT) -l -w ../
 
-# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
-# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
-GOVERSION := $(shell go env GOVERSION)
-export GOTOOLCHAIN := $(GOVERSION)+auto
-
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: ENVTEST_K8S_VERSION ?= 1.37.0
 test: manifests fmt vet envtest ## Run tests.

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -200,7 +200,7 @@ var _ = Context("RayJob with different submission modes", func() {
 					job := &batchv1.Job{}
 					err := k8sClient.Get(ctx, namespacedName, job)
 					Expect(err).NotTo(HaveOccurred(), "failed to get Kubernetes Job")
-					Expect(*(job.Spec.BackoffLimit)).To(Equal(backoffLimit))
+					Expect(*job.Spec.BackoffLimit).To(Equal(backoffLimit))
 				}
 			})
 		})

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -416,8 +416,8 @@ var (
 )
 
 func RayClusterReplicaFailureReason(err error) string {
-	var failure *errRayClusterReplicaFailure
-	if errors.As(err, &failure) {
+	failure, ok := errors.AsType[*errRayClusterReplicaFailure](err)
+	if ok {
 		return failure.reason
 	}
 	return ""

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay/ray-operator
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -249,7 +249,8 @@ func TestRayClusterAutoscalerWithFakeTPU(t *testing.T) {
 				// It's not possible to wait on idle timeout since the required TPU nodeSelectors prevent scheduling.
 				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
-				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = Ptr(int32(0))
+				zero := int32(0)
+				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = &zero
 				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)

--- a/ray-operator/test/support/support.go
+++ b/ray-operator/test/support/support.go
@@ -92,7 +92,7 @@ func RayClusterSpecWith(spec *rayv1ac.RayClusterSpecApplyConfiguration, options 
 
 func MountConfigMap[T rayv1ac.RayClusterSpecApplyConfiguration | corev1ac.PodTemplateSpecApplyConfiguration](configMap *corev1.ConfigMap, mountPath string) SupportOption[T] {
 	return func(t *T) *T {
-		switch obj := (any)(t).(type) {
+		switch obj := any(t).(type) {
 		case *rayv1ac.RayClusterSpecApplyConfiguration:
 			obj.HeadGroupSpec.Template.Spec.Containers[0].WithVolumeMounts(corev1ac.VolumeMount().
 				WithName(configMap.Name).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?

This change aligns the Kuberay repository with Go 1.27 after recent CI and build-tooling compatibility differences. It updates Go toolchain declarations, build/test images, and lint/tooling references to keep CI and local workflows consistent and avoid version drift between components.

## Related issue number

Closes #5178

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [x] This PR is not tested :(

