### PR TITLE
[Helm][Feat] Expose enableIngress and ingressOptions in the RayCluster chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -40,6 +40,13 @@ spec:
     headService:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.head.enableIngress }}
+    enableIngress: {{ . }}
+    {{- end }}
+    {{- with .Values.head.ingressOptions }}
+    ingressOptions:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values.service.type }}
     serviceType: {{ . }}
     {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -147,6 +147,54 @@ tests:
               name: test-head-service
               namespace: ray
 
+  - it: Should not set ingress fields by default
+    asserts:
+      - notExists:
+          path: spec.headGroupSpec.enableIngress
+      - notExists:
+          path: spec.headGroupSpec.ingressOptions
+
+  - it: Should enable ingress if `head.enableIngress` is `true`
+    set:
+      head:
+        enableIngress: true
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.enableIngress
+          value: true
+
+  - it: Should not enable ingress if `head.enableIngress` is `false`
+    set:
+      head:
+        enableIngress: false
+    asserts:
+      - notExists:
+          path: spec.headGroupSpec.enableIngress
+
+  - it: Should use the specified ingress options if `head.ingressOptions` is set
+    set:
+      head:
+        enableIngress: true
+        ingressOptions:
+          host: ray.example.com
+          path: /dashboard
+          pathType: Exact
+          tls:
+            - hosts:
+                - ray.example.com
+              secretName: ray-tls
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.ingressOptions
+          value:
+            host: ray.example.com
+            path: /dashboard
+            pathType: Exact
+            tls:
+              - hosts:
+                  - ray.example.com
+                secretName: ray-tls
+
   - it: Should use the specified service type if `service.type` is set
     set:
       service:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -179,6 +179,22 @@ head:
     #   annotations:
     #     prometheus.io/scrape: "true"
 
+  # enableIngress tells the operator to create an Ingress for the head dashboard service.
+  # The ingress class comes from the RayCluster annotations, so set it in the top-level
+  # `annotations` value, for example `kubernetes.io/ingress.class: nginx`.
+  # enableIngress: true
+
+  # ingressOptions customizes the Ingress created when enableIngress is true.
+  # host defaults to matching any host, path defaults to "/", pathType defaults to Prefix.
+  # ingressOptions:
+    # host: ray.example.com
+    # path: /dashboard
+    # pathType: Exact
+    # tls:
+    #   - hosts:
+    #       - ray.example.com
+    #     secretName: ray-tls
+
   # Custom pod DNS configuration
   # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
   # dnsConfig:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -182,6 +182,7 @@ head:
   # enableIngress tells the operator to create an Ingress for the head dashboard service.
   # The ingress class comes from the RayCluster annotations, so set it in the top-level
   # `annotations` value, for example `kubernetes.io/ingress.class: nginx`.
+  # All other RayCluster annotations are copied to the Ingress, so use them to customize ingress behavior
   # enableIngress: true
 
   # ingressOptions customizes the Ingress created when enableIngress is true.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -183,14 +183,17 @@ head:
   # The ingress class comes from the RayCluster annotations, so set it in the top-level
   # `annotations` value, for example `kubernetes.io/ingress.class: nginx`.
   # All other RayCluster annotations are copied to the Ingress, so use them to customize ingress behavior
+  # WARNING: The Ray Dashboard provides read and write access to the cluster. Anyone who can
+  # reach this Ingress can launch arbitrary code execution on the Ray Cluster. Do not expose
+  # it publicly without additional authentication/authorization at the ingress controller.
   # enableIngress: true
 
   # ingressOptions customizes the Ingress created when enableIngress is true.
   # host defaults to matching any host, path defaults to "/", pathType defaults to Prefix.
   # ingressOptions:
     # host: ray.example.com
-    # path: /dashboard
-    # pathType: Exact
+    # path: /
+    # pathType: Prefix
     # tls:
     #   - hosts:
     #       - ray.example.com


### PR DESCRIPTION
## Why are these changes needed?

KubeRay 1.7 added `headGroupSpec.ingressOptions` to the RayCluster CRD in #4901, which lets users customize the Ingress the operator generates for the head dashboard (`host`, `path`, `pathType`, `tls`). The `ray-cluster` Helm chart does not expose it, so Helm users cannot enable or configure the generated Ingress.

This PR exposes those settings in the chart:

* `head.ingressOptions` is passed through to `spec.headGroupSpec.ingressOptions` with `toYaml`, so any field the CRD supports now or later works without further chart changes. This matches how `head.headService` and `head.autoscalerOptions` are already handled.
* `head.enableIngress` is exposed as well. The operator only builds an Ingress when `headGroupSpec.enableIngress` is true, and the chart never exposed that flag either, so `ingressOptions` on its own would have no effect. Both fields are needed for the chart to produce a working Ingress end to end.

Both values are commented out in `values.yaml` and rendered with `{{- with }}`, so they are omitted from the RayCluster spec unless the user sets them. The default rendering is byte for byte identical to before this change, and the operator and CRD defaults still apply when the fields are unset.

Example usage:

```yaml
annotations:
  kubernetes.io/ingress.class: nginx

head:
  enableIngress: true
  ingressOptions:
    host: ray.example.com
    path: /dashboard
    pathType: Exact
    tls:
      - hosts:
          - ray.example.com
        secretName: ray-tls
```

## Related issue number

Closes #5189

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests

Helm unit tests added in `helm-chart/ray-cluster/tests/raycluster_test.yaml`:

* neither field appears in the rendered spec by default
* `head.enableIngress: true` renders `enableIngress: true`
* `head.enableIngress: false` renders nothing, leaving the CRD default in place
* `head.ingressOptions` with `host`, `path`, `pathType` and `tls` is passed through unchanged

`helm unittest helm-chart/ray-cluster --file "tests/**/*_test.yaml" --strict` passes, 108 tests. `helm lint` passes. `make -C helm-chart helm-docs` produces no diff, since helm-docs does not document commented out keys.

### Manual test instructions

Verified end to end on a KinD cluster with the operator installed from this repo (`quay.io/kuberay/operator:nightly`).

```sh
kind create cluster --name ingress-opts-test
helm install kuberay-operator ./helm-chart/kuberay-operator --wait

helm template raycluster ./helm-chart/ray-cluster \
  --set annotations."kubernetes\.io/ingress\.class"=nginx \
  --set head.enableIngress=true \
  --set head.ingressOptions.host=ray.example.com \
  --set head.ingressOptions.path=/dashboard \
  --set head.ingressOptions.pathType=Exact \
  --set head.ingressOptions.tls[0].secretName=ray-tls \
  --set head.ingressOptions.tls[0].hosts[0]=ray.example.com | kubectl apply -f -

kubectl get ingress -o yaml
```

The Ingress created by the operator carries every configured field:

```
name: raycluster-kuberay-head-ingress
ingressClassName: nginx
tls: [{"hosts":["ray.example.com"],"secretName":"ray-tls"}]
host: ray.example.com
  path: /dashboard | pathType: Exact | backend: {"name":"raycluster-kuberay-head-svc","port":{"number":8265}}
```

Additional checks on the same cluster:

* `kubectl apply --dry-run=server` on the rendered chart is accepted by the API server, confirming the field paths match the CRD schema.
* A deliberately invalid value is rejected by CRD validation rather than silently ignored:
  `spec.headGroupSpec.ingressOptions.pathType: Unsupported value: "Bogus": supported values: "Exact", "Prefix", "ImplementationSpecific"`
* A second release installed with default values produces no Ingress at all, so existing users are unaffected.
