### PR TITLE
[kubectl-plugin] create cluster --file should not discard worker grou…

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -346,8 +346,8 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 	return nil
 }
 
-// warnOnEmptyWorkerGroups warns about worker groups that will start with no worker pods. 0 replicas
-// is valid when the autoscaler can scale the group up, so this never fails the command.
+// warnOnEmptyWorkerGroups warns about each worker group that will start with no worker pods. 0
+// replicas is valid when the autoscaler can scale the group up, so this never fails the command.
 func (options *CreateClusterOptions) warnOnEmptyWorkerGroups() {
 	if options.rayClusterConfig.Autoscaler != nil && options.rayClusterConfig.Autoscaler.Version != "" {
 		return
@@ -358,7 +358,7 @@ func (options *CreateClusterOptions) warnOnEmptyWorkerGroups() {
 			continue
 		}
 		name := ptr.Deref(workerGroup.Name, fmt.Sprintf("#%d", i))
-		fmt.Fprintf(options.ioStreams.ErrOut, "Warning: worker group %q has 0 replicas, so the cluster will start with no worker pods.\n", name)
+		fmt.Fprintf(options.ioStreams.ErrOut, "Warning: worker group %q has 0 replicas and will start with no worker pods.\n", name)
 	}
 }
 

--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/ptr"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
@@ -293,7 +294,7 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 			WorkerGroups: []generation.WorkerGroup{
 				{
 					Name:             new("default-group"),
-					Replicas:         options.workerReplicas,
+					Replicas:         &options.workerReplicas,
 					NumOfHosts:       &options.numOfHosts,
 					CPU:              &options.workerCPU,
 					Memory:           &options.workerMemory,
@@ -309,6 +310,8 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 			},
 		}
 	}
+
+	options.warnOnEmptyWorkerGroups()
 
 	rayClusterac = options.rayClusterConfig.GenerateRayClusterApplyConfig()
 
@@ -341,6 +344,22 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 	}
 
 	return nil
