### PR TITLE
[Dashboard] Resolve the Ray head dashboard link by Service port name

### DIFF
--- a/dashboard/src/hooks/api/useListClusters.ts
+++ b/dashboard/src/hooks/api/useListClusters.ts
@@ -7,7 +7,7 @@ import { ClusterRow } from "@/types/table";
 import { ClusterStatus } from "@/types/v2/raycluster";
 import { V1Condition } from "@kubernetes/client-node";
 import { ALL_NAMESPACES } from "@/utils/config-defaults";
-import { config } from "@/utils/constants";
+import { buildRayHeadDashboardLink } from "@/utils/links";
 
 export const useListClusters = (
   refreshInterval: number = 5000,
@@ -78,19 +78,14 @@ const transformRayClusterResponse = (
     const namespace = item.metadata.namespace!;
 
     const generateLinks = () => {
-      const serviceName = item.status.head?.serviceName ?? "";
-      const dashboardPort =
-        item.spec.headGroupSpec?.template?.spec?.containers?.[0].ports?.find(
-          (port) => port.name === "dashboard",
-        )?.containerPort;
+      const dashboardLink = buildRayHeadDashboardLink(
+        namespace,
+        item.status.head?.serviceName,
+        item.status.endpoints,
+      );
 
-      if (!serviceName || !dashboardPort) {
-        return {
-          rayHeadDashboardLink: "",
-        };
-      }
       return {
-        rayHeadDashboardLink: `${config.coreApiUrl}/namespaces/${namespace}/services/${serviceName}:${dashboardPort}/proxy/#/cluster`,
+        rayHeadDashboardLink: dashboardLink ? `${dashboardLink}#/cluster` : "",
       };
     };
 

--- a/dashboard/src/hooks/api/useListJobs.ts
+++ b/dashboard/src/hooks/api/useListJobs.ts
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import { RayJobListResponse, RayJobItem } from "@/types/v2/api/rayjob";
 import { JobRow } from "@/types/table";
 import { ALL_NAMESPACES } from "@/utils/config-defaults";
-import { config } from "@/utils/constants";
+import { buildRayHeadDashboardLink } from "@/utils/links";
 
 export const useListJobs = (
   refreshInterval: number = 5000,
@@ -45,15 +45,15 @@ export const useListJobs = (
 const convertRayJobItemToJobRow = (item: RayJobItem): JobRow => {
   const namespace = item.metadata.namespace!;
   const generateLinks = () => {
-    const serviceName = item.status?.rayClusterStatus?.head?.serviceName;
-    const dashboardPort =
-      item.spec?.rayClusterSpec?.headGroupSpec?.template?.spec?.containers?.[0]?.ports?.find(
-        (port) => port.name === "dashboard",
-      )?.containerPort;
-    if (!serviceName || !dashboardPort || !config.coreApiUrl) {
+    const dashboardLink = buildRayHeadDashboardLink(
+      namespace,
+      item.status?.rayClusterStatus?.head?.serviceName,
+      item.status?.rayClusterStatus?.endpoints,
+    );
+    if (!dashboardLink) {
       return {};
     }
-    const rayHeadDashboardLink = `${config.coreApiUrl}/namespaces/${namespace}/services/${serviceName}:${dashboardPort}/proxy/#/jobs`;
+    const rayHeadDashboardLink = `${dashboardLink}#/jobs`;
     const rayJobId = item.status?.jobId;
     return {
       rayHeadDashboardLink,

--- a/dashboard/src/utils/links.ts
+++ b/dashboard/src/utils/links.ts
@@ -1,0 +1,34 @@
+import { config } from "./constants";
+
+// Name of the Ray dashboard port on the head Service. The operator always adds
+// this port to the head Service, either from the ports declared by the head
+// container or, when it declares none, from the default ports.
+const DASHBOARD_PORT_NAME = "dashboard";
+
+/**
+ * Builds the apiserver Service proxy link to the Ray head dashboard, or returns
+ * undefined when the cluster doesn't expose one (yet).
+ *
+ * The port is addressed by name (`<head-svc>:dashboard`) rather than by number
+ * so that the link also works for head containers that declare no ports at all,
+ * for which the head Service is built from the default ports and no
+ * `containerPort` is available in the spec.
+ *
+ * `status.endpoints` mirrors the head Service ports, so the presence of the
+ * `dashboard` key is what tells us the port exists. Its value can't be used to
+ * build the link, since it holds the nodePort or targetPort rather than the
+ * Service port.
+ */
+export const buildRayHeadDashboardLink = (
+  namespace: string | undefined,
+  serviceName: string | undefined,
+  endpoints: Record<string, string> | undefined,
+): string | undefined => {
+  if (!namespace || !serviceName || !config.coreApiUrl) {
+    return undefined;
+  }
+  if (!endpoints || !(DASHBOARD_PORT_NAME in endpoints)) {
+    return undefined;
+  }
+  return `${config.coreApiUrl}/namespaces/${namespace}/services/${serviceName}:${DASHBOARD_PORT_NAME}/proxy/`;
+};


### PR DESCRIPTION
## Why are these changes needed?

The dashboard resolved the Ray head dashboard port by scanning the head group spec for a container port literally named `dashboard`, and returned an empty link when it was absent (`useListClusters.ts`, `useListJobs.ts`). The link then just vanished from the row with no explanation — even though the dashboard was still reachable.

That named port is optional. When the head container declares no ports at all — which is the case for several samples under `ray-operator/config/samples/` and for `historyserver/config/raycluster.yaml` — the operator falls back to the default ports when it builds the head Service:

- `getServicePorts` ([`ray-operator/controllers/ray/common/service.go`](https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/common/service.go)) uses `getDefaultPorts()`, which includes `dashboard: 8265`, whenever the head container declares no ports.
- `updateStatus` ([`ray-operator/controllers/ray/raycluster_controller.go`](https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/raycluster_controller.go)) then copies the head Service ports into `status.endpoints`, keyed by port name.

So the dashboard port exists on the Service; the spec just doesn't mention it.

This PR builds the link from the Service port **name** instead of a container port number — the Service proxy subresource accepts `services/<head-svc>:dashboard/proxy/` — and decides whether to show the link from `status.endpoints`. Only the *presence* of the `dashboard` key there is usable: its value is the nodePort or targetPort, not the Service port, so it can't be substituted into the URL.

The logic is shared between the two hooks by a new `buildRayHeadDashboardLink` helper in `dashboard/src/utils/links.ts`.

Behavior change: clusters/jobs whose head container omits the named `dashboard` port now show a working dashboard link. Clusters whose head Service genuinely has no `dashboard` port still show no link, as before.

## Related issue number

Closes #5179

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests

`yarn lint` (eslint + prettier + `tsc --noEmit`) passes in `dashboard/`, and the full `pre-commit` suite passes. The dashboard has no unit-test harness at the moment, so this is verified manually.

### Manual test instructions

```bash
# a RayCluster whose head container declares no ports at all
kubectl apply -f - <<'YAML'
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: rc-noports
spec:
  rayVersion: "2.56.0"
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
      num-cpus: "0"
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.56.0
YAML
kubectl wait --for=condition=Ready pod -l ray.io/cluster=rc-noports --timeout=300s

# the head Service carries the port even though the container spec declares none
kubectl get svc rc-noports-head-svc \
  -o jsonpath='{range .spec.ports[*]}{.name}={.port} {end}'; echo
# -> client=10001 dashboard=8265 gcs-server=6379 metrics=8080 serve=8000

# and status.endpoints has the `dashboard` key the fix keys off
kubectl get raycluster rc-noports -o jsonpath='{.status.endpoints}'; echo

SVC=http://localhost:31888/api/v1/namespaces/default/services/rc-noports-head-svc
curl -s -o /dev/null -w '%{http_code}\n' "$SVC:dashboard/proxy/"  # 200, resolved by port name
```

Then browse `http://localhost:3000/clusters`: before this change the `rc-noports` row has no dashboard link; after it, the link is present and opens the Ray dashboard through the apiserver Service proxy. Same for `/jobs` with a RayJob whose `rayClusterSpec` head container omits the port.
