### PR TITLE
[Helm][Feat] Expose spec.authOptions and spec.upgradeStrategy in RayCluster Helm Chart

### DIFF
--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -78,8 +78,8 @@ helm uninstall raycluster
 | nameOverride | string | `"kuberay"` | String to partially override release name. |
 | fullnameOverride | string | `""` | String to fully override release name. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
-| upgradeStrategy | object | `{}` | Recreate all Pods on RayCluster spec change. Intended for GitOps; running workloads are lost |
-| authOptions | object | `{}` | Token authentication for the RayCluster |
+| upgradeStrategy | object | `{}` | Recreate all Pods on RayCluster spec change. Intended for GitOps; running workloads are lost. |
+| authOptions | object | `{}` | Token authentication for the RayCluster. |
 | gcsFaultTolerance.enabled | bool | `false` |  |
 | common.containerEnv | list | `[]` | containerEnv specifies environment variables for the Ray head and worker containers. Follows standard K8s container env schema. |
 | head.initContainers | list | `[]` | Init containers to add to the head pod |

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -78,6 +78,8 @@ helm uninstall raycluster
 | nameOverride | string | `"kuberay"` | String to partially override release name. |
 | fullnameOverride | string | `""` | String to fully override release name. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
+| upgradeStrategy | object | `{}` | Recreate all Pods on RayCluster spec change. Intended for GitOps; running workloads are lost |
+| authOptions | object | `{}` | Token authentication for the RayCluster |
 | gcsFaultTolerance.enabled | bool | `false` |  |
 | common.containerEnv | list | `[]` | containerEnv specifies environment variables for the Ray head and worker containers. Follows standard K8s container env schema. |
 | head.initContainers | list | `[]` | Init containers to add to the head pod |

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -20,6 +20,14 @@ spec:
   autoscalerOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.upgradeStrategy }}
+  upgradeStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.authOptions }}
+  authOptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.gcsFaultTolerance.enabled }}
   gcsFaultToleranceOptions:
     redisAddress: {{ .Values.gcsFaultTolerance.redisAddress | quote }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -97,6 +97,50 @@ tests:
               seccompProfile:
                 type: RuntimeDefault
 
+  - it: Should set upgradeStrategy when `upgradeStrategy` is set
+    set:
+      upgradeStrategy:
+        type: Recreate
+    asserts:
+      - equal:
+          path: spec.upgradeStrategy
+          value:
+            type: Recreate
+
+  - it: Should set upgradeStrategy type None when configured
+    set:
+      upgradeStrategy:
+        type: None
+    asserts:
+      - equal:
+          path: spec.upgradeStrategy
+          value:
+            type: None
+
+  - it: Should set authOptions when `authOptions` is set
+    set:
+      authOptions:
+        mode: token
+        secretName: ray-cluster-token
+    asserts:
+      - equal:
+          path: spec.authOptions
+          value:
+            mode: token
+            secretName: ray-cluster-token
+
+  - it: Should set Kubernetes token auth when `authOptions.enableK8sTokenAuth` is true
+    set:
+      authOptions:
+        mode: token
+        enableK8sTokenAuth: true
+    asserts:
+      - equal:
+          path: spec.authOptions
+          value:
+            mode: token
+            enableK8sTokenAuth: true
+
   - it: Should add GCS fault tolerance options when `gcsFaultTolerance.enabled` is `true`
     set:
       gcsFaultTolerance:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -23,6 +23,23 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
+# -- Recreate all Pods on RayCluster spec change. Intended for GitOps; running workloads are lost.
+upgradeStrategy: {}
+  # Recreate | None
+  # type: Recreate
+
+# See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-auth.html
+# for more details.
+# -- Token authentication for the RayCluster.
+authOptions: {}
+  # disabled | token
+  # mode: token
+  # Kubernetes RBAC via client's own ServiceAccount tokens.
+  # Required Ray >= 2.55.0. Mutually exclusive with secretName.
+  # enableK8sTokenAuth: true
+  # Existing Secret with data key `auth_token`.
+  # secretName: ray-cluster-token
+
 # gcsFaultTolerance specifies configuration for GCS fault tolerance.
 # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#kuberay-gcs-ft
 # for more details.
@@ -47,7 +64,6 @@ gcsFaultTolerance:
     #   secretKeyRef:
     #     name: redis-username-secret
     #     key: username
-
 
 # common defined values shared between the head and worker
 common:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Because RayClusterSpec defines 35 fields, but the Helm chart only renders 19 of them. This leaves `authOptions` and `upgradeStrategy`unavailable to users who install via Helm, even though both fields work out of the box on a standard KubeRay operator with no feature gate required.
And fields like `tlsOptions`, `networkPolicy`, `historyServerOptions`, `gcsFaultToleranceOptions.backend`/`.storage`) are intentionally left out until those reach beta.

## Related issue number
Closes #5196 


## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