+}
+
+// warnOnEmptyWorkerGroups warns about worker groups that will start with no worker pods. 0 replicas
+// is valid when the autoscaler can scale the group up, so this never fails the command.
+func (options *CreateClusterOptions) warnOnEmptyWorkerGroups() {
+	if options.rayClusterConfig.Autoscaler != nil && options.rayClusterConfig.Autoscaler.Version != "" {
+		return
+	}
+
+	for i, workerGroup := range options.rayClusterConfig.WorkerGroups {
+		if ptr.Deref(workerGroup.Replicas, util.DefaultWorkerReplicas) != 0 {
+			continue
+		}
+		name := ptr.Deref(workerGroup.Name, fmt.Sprintf("#%d", i))
+		fmt.Fprintf(options.ioStreams.ErrOut, "Warning: worker group %q has 0 replicas, so the cluster will start with no worker pods.\n", name)
+	}
 }
 
 // clusterExists checks if a RayCluster with the given name exists in the given namespace

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -247,9 +247,11 @@ func TestRayClusterCreateClusterRun(t *testing.T) {
 	namespace := "namespace-1"
 	clusterName := "cluster-1"
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 
 	options := CreateClusterOptions{
 		cmdFactory:   cmdFactory,
+		ioStreams:    &testStreams,
 		clusterName:  clusterName,
 		labels:       map[string]string{"app": "ray", "env": "dev"},
 		annotations:  map[string]string{"ttl-hours": "24", "owner": "chthulu"},
@@ -280,6 +282,110 @@ func TestRayClusterCreateClusterRun(t *testing.T) {
 		err := options.Run(context.Background(), k8sClients)
 		require.Error(t, err)
 	})
+}
+
+// A config file must produce the same RayCluster as the equivalent command-line flags. Anything the
+// file leaves out gets the documented default rather than the zero value.
+// See https://github.com/ray-project/kuberay/issues/5165.
+func TestRayCreateClusterConfigFileMatchesFlags(t *testing.T) {
+	kubeConfig, err := createTempKubeConfigFile(t, "")
+	require.NoError(t, err)
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(&genericclioptions.ConfigFlags{KubeConfig: &kubeConfig})
+
+	configFile := filepath.Join(t.TempDir(), "cluster.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("ray-version: 2.56.0\nworker-groups:\n  - cpu: 3\n"), 0o600))
+
+	rayClusterConfig, err := generation.ParseConfigFile(configFile)
+	require.NoError(t, err)
+
+	k8sClients := client.NewClientForTesting(kubefake.NewClientset(), clienttesting.NewRayClientset())
+
+	fromFile := NewCreateClusterOptions(cmdFactory, testStreams)
+	fromFile.clusterName = "cluster-1"
+	fromFile.dryRun = true
+	fromFile.rayClusterConfig = rayClusterConfig
+	require.NoError(t, fromFile.Run(context.Background(), k8sClients))
+
+	// The same values passed as flags, with every other flag left at its cobra default
+	fromFlags := NewCreateClusterOptions(cmdFactory, testStreams)
+	fromFlags.clusterName = "cluster-1"
+	fromFlags.dryRun = true
+	fromFlags.namespace = "default"
+	fromFlags.rayVersion = "2.56.0"
+	fromFlags.image = "rayproject/ray:2.56.0"
+	fromFlags.headCPU = util.DefaultHeadCPU
+	fromFlags.headMemory = util.DefaultHeadMemory
+	fromFlags.headGPU = util.DefaultHeadGPU
+	fromFlags.headEphemeralStorage = util.DefaultHeadEphemeralStorage
+	fromFlags.headRayStartParams = make(map[string]string)
+	fromFlags.headNodeSelectors = make(map[string]string)
+	fromFlags.workerReplicas = util.DefaultWorkerReplicas
+	fromFlags.numOfHosts = util.DefaultNumOfHosts
+	fromFlags.workerCPU = "3"
+	fromFlags.workerMemory = util.DefaultWorkerMemory
+	fromFlags.workerGPU = util.DefaultWorkerGPU
+	fromFlags.workerTPU = util.DefaultWorkerTPU
+	fromFlags.workerEphemeralStorage = util.DefaultWorkerEphemeralStorage
+	fromFlags.workerRayStartParams = make(map[string]string)
+	fromFlags.workerNodeSelectors = make(map[string]string)
+	require.NoError(t, fromFlags.Run(context.Background(), k8sClients))
+
+	require.Equal(t,
+		fromFlags.rayClusterConfig.GenerateRayClusterApplyConfig().Spec,
+		fromFile.rayClusterConfig.GenerateRayClusterApplyConfig().Spec,
+	)
+}
+
+func TestRayCreateClusterWarnsOnZeroWorkerReplicas(t *testing.T) {
+	kubeConfig, err := createTempKubeConfigFile(t, "")
+	require.NoError(t, err)
+	cmdFactory := cmdutil.NewFactory(&genericclioptions.ConfigFlags{KubeConfig: &kubeConfig})
+
+	tests := map[string]struct {
+		config         string
+		expectedWarned bool
+	}{
+		"should warn when a worker group is explicitly set to 0 replicas": {
+			config:         "worker-groups:\n  - cpu: 3\n    replicas: 0\n",
+			expectedWarned: true,
+		},
+		"should not warn when the replicas are defaulted": {
+			config:         "worker-groups:\n  - cpu: 3\n",
+			expectedWarned: false,
+		},
+		"should not warn when the autoscaler can scale the group up": {
+			config:         "autoscaler:\n  version: v2\nworker-groups:\n  - cpu: 3\n    replicas: 0\n",
+			expectedWarned: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			configFile := filepath.Join(t.TempDir(), "cluster.yaml")
+			require.NoError(t, os.WriteFile(configFile, []byte(tc.config), 0o600))
+
+			rayClusterConfig, err := generation.ParseConfigFile(configFile)
+			require.NoError(t, err)
+
+			testStreams, _, _, errOut := genericclioptions.NewTestIOStreams()
+			options := NewCreateClusterOptions(cmdFactory, testStreams)
+			options.clusterName = "cluster-1"
+			options.dryRun = true
+			options.rayClusterConfig = rayClusterConfig
+
+			k8sClients := client.NewClientForTesting(kubefake.NewClientset(), clienttesting.NewRayClientset())
+
+			// 0 replicas is a valid configuration, so the command still succeeds
+			require.NoError(t, options.Run(context.Background(), k8sClients))
+
+			if tc.expectedWarned {
+				require.Contains(t, errOut.String(), `Warning: worker group "default-group" has 0 replicas`)
+			} else {
+				require.Empty(t, errOut.String())
+			}
+		})
+	}
 }
 
 func TestNewCreateClusterCommand(t *testing.T) {

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -343,20 +344,24 @@ func TestRayCreateClusterWarnsOnZeroWorkerReplicas(t *testing.T) {
 	cmdFactory := cmdutil.NewFactory(&genericclioptions.ConfigFlags{KubeConfig: &kubeConfig})
 
 	tests := map[string]struct {
-		config         string
-		expectedWarned bool
+		config           string
+		expectedWarnings []string
 	}{
 		"should warn when a worker group is explicitly set to 0 replicas": {
-			config:         "worker-groups:\n  - cpu: 3\n    replicas: 0\n",
-			expectedWarned: true,
+			config:           "worker-groups:\n  - cpu: 3\n    replicas: 0\n",
+			expectedWarnings: []string{`Warning: worker group "default-group" has 0 replicas and will start with no worker pods.`},
+		},
+		"should warn only about the empty group when another group has replicas": {
+			config: "worker-groups:\n  - name: cpu-workers\n    replicas: 3\n  - name: gpu-workers\n    replicas: 0\n",
+			expectedWarnings: []string{
+				`Warning: worker group "gpu-workers" has 0 replicas and will start with no worker pods.`,
+			},
 		},
 		"should not warn when the replicas are defaulted": {
-			config:         "worker-groups:\n  - cpu: 3\n",
-			expectedWarned: false,
+			config: "worker-groups:\n  - cpu: 3\n",
 		},
 		"should not warn when the autoscaler can scale the group up": {
-			config:         "autoscaler:\n  version: v2\nworker-groups:\n  - cpu: 3\n    replicas: 0\n",
-			expectedWarned: false,
+			config: "autoscaler:\n  version: v2\nworker-groups:\n  - cpu: 3\n    replicas: 0\n",
 		},
 	}
 
@@ -379,11 +384,16 @@ func TestRayCreateClusterWarnsOnZeroWorkerReplicas(t *testing.T) {
 			// 0 replicas is a valid configuration, so the command still succeeds
 			require.NoError(t, options.Run(context.Background(), k8sClients))
 
-			if tc.expectedWarned {
-				require.Contains(t, errOut.String(), `Warning: worker group "default-group" has 0 replicas`)
-			} else {
+			if len(tc.expectedWarnings) == 0 {
 				require.Empty(t, errOut.String())
+				return
 			}
+			for _, warning := range tc.expectedWarnings {
+				require.Contains(t, errOut.String(), warning)
+			}
+			// The warning is about the group, not the cluster: a group with replicas cannot be
+			// warned about, and the cluster as a whole may still get worker pods.
+			require.Len(t, strings.Split(strings.TrimSpace(errOut.String()), "\n"), len(tc.expectedWarnings))
 		})
 	}
 }

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -358,7 +358,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 						CPU:           &options.workerCPU,
 						Memory:        &options.workerMemory,
 						GPU:           &options.workerGPU,
-						Replicas:      options.workerReplicas,
+						Replicas:      &options.workerReplicas,
 						NodeSelectors: options.workerNodeSelectors,
 					},
 				},

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -431,7 +431,9 @@ func applyDefaults(config *RayClusterConfig) {
 		config.Head.Memory = ptr.To(util.DefaultHeadMemory)
 	}
 
-	if len(config.WorkerGroups) == 0 {
+	// A nil list means the user did not mention worker groups at all. An explicitly empty list is a
+	// head-only cluster, which is valid, so it must not be replaced with a default group.
+	if config.WorkerGroups == nil {
 		config.WorkerGroups = []WorkerGroup{{}}
 	}
 	for i := range config.WorkerGroups {

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -58,7 +58,7 @@ type WorkerGroup struct {
 	EphemeralStorage *string           `yaml:"ephemeral-storage,omitempty"`
 	RayStartParams   map[string]string `yaml:"ray-start-params,omitempty"`
 	NodeSelectors    map[string]string `yaml:"node-selectors,omitempty"`
-	Replicas         int32             `yaml:"replicas"`
+	Replicas         *int32            `yaml:"replicas,omitempty"`
 }
 
 type AutoscalerVersion string
@@ -235,12 +235,7 @@ func (rayClusterConfig *RayClusterConfig) generateRayClusterSpec() *rayv1ac.RayC
 	workerGroupSpecs := make([]*rayv1ac.WorkerGroupSpecApplyConfiguration, len(rayClusterConfig.WorkerGroups))
 	for i, workerGroup := range rayClusterConfig.WorkerGroups {
 		if workerGroup.Name == nil || *workerGroup.Name == "" {
-			name := "default-group"
-			// For backwards compatibility, if no name is specified, use "default-group"
-			if i != 0 {
-				name = fmt.Sprintf("default-group-%d", i)
-			}
-			workerGroup.Name = new(name)
+			workerGroup.Name = new(defaultWorkerGroupName(i))
 		}
 
 		workerRequestResources := generateRequestResources(workerGroup.CPU, workerGroup.Memory, workerGroup.EphemeralStorage, workerGroup.GPU, workerGroup.TPU)
@@ -249,7 +244,7 @@ func (rayClusterConfig *RayClusterConfig) generateRayClusterSpec() *rayv1ac.RayC
 		workerGroupSpecs[i] = rayv1ac.WorkerGroupSpec().
 			WithRayStartParams(workerGroup.RayStartParams).
 			WithGroupName(*workerGroup.Name).
-			WithReplicas(workerGroup.Replicas).
+			WithReplicas(ptr.Deref(workerGroup.Replicas, util.DefaultWorkerReplicas)).
 			WithTemplate(corev1ac.PodTemplateSpec().
 				WithSpec(corev1ac.PodSpec().
 					WithNodeSelector(workerGroup.NodeSelectors).
@@ -413,24 +408,59 @@ func ConvertRayJobApplyConfigToYaml(rayJobac *rayv1ac.RayJobApplyConfiguration) 
 	return string(podByte), nil
 }
 
-// newRayClusterConfigWithDefaults returns a new RayClusterConfig object with default values
-func newRayClusterConfigWithDefaults() *RayClusterConfig {
-	return &RayClusterConfig{
-		RayVersion: ptr.To(util.RayVersion),
-		Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
-		Head: &Head{
-			CPU:    ptr.To(util.DefaultHeadCPU),
-			Memory: ptr.To(util.DefaultHeadMemory),
-		},
-		WorkerGroups: []WorkerGroup{
-			{
-				Name:     new("default-group"),
-				Replicas: util.DefaultWorkerReplicas,
-				CPU:      ptr.To(util.DefaultWorkerCPU),
-				Memory:   ptr.To(util.DefaultWorkerMemory),
-			},
-		},
+// applyDefaults fills in the fields the user did not set. It must run after unmarshalling, not by
+// unmarshalling on top of a pre-populated object: yaml.v2 rebuilds slices from scratch, so any
+// default seeded into WorkerGroups is discarded as soon as the file mentions "worker-groups".
+func applyDefaults(config *RayClusterConfig) {
+	if config.RayVersion == nil || *config.RayVersion == "" {
+		config.RayVersion = ptr.To(util.RayVersion)
 	}
+
+	// The image follows the Ray version, so this must come after the Ray version default
+	if config.Image == nil || *config.Image == "" {
+		config.Image = new(fmt.Sprintf("rayproject/ray:%s", *config.RayVersion))
+	}
+
+	if config.Head == nil {
+		config.Head = &Head{}
+	}
+	if config.Head.CPU == nil || *config.Head.CPU == "" {
+		config.Head.CPU = ptr.To(util.DefaultHeadCPU)
+	}
+	if config.Head.Memory == nil || *config.Head.Memory == "" {
+		config.Head.Memory = ptr.To(util.DefaultHeadMemory)
+	}
+
+	if len(config.WorkerGroups) == 0 {
+		config.WorkerGroups = []WorkerGroup{{}}
+	}
+	for i := range config.WorkerGroups {
+		workerGroup := &config.WorkerGroups[i]
+		if workerGroup.Name == nil || *workerGroup.Name == "" {
+			workerGroup.Name = new(defaultWorkerGroupName(i))
+		}
+		if workerGroup.Replicas == nil {
+			workerGroup.Replicas = ptr.To(util.DefaultWorkerReplicas)
+		}
+		if workerGroup.NumOfHosts == nil {
+			workerGroup.NumOfHosts = ptr.To(int32(util.DefaultNumOfHosts))
+		}
+		if workerGroup.CPU == nil || *workerGroup.CPU == "" {
+			workerGroup.CPU = ptr.To(util.DefaultWorkerCPU)
+		}
+		if workerGroup.Memory == nil || *workerGroup.Memory == "" {
+			workerGroup.Memory = ptr.To(util.DefaultWorkerMemory)
+		}
+	}
+}
+
+// defaultWorkerGroupName returns the name given to the worker group at index i when the user did not name it
+func defaultWorkerGroupName(i int) string {
+	// For backwards compatibility, the first group is named "default-group"
+	if i == 0 {
+		return "default-group"
+	}
+	return fmt.Sprintf("default-group-%d", i)
 }
 
 // ParseConfigFile parses the YAML configuration file into a RayClusterConfig object
@@ -444,10 +474,11 @@ func ParseConfigFile(filePath string) (*RayClusterConfig, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	config := newRayClusterConfigWithDefaults()
-	if err := yaml.UnmarshalStrict(data, &config); err != nil {
+	config := &RayClusterConfig{}
+	if err := yaml.UnmarshalStrict(data, config); err != nil {
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
+	applyDefaults(config)
 
 	return config, nil
 }

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -834,25 +834,37 @@ func TestApplyDefaults(t *testing.T) {
 	})
 
 	t.Run("should not overwrite values the user already set", func(t *testing.T) {
-		result := &RayClusterConfig{
-			RayVersion: new("2.56.0"),
-			Image:      new("my-registry/my-ray:custom"),
-			Head:       &Head{CPU: new("8"), Memory: new("16Gi")},
-			WorkerGroups: []WorkerGroup{
-				{
-					Name:       new("gpu-workers"),
-					CPU:        new("4"),
-					Memory:     new("32Gi"),
-					Replicas:   new(int32(0)),
-					NumOfHosts: new(int32(4)),
+		// Both sides must be built independently: a copy of the struct would share the Head pointer
+		// and the WorkerGroups backing array that applyDefaults writes to in place.
+		build := func() *RayClusterConfig {
+			return &RayClusterConfig{
+				RayVersion: new("2.56.0"),
+				Image:      new("my-registry/my-ray:custom"),
+				Head:       &Head{CPU: new("8"), Memory: new("16Gi")},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("gpu-workers"),
+						CPU:        new("4"),
+						Memory:     new("32Gi"),
+						Replicas:   new(int32(0)),
+						NumOfHosts: new(int32(4)),
+					},
 				},
-			},
+			}
 		}
-		expected := *result
+
+		result := build()
+		applyDefaults(result)
+
+		assert.Equal(t, build(), result)
+	})
+
+	t.Run("should keep an explicitly empty worker group list", func(t *testing.T) {
+		result := &RayClusterConfig{WorkerGroups: []WorkerGroup{}}
 
 		applyDefaults(result)
 
-		assert.Equal(t, &expected, result)
+		assert.Empty(t, result.WorkerGroups)
 	})
 }
 
@@ -937,6 +949,22 @@ func TestParseConfigFile(t *testing.T) {
 						Memory:     new("4Gi"),
 					},
 				},
+			},
+		},
+		// An explicitly empty list is a head-only cluster, not "the user said nothing"
+		"explicitly empty worker groups": {
+			config: `head:
+  cpu: 4
+worker-groups: []
+`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    new("4"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{},
 			},
 		},
 		// An explicit "replicas: 0" must survive defaulting

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -46,7 +46,7 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 		},
 		WorkerGroups: []WorkerGroup{
 			{
-				Replicas:   int32(3),
+				Replicas:   new(int32(3)),
 				NumOfHosts: new(int32(2)),
 				CPU:        new("2"),
 				Memory:     new("10Gi"),
@@ -179,7 +179,7 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 			},
 			WorkerGroups: []WorkerGroup{
 				{
-					Replicas:   int32(3),
+					Replicas:   new(int32(3)),
 					NumOfHosts: new(int32(2)),
 					CPU:        new("2"),
 					Memory:     new("10Gi"),
@@ -310,7 +310,7 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 		},
 		WorkerGroups: []WorkerGroup{
 			{
-				Replicas:   int32(3),
+				Replicas:   new(int32(3)),
 				NumOfHosts: new(int32(2)),
 				CPU:        new("2"),
 				Memory:     new("10Gi"),
@@ -476,7 +476,7 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 		},
 		WorkerGroups: []WorkerGroup{
 			{
-				Replicas:   int32(3),
+				Replicas:   new(int32(3)),
 				NumOfHosts: new(int32(1)),
 				CPU:        new("2"),
 				Memory:     new("10Gi"),
@@ -585,7 +585,8 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 			},
 			{
 				GroupName: new("worker-group-2"),
-				Replicas:  new(int32(0)),
+				// This group does not set replicas, so it falls back to the default rather than 0
+				Replicas: new(int32(1)),
 				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 					Spec: &corev1ac.PodSpecApplyConfiguration{
 						ServiceAccountName: new("my-service-account"),
@@ -806,26 +807,53 @@ func TestSetGCSFuseOptions(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestNewRayClusterConfigWithDefaults(t *testing.T) {
-	result := newRayClusterConfigWithDefaults()
-	expected := &RayClusterConfig{
-		Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
-		RayVersion: ptr.To(util.RayVersion),
-		Head: &Head{
-			CPU:    new("2"),
-			Memory: new("4Gi"),
-		},
-		WorkerGroups: []WorkerGroup{
-			{
-				Name:     new("default-group"),
-				CPU:      new("2"),
-				Memory:   new("4Gi"),
-				Replicas: int32(1),
-			},
-		},
-	}
+func TestApplyDefaults(t *testing.T) {
+	t.Run("should fill in every default for an empty config", func(t *testing.T) {
+		result := &RayClusterConfig{}
+		applyDefaults(result)
 
-	assert.Equal(t, expected, result)
+		expected := &RayClusterConfig{
+			Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+			RayVersion: ptr.To(util.RayVersion),
+			Head: &Head{
+				CPU:    new("2"),
+				Memory: new("4Gi"),
+			},
+			WorkerGroups: []WorkerGroup{
+				{
+					Name:       new("default-group"),
+					CPU:        new("2"),
+					Memory:     new("4Gi"),
+					Replicas:   new(int32(1)),
+					NumOfHosts: new(int32(1)),
+				},
+			},
+		}
+
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("should not overwrite values the user already set", func(t *testing.T) {
+		result := &RayClusterConfig{
+			RayVersion: new("2.56.0"),
+			Image:      new("my-registry/my-ray:custom"),
+			Head:       &Head{CPU: new("8"), Memory: new("16Gi")},
+			WorkerGroups: []WorkerGroup{
+				{
+					Name:       new("gpu-workers"),
+					CPU:        new("4"),
+					Memory:     new("32Gi"),
+					Replicas:   new(int32(0)),
+					NumOfHosts: new(int32(4)),
+				},
+			},
+		}
+		expected := *result
+
+		applyDefaults(result)
+
+		assert.Equal(t, &expected, result)
+	})
 }
 
 func TestParseConfigFile(t *testing.T) {
@@ -853,14 +881,17 @@ func TestParseConfigFile(t *testing.T) {
 				},
 				WorkerGroups: []WorkerGroup{
 					{
-						Name:     new("default-group"),
-						Replicas: int32(1),
-						CPU:      new("2"),
-						Memory:   new("4Gi"),
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("4Gi"),
 					},
 				},
 			},
 		},
+		// A worker group that sets only some of its fields must still get the defaults for the
+		// rest. See https://github.com/ray-project/kuberay/issues/5165.
 		"minimal config": {
 			config: `worker-groups:
 - replicas: 1
@@ -875,8 +906,135 @@ func TestParseConfigFile(t *testing.T) {
 				},
 				WorkerGroups: []WorkerGroup{
 					{
-						Replicas: int32(1),
-						GPU:      new("1"),
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("4Gi"),
+						GPU:        new("1"),
+					},
+				},
+			},
+		},
+		// The sample config shipped in config/samples/create-cluster.sample.yaml
+		"sample config": {
+			config: `worker-groups:
+  - cpu: 3
+`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    new("2"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("3"),
+						Memory:     new("4Gi"),
+					},
+				},
+			},
+		},
+		// An explicit "replicas: 0" must survive defaulting
+		"explicit zero replicas": {
+			config: `worker-groups:
+- replicas: 0
+`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    new("2"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("default-group"),
+						Replicas:   new(int32(0)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("4Gi"),
+					},
+				},
+			},
+		},
+		// Each group gets its own defaults, and unnamed groups after the first are suffixed
+		"multiple partial worker groups": {
+			config: `worker-groups:
+- cpu: 3
+- memory: 8Gi
+`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      new(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    new("2"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("3"),
+						Memory:     new("4Gi"),
+					},
+					{
+						Name:       new("default-group-1"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("8Gi"),
+					},
+				},
+			},
+		},
+		// The image follows the Ray version set in the file so that the cluster does not claim one
+		// version while running the images of another
+		"ray version without image": {
+			config: `ray-version: 2.56.0
+`,
+			expected: &RayClusterConfig{
+				RayVersion: new("2.56.0"),
+				Image:      new("rayproject/ray:2.56.0"),
+				Head: &Head{
+					CPU:    new("2"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("4Gi"),
+					},
+				},
+			},
+		},
+		// An explicit image wins over the one derived from the Ray version
+		"ray version with image": {
+			config: `ray-version: 2.56.0
+image: my-registry/my-ray:custom
+`,
+			expected: &RayClusterConfig{
+				RayVersion: new("2.56.0"),
+				Image:      new("my-registry/my-ray:custom"),
+				Head: &Head{
+					CPU:    new("2"),
+					Memory: new("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:       new("default-group"),
+						Replicas:   new(int32(1)),
+						NumOfHosts: new(int32(1)),
+						CPU:        new("2"),
+						Memory:     new("4Gi"),
 					},
 				},
 			},
@@ -950,7 +1108,8 @@ gke:
 				WorkerGroups: []WorkerGroup{
 					{
 						Name:             new("cpu-workers"),
-						Replicas:         int32(1),
+						Replicas:         new(int32(1)),
+						NumOfHosts:       new(int32(1)),
 						CPU:              new("2"),
 						Memory:           new("4Gi"),
 						GPU:              new("0"),
@@ -959,7 +1118,8 @@ gke:
 					},
 					{
 						Name:             new("gpu-workers"),
-						Replicas:         int32(1),
+						Replicas:         new(int32(1)),
+						NumOfHosts:       new(int32(1)),
 						CPU:              new("3"),
 						Memory:           new("6Gi"),
 						GPU:              new("1"),


### PR DESCRIPTION
## Why are these changes needed?

`kubectl ray create cluster --file` produced a worker group with `replicas: 0` and no memory request or limit whenever the config file mentioned `worker-groups` at all, including the sample config the user guide links to. The command printed
`Created Ray cluster` and exited 0, and the cluster reached `ready`, but no worker pod was ever created.

`ParseConfigFile` applied the defaults by seeding a config object and unmarshalling the file on top of it. yaml.v2 reuses an existing pointer-to-struct, which is why the `head:` defaults survived, but it rebuilds slices from scratch and decodes each element into a zero value, so every worker group default was discarded. `WorkerGroup.Replicas` was an `int32` while every other field is a pointer, so an omitted value could not be told apart from an explicit `0` and went straight into the spec. Separately, the image stayed on the built-in Ray version because the logic that makes the image follow `--ray-version` lives in `Complete()`, which only reads the flag fields and is a no-op on the `--file` path.

The defaults are now applied after unmarshalling, `Replicas` is a `*int32`, and the image is derived from the resolved Ray version. A config file and the equivalent flags now produce the same RayCluster, which a new test asserts directly. The command also
warns when a worker group ends up with 0 replicas and the autoscaler cannot scale it up.

## Related issue number

Closes #5165 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests

### Manual test instructions

A config file and the equivalent flags now generate the same RayCluster:

```console
$ printf 'ray-version: 2.56.0\nworker-groups:\n  - cpu: 3\n' > wg.yaml
$ kubectl ray create cluster t --file wg.yaml --dry-run > from-file.yaml
$ kubectl ray create cluster t --worker-cpu 3 --ray-version 2.56.0 --dry-run > from-flags.yaml
$ diff from-file.yaml from-flags.yaml   # no output
```

The sample config from the user guide now gets the documented defaults:

```console
$ kubectl ray create cluster raycluster-sample --file create-cluster.sample.yaml --dry-run
  workerGroupSpecs:
  - groupName: default-group
    numOfHosts: 1
    replicas: 1
    ...
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "3"
              memory: 4Gi
```

A worker group that really is set to 0 replicas is reported on stderr, and the command
still succeeds:

```console
$ printf 'worker-groups:\n  - cpu: 3\n    replicas: 0\n' > zero.yaml
$ kubectl ray create cluster t --file zero.yaml --dry-run
Warning: worker group "default-group" has 0 replicas and will start with no worker pods.
```
