### PR TITLE
[History Server] Disable live cluster support by default

### DIFF
--- a/historyserver/DEVELOPMENT.md
+++ b/historyserver/DEVELOPMENT.md
@@ -106,8 +106,8 @@ kubectl apply -f historyserver/config/historyserver.yaml
 
 > [!NOTE]
 > Access to live RayClusters is off by default, so `/clusters` lists only sessions already flushed to
-> storage. If you want to access live RayCluster, set `--enable-live-clusters=true` in
-> `historyserver/config/historyserver.yaml` before applying it.
+> storage. If you want to access live RayClusters, uncomment the `--enable-live-clusters=true` line
+> in the container `args` of `historyserver/config/historyserver.yaml` before applying it.
 
 ## Step 6: Access the Local Ray Dashboard
 

--- a/historyserver/DEVELOPMENT.md
+++ b/historyserver/DEVELOPMENT.md
@@ -104,6 +104,11 @@ kubectl apply -f historyserver/config/service_account.yaml
 kubectl apply -f historyserver/config/historyserver.yaml
 ```
 
+> [!NOTE]
+> Access to live RayCluster is off by default, so `/clusters` lists only sessions already flushed to
+> storage. If you want to access live RayCluster, set `--enable-live-clusters=true` in
+> `historyserver/config/historyserver.yaml` before applying it.
+
 ## Step 6: Access the Local Ray Dashboard
 
 To access the local Ray Dashboard, you have to port forward the History Server service:

--- a/historyserver/DEVELOPMENT.md
+++ b/historyserver/DEVELOPMENT.md
@@ -105,7 +105,7 @@ kubectl apply -f historyserver/config/historyserver.yaml
 ```
 
 > [!NOTE]
-> Access to live RayCluster is off by default, so `/clusters` lists only sessions already flushed to
+> Access to live RayClusters is off by default, so `/clusters` lists only sessions already flushed to
 > storage. If you want to access live RayCluster, set `--enable-live-clusters=true` in
 > `historyserver/config/historyserver.yaml` before applying it.
 

--- a/historyserver/README.md
+++ b/historyserver/README.md
@@ -68,6 +68,14 @@ The history server can be configured using command-line flags:
 - `--kubeconfigs`: Path to kubeconfig file(s) for accessing Kubernetes clusters
 - `--dashboard-dir`: Directory containing dashboard assets (default: "/dashboard")
 - `--storage-backend-config-path`: Path to storage backend configuration file
+- `--enable-live-clusters`: Serve RayClusters that are still running by reverse-proxying to their
+  head dashboard (default: `false`)
+
+> [!WARNING]
+> The history server does not authenticate its own callers, and the RayCluster it proxies to is
+> chosen from a client-supplied cookie. Enabling `--enable-live-clusters` therefore exposes the Ray
+> Dashboard API of every RayCluster the history server can reach to anyone who can reach the history
+> server. Only turn it on where that access is already restricted by other means.
 
 ### Collector Configuration
 
@@ -171,8 +179,9 @@ kubectl wait rayjob/rayjob-historyserver --for=jsonpath='{.status.jobStatus}=SUC
 # Delete the RayJob only to skip the TTL wait:
 kubectl delete -f historyserver/config/rayjob.yaml
 
-# Discover the session name. /clusters lists both live and dead sessions;
-# dead sessions carry the `session_*` name you'll feed into /enter_cluster.
+# Discover the session name. /clusters lists dead sessions, plus live ones when
+# --enable-live-clusters is set; dead sessions carry the `session_*` name you'll
+# feed into /enter_cluster.
 curl -sS http://localhost:8080/clusters
 ```
 

--- a/historyserver/README.md
+++ b/historyserver/README.md
@@ -73,9 +73,9 @@ The history server can be configured using command-line flags:
 
 > [!WARNING]
 > The history server does not authenticate its own callers, and the RayCluster it proxies to is
-> chosen from a client-supplied cookie. Enabling `--enable-live-clusters` therefore exposes the Ray
-> Dashboard API of every RayCluster the history server can reach to anyone who can reach the history
-> server. Only turn it on where that access is already restricted by other means.
+> chosen from a client-supplied cookie. With `--enable-live-clusters` enabled, anyone who can reach
+> the history server can reach the Ray Dashboard API of every RayCluster the history server can
+> access. Only turn it on where that access is already restricted by other means.
 
 ### Collector Configuration
 

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -76,10 +76,8 @@ func main() {
 	if sessionCacheTTL < 0 {
 		logrus.Fatalf("--session-cache-ttl must be >= 0, got %s", sessionCacheTTL)
 	}
-	// Auth-token mode only injects a token into requests proxied to a live cluster, so it is inert
-	// while live clusters are disabled. Warn instead of failing: this combination is what an
-	// existing deployment ends up with after upgrading to a release that flipped the default, and
-	// a Fatal here would turn that upgrade into a CrashLoopBackOff.
+	// Auth-token mode only affects proxied live-cluster requests. Warn rather than failing so that
+    // deployments upgrading across the default flip do not CrashLoopBackOff.
 	if useAuthTokenMode && !enableLiveClusters {
 		logrus.Warnf("--use-auth-token-mode has no effect while --enable-live-clusters=false")
 	}

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -25,6 +25,7 @@ func main() {
 	dashboardDir := ""
 	useKubernetesProxy := false
 	useAuthTokenMode := false
+	enableLiveClusters := false
 	qps := historyserver.DefaultKubeAPIQPS
 	burst := historyserver.DefaultKubeAPIBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&storageBackendConfigPath, "storage-backend-config-path", "", "Path to backend config JSON")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false, "Use local kubeconfig instead of in-cluster config")
 	flag.BoolVar(&useAuthTokenMode, "use-auth-token-mode", false, "Enable Ray dashboard token authentication mode (requires x-ray-authorization header)")
+	flag.BoolVar(&enableLiveClusters, "enable-live-clusters", false, "Enable access to live clusters")
 	flag.Float64Var(&qps, "kube-api-qps", historyserver.DefaultKubeAPIQPS, "The QPS value for the client communicating with the Kubernetes API server.")
 	flag.IntVar(&burst, "kube-api-burst", historyserver.DefaultKubeAPIBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
@@ -73,6 +75,13 @@ func main() {
 	}
 	if sessionCacheTTL < 0 {
 		logrus.Fatalf("--session-cache-ttl must be >= 0, got %s", sessionCacheTTL)
+	}
+	// Auth-token mode only injects a token into requests proxied to a live cluster, so it is inert
+	// while live clusters are disabled. Warn instead of failing: this combination is what an
+	// existing deployment ends up with after upgrading to a release that flipped the default, and
+	// a Fatal here would turn that upgrade into a CrashLoopBackOff.
+	if useAuthTokenMode && !enableLiveClusters {
+		logrus.Warnf("--use-auth-token-mode has no effect while --enable-live-clusters=false")
 	}
 
 	cliMgr, err := historyserver.NewClientManager(historyserver.ClientManagerConfig{
@@ -129,7 +138,7 @@ func main() {
 		close(stop)
 	}()
 
-	handler, err := historyserver.NewServerHandler(&globalConfig, dashboardDir, reader, cliMgr, sessionLoader, useKubernetesProxy, useAuthTokenMode)
+	handler, err := historyserver.NewServerHandler(&globalConfig, dashboardDir, reader, cliMgr, sessionLoader, useKubernetesProxy, useAuthTokenMode, enableLiveClusters)
 	if err != nil {
 		logrus.Fatalf("Failed to create server handler: %v", err)
 	}

--- a/historyserver/config/historyserver-azureblob.yaml
+++ b/historyserver/config/historyserver-azureblob.yaml
@@ -49,7 +49,7 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
-        # Enable access to live RayCluster through the History Server.
+        # Enable access to live RayClusters through the History Server.
         # - --enable-live-clusters=true
         #
         # Enable proxying to live RayClusters with token authentication enabled.

--- a/historyserver/config/historyserver-azureblob.yaml
+++ b/historyserver/config/historyserver-azureblob.yaml
@@ -49,6 +49,14 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
+        # Enable access to live RayCluster through the History Server.
+        # - --enable-live-clusters=true
+        #
+        # Enable proxying to live RayClusters with token authentication enabled.
+        # The history server reads the auth Secret and forwards requests with the
+        # appropriate authorization header. Requires the RBAC in
+        # service_account_auth_token_mode.yaml.
+        # - --use-auth-token-mode=true
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -48,7 +48,7 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
-        # Enable access to live RayCluster through the History Server.
+        # Enable access to live RayClusters through the History Server.
         # - --enable-live-clusters=true
         #
         # Enable proxying to live RayClusters with token authentication enabled.

--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -48,6 +48,14 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
+        # Enable access to live RayCluster through the History Server.
+        # - --enable-live-clusters=true
+        #
+        # Enable proxying to live RayClusters with token authentication enabled.
+        # The history server reads the auth Secret and forwards requests with the
+        # appropriate authorization header. Requires the RBAC in
+        # service_account_auth_token_mode.yaml.
+        # - --use-auth-token-mode=true
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -60,8 +60,7 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
-        # Reverse-proxy requests to running RayCluster dashboards.
-        # Off by default; enabling this exposes live RayCluster APIs.
+        # Enable access to live RayCluster through the History Server.
         # - --enable-live-clusters=true
         #
         # Enable proxying to live RayClusters with token authentication enabled.

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -60,7 +60,7 @@ spec:
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
-        # Enable access to live RayCluster through the History Server.
+        # Enable access to live RayClusters through the History Server.
         # - --enable-live-clusters=true
         #
         # Enable proxying to live RayClusters with token authentication enabled.

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -54,19 +54,21 @@ spec:
             value: "s3"
         image: historyserver:v0.1.0
         imagePullPolicy: IfNotPresent
-        # Enable proxying to live RayClusters with token authentication enabled.
-        # The history server reads the auth Secret and forwards requests with the
-        # appropriate authorization header. Requires the RBAC in
-        # service_account_auth_token_mode.yaml.
-        # command:
-        # - historyserver
-        # - --use-auth-token-mode=true
         ports:
         - containerPort: 8080
         # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
         - --session-cache-max-memory=8Gi
+        # Reverse-proxy requests to running RayCluster dashboards.
+        # Off by default; enabling this exposes live RayCluster APIs.
+        # - --enable-live-clusters=true
+        #
+        # Enable proxying to live RayClusters with token authentication enabled.
+        # The history server reads the auth Secret and forwards requests with the
+        # appropriate authorization header. Requires the RBAC in
+        # service_account_auth_token_mode.yaml.
+        # - --use-auth-token-mode=true
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -84,6 +84,11 @@ kubectl apply -f historyserver/config/historyserver.yaml
 kubectl port-forward svc/historyserver 8080:30080
 ```
 
+> [!IMPORTANT]
+> Access to live RayClusters is disabled by default. When disabled, `/clusters` only lists sessions
+> already flushed to storage, and `/enter_cluster/.../live` returns 404. To enable access to live
+> RayCluster, set `--enable-live-clusters=true`.
+
 #### Run History Server Outside the Kind Cluster
 
 You can also run the history server outside the Kind cluster to accelerate the development iteration and enable
@@ -101,6 +106,7 @@ debugging in your own IDE. For example, you can set up `.vscode/launch.json` as 
             "cwd": "${workspaceFolder}",
             "args": [
                 "--storage-backend=s3",
+                "--enable-live-clusters=true",
             ],
             "env": {
                 "S3_REGION": "test",
@@ -141,6 +147,7 @@ export S3DISABLE_SSL=true
 ./output/bin/historyserver \
   --storage-backend=s3 \
   --use-kubernetes-proxy=true
+  --enable-live-clusters=true
 ```
 
 ## API Endpoints

--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -146,7 +146,7 @@ export S3DISABLE_SSL=true
 # Run the history server.
 ./output/bin/historyserver \
   --storage-backend=s3 \
-  --use-kubernetes-proxy=true
+  --use-kubernetes-proxy=true \
   --enable-live-clusters=true
 ```
 

--- a/historyserver/html/select_cluster.html
+++ b/historyserver/html/select_cluster.html
@@ -656,7 +656,11 @@
 
                 fetch(`/enter_cluster/${namespace}/raycluster/${name}/${session}`)
                     .then(res => {
-                        if (!res.ok) throw new Error(`${res.status}: ${res.statusText || 'Error'}`);
+                        if (!res.ok) {
+                            return res.text().then(body => {
+                                throw new Error(body.trim() || `${res.status}: ${res.statusText || 'Error'}`);
+                            });
+                        }
                         return res.json();
                     })
                     .then(data => {

--- a/historyserver/pkg/historyserver/cookie_handle_test.go
+++ b/historyserver/pkg/historyserver/cookie_handle_test.go
@@ -1,0 +1,144 @@
+package historyserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+// newTestClientManager builds a ClientManager backed by a fake client holding objs.
+func newTestClientManager(objs ...client.Object) *ClientManager {
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	return &ClientManager{
+		clients:      []client.Client{fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()},
+		svcInfoCache: cache.NewLRUExpireCache(16),
+	}
+}
+
+// liveRayCluster returns a RayCluster whose head service is resolvable by fetchSvcInfo.
+func liveRayCluster(namespace, name string) *rayv1.RayCluster {
+	return &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: rayv1.RayClusterStatus{
+			Head: rayv1.HeadInfo{ServiceName: name + "-head-svc"},
+		},
+	}
+}
+
+// serveThroughCookieHandle drives one request through CookieHandle and reports whether the
+// downstream handler ran. Using a real container exercises the filter exactly as the routes do.
+func serveThroughCookieHandle(handler *ServerHandler, cookies map[string]string) (*httptest.ResponseRecorder, bool) {
+	reached := false
+
+	container := restful.NewContainer()
+	ws := new(restful.WebService)
+	// Mirror the real routes: CookieHandle answers with WriteHeaderAndEntity, which needs a
+	// negotiable media type or go-restful replies 406 before the body is written.
+	ws.Path("/probe").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
+	ws.Route(ws.GET("").To(func(_ *restful.Request, resp *restful.Response) {
+		reached = true
+		resp.WriteHeader(http.StatusOK)
+	}).Filter(handler.CookieHandle))
+	container.Add(ws)
+
+	req := httptest.NewRequest("GET", "/probe", nil)
+	for name, value := range cookies {
+		req.AddCookie(&http.Cookie{Name: name, Value: value})
+	}
+	resp := httptest.NewRecorder()
+	container.ServeHTTP(resp, req)
+
+	return resp, reached
+}
+
+func liveCookies() map[string]string {
+	return map[string]string{
+		COOKIE_CLUSTER_NAME_KEY:      "cluster-a",
+		COOKIE_CLUSTER_NAMESPACE_KEY: "default",
+		COOKIE_SESSION_NAME_KEY:      "live",
+	}
+}
+
+// TestCookieHandleRejectsLiveSessionWhenDisabled is the security boundary: a live session cookie is
+// entirely client-controlled, so a caller can forge one even though nothing in the UI hands it out
+// while live clusters are disabled.
+func TestCookieHandleRejectsLiveSessionWhenDisabled(t *testing.T) {
+	// No RayCluster in the fake client. If the gate did not fire first, GetSvcInfo would fail and
+	// CookieHandle would answer 400, so a 403 proves the rejection happened before the K8s read.
+	handler := &ServerHandler{clientManager: newTestClientManager()}
+
+	resp, reached := serveThroughCookieHandle(handler, liveCookies())
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if reached {
+		t.Error("downstream handler ran; the live session must be rejected by the filter")
+	}
+}
+
+// TestCookieHandleRejectsLiveSessionBeforeReadingSecret guards the confused-deputy path: in
+// auth-token mode CookieHandle reads the cluster's auth token Secret on the caller's behalf, so the
+// gate has to fire before that read, not after.
+func TestCookieHandleRejectsLiveSessionBeforeReadingSecret(t *testing.T) {
+	// The RayCluster exists, so GetSvcInfo would succeed and GetAuthTokenForRayCluster would run.
+	// The fake client has no corev1 scheme registered, so any Secret read would error into a 500.
+	handler := &ServerHandler{
+		clientManager:    newTestClientManager(liveRayCluster("default", "cluster-a")),
+		useAuthTokenMode: true,
+	}
+
+	resp, reached := serveThroughCookieHandle(handler, liveCookies())
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if reached {
+		t.Error("downstream handler ran; the live session must be rejected by the filter")
+	}
+}
+
+// TestCookieHandleAllowsLiveSessionWhenEnabled keeps the gate from becoming an unconditional block.
+func TestCookieHandleAllowsLiveSessionWhenEnabled(t *testing.T) {
+	handler := &ServerHandler{
+		clientManager:      newTestClientManager(liveRayCluster("default", "cluster-a")),
+		enableLiveClusters: true,
+	}
+
+	resp, reached := serveThroughCookieHandle(handler, liveCookies())
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !reached {
+		t.Error("downstream handler did not run for an enabled live session")
+	}
+}
+
+// TestCookieHandlePassesStoredSessionWhenLiveDisabled confirms the gate is scoped to the live
+// sentinel and does not disturb replay of stored sessions.
+func TestCookieHandlePassesStoredSessionWhenLiveDisabled(t *testing.T) {
+	handler := &ServerHandler{clientManager: newTestClientManager()}
+
+	cookies := liveCookies()
+	cookies[COOKIE_SESSION_NAME_KEY] = "session_2026-04-22_10-00-00_000000_1"
+
+	resp, reached := serveThroughCookieHandle(handler, cookies)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !reached {
+		t.Error("downstream handler did not run for a stored session")
+	}
+}

--- a/historyserver/pkg/historyserver/cookie_handle_test.go
+++ b/historyserver/pkg/historyserver/cookie_handle_test.go
@@ -69,24 +69,6 @@ func liveCookies() map[string]string {
 	}
 }
 
-// TestCookieHandleRejectsLiveSessionWhenDisabled is the security boundary: a live session cookie is
-// entirely client-controlled, so a caller can forge one even though nothing in the UI hands it out
-// while live clusters are disabled.
-func TestCookieHandleRejectsLiveSessionWhenDisabled(t *testing.T) {
-	// No RayCluster in the fake client. If the gate did not fire first, GetSvcInfo would fail and
-	// CookieHandle would answer 400, so a 403 proves the rejection happened before the K8s read.
-	handler := &ServerHandler{clientManager: newTestClientManager()}
-
-	resp, reached := serveThroughCookieHandle(handler, liveCookies())
-
-	if resp.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
-	}
-	if reached {
-		t.Error("downstream handler ran; the live session must be rejected by the filter")
-	}
-}
-
 // TestCookieHandleRejectsLiveSessionBeforeReadingSecret guards the confused-deputy path: in
 // auth-token mode CookieHandle reads the cluster's auth token Secret on the caller's behalf, so the
 // gate has to fire before that read, not after.

--- a/historyserver/pkg/historyserver/cookie_handle_test.go
+++ b/historyserver/pkg/historyserver/cookie_handle_test.go
@@ -36,7 +36,7 @@ func liveRayCluster(namespace, name string) *rayv1.RayCluster {
 }
 
 // serveThroughCookieHandle drives one request through CookieHandle and reports whether the
-// downstream handler ran. Using a real container exercises the filter exactly as the routes do.
+// downstream handler ran.
 func serveThroughCookieHandle(handler *ServerHandler, cookies map[string]string) (*httptest.ResponseRecorder, bool) {
 	reached := false
 

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -95,9 +95,10 @@ func TestEnterCluster(t *testing.T) {
 
 	// Create ServerHandler with fake sessionLoader and mockStorageReader
 	handler := &ServerHandler{
-		maxClusters:   100,
-		reader:        mockReader,
-		clientManager: clientManager,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		reader:             mockReader,
+		clientManager:      clientManager,
 	}
 
 	// Setup fake processor for sessionLoader
@@ -265,9 +266,10 @@ func TestEnterClusterLatestFromStorage(t *testing.T) {
 	}
 
 	handler := &ServerHandler{
-		maxClusters:   100,
-		reader:        mockReader,
-		clientManager: clientManager,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		reader:             mockReader,
+		clientManager:      clientManager,
 	}
 
 	fp := &fakeProcessor{
@@ -330,9 +332,10 @@ func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
 	}
 
 	handler := &ServerHandler{
-		maxClusters:   100,
-		clientManager: clientManager,
-		reader:        mockReader,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		clientManager:      clientManager,
+		reader:             mockReader,
 	}
 
 	fp := &fakeProcessor{
@@ -382,9 +385,10 @@ func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
 	}
 
 	handler := &ServerHandler{
-		maxClusters:   100,
-		reader:        mockReader,
-		clientManager: clientManager,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		reader:             mockReader,
+		clientManager:      clientManager,
 	}
 
 	fp := &fakeProcessor{
@@ -440,9 +444,10 @@ func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
 	}
 
 	handler := &ServerHandler{
-		maxClusters:   100,
-		reader:        mockReader,
-		clientManager: clientManager,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		reader:             mockReader,
+		clientManager:      clientManager,
 	}
 
 	fp := &fakeProcessor{
@@ -498,9 +503,10 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 	}
 
 	handler := &ServerHandler{
-		maxClusters:   100,
-		reader:        mockReader,
-		clientManager: clientManager,
+		enableLiveClusters: true,
+		maxClusters:        100,
+		reader:             mockReader,
+		clientManager:      clientManager,
 	}
 
 	fp := &fakeProcessor{
@@ -554,4 +560,118 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 			t.Errorf("Expected cookie %s to be 'rayservice', got %v", COOKIE_OWNER_KIND_KEY, c)
 		}
 	})
+}
+
+// newDisabledLiveHandler builds a handler with live clusters off, a running RayCluster known to
+// Kubernetes, and one stored session for it.
+func newDisabledLiveHandler(t *testing.T, status SessionStatus) *ServerHandler {
+	t.Helper()
+
+	handler := &ServerHandler{
+		maxClusters: 100,
+		reader: &mockStorageReader{
+			clusters: []utils.ClusterInfo{{
+				Namespace:   "default",
+				Name:        "cluster-running",
+				SessionName: "session_2026-04-22_10-00-00_000000_1",
+			}},
+		},
+		clientManager: newTestClientManager(liveRayCluster("default", "cluster-running")),
+	}
+	fp := &fakeProcessor{
+		fn: func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			if status == SessionStatusProcessed {
+				return status, &eventserver.SessionSnapshot{}, nil
+			}
+			return status, nil, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, defaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	return handler
+}
+
+// TestListClustersOmitsLiveWhenDisabled asserts the RayCluster listing stays off the response, so a
+// server with live clusters disabled never enumerates RayClusters on a caller's behalf.
+func TestListClustersOmitsLiveWhenDisabled(t *testing.T) {
+	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+
+	for _, c := range handler.listClusters(100) {
+		if c.SessionName == "live" {
+			t.Fatalf("listClusters returned a live entry for %s/%s while live clusters are disabled", c.Namespace, c.Name)
+		}
+	}
+}
+
+// TestListClustersIncludesLiveWhenEnabled keeps the gate from silently becoming unconditional.
+func TestListClustersIncludesLiveWhenEnabled(t *testing.T) {
+	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+	handler.enableLiveClusters = true
+
+	for _, c := range handler.listClusters(100) {
+		if c.SessionName == "live" {
+			return
+		}
+	}
+	t.Fatal("listClusters returned no live entry while live clusters are enabled")
+}
+
+// TestEnterClusterLiveSessionRejectedWhenDisabled covers an explicit request for the live sentinel.
+func TestEnterClusterLiveSessionRejectedWhenDisabled(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+	routerRayClusterSet(handler)
+
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/live", nil)
+	resp := httptest.NewRecorder()
+	restful.DefaultContainer.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+	for _, c := range resp.Result().Cookies() {
+		if c.Name == COOKIE_SESSION_NAME_KEY && c.Value == "live" {
+			t.Error("a live session cookie was handed out while live clusters are disabled")
+		}
+	}
+}
+
+// TestEnterClusterRunningClusterRejectedWhenDisabled covers the common path: the cluster is still
+// running, so its stored session has no replayable state and there is nothing to fall back to.
+func TestEnterClusterRunningClusterRejectedWhenDisabled(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+	handler := newDisabledLiveHandler(t, SessionStatusLive)
+	routerRayClusterSet(handler)
+
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
+	resp := httptest.NewRecorder()
+	restful.DefaultContainer.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+	// The frontend surfaces this body verbatim, so it has to say why rather than just "not found".
+	if !strings.Contains(resp.Body.String(), "still running") {
+		t.Errorf("expected the body to explain the cluster is still running, got %q", resp.Body.String())
+	}
+}
+
+// TestEnterClusterStoredSessionStillWorksWhenDisabled guards the blast radius: turning live clusters
+// off must not disturb replay of a cluster that has already gone away.
+func TestEnterClusterStoredSessionStillWorksWhenDisabled(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+	routerRayClusterSet(handler)
+
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
+	resp := httptest.NewRecorder()
+	restful.DefaultContainer.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	for _, c := range resp.Result().Cookies() {
+		if c.Name == COOKIE_SESSION_NAME_KEY && c.Value != "session_2026-04-22_10-00-00_000000_1" {
+			t.Errorf("expected the stored session cookie, got %q", c.Value)
+		}
+	}
 }

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -617,8 +617,7 @@ func TestListClusters(t *testing.T) {
 }
 
 // TestEnterClusterWithLiveClustersDisabled checks how /enter_cluster answers while
-// --enable-live-clusters is off: a request that resolves to a running cluster is refused, and one
-// that resolves to a stored session still succeeds.
+// --enable-live-clusters is off.
 func TestEnterClusterWithLiveClustersDisabled(t *testing.T) {
 	t.Run("Explicit live session is rejected", func(t *testing.T) {
 		restful.DefaultContainer = restful.NewContainer()

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -562,13 +562,9 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 	})
 }
 
-// newDisabledLiveHandler returns a ServerHandler with --enable-live-clusters off. One cluster,
-// default/cluster-running, is known both to Kubernetes and to object storage, which is what a
-// still-running cluster looks like once its collector has flushed a session.
-//
-// status is what the session loader reports for that stored session. A real SessionProcessor would
-// always report SessionStatusLive, because the fake Kubernetes client holds the RayCluster, so a
-// fake processor is used to reach the SessionStatusProcessed path as well.
+// newDisabledLiveHandler returns a handler with live clusters disabled and a single RayCluster that
+// exists in both Kubernetes and storage. status controls what the fake session loader reports for
+// its stored session.
 func newDisabledLiveHandler(t *testing.T, status SessionStatus) *ServerHandler {
 	t.Helper()
 

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -562,8 +562,13 @@ func TestEnterClusterRayJobAndRayService(t *testing.T) {
 	})
 }
 
-// newDisabledLiveHandler builds a handler with live clusters off, a running RayCluster known to
-// Kubernetes, and one stored session for it.
+// newDisabledLiveHandler returns a ServerHandler with --enable-live-clusters off. One cluster,
+// default/cluster-running, is known both to Kubernetes and to object storage, which is what a
+// still-running cluster looks like once its collector has flushed a session.
+//
+// status is what the session loader reports for that stored session. A real SessionProcessor would
+// always report SessionStatusLive, because the fake Kubernetes client holds the RayCluster, so a
+// fake processor is used to reach the SessionStatusProcessed path as well.
 func newDisabledLiveHandler(t *testing.T, status SessionStatus) *ServerHandler {
 	t.Helper()
 
@@ -590,88 +595,92 @@ func newDisabledLiveHandler(t *testing.T, status SessionStatus) *ServerHandler {
 	return handler
 }
 
-// TestListClustersOmitsLiveWhenDisabled asserts the RayCluster listing stays off the response, so a
-// server with live clusters disabled never enumerates RayClusters on a caller's behalf.
-func TestListClustersOmitsLiveWhenDisabled(t *testing.T) {
-	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+// TestListClusters checks which entries listClusters returns. live RayClusters are read from the
+// Kubernetes API and carry the session name "live"; they are returned only when
+// --enable-live-clusters is set.
+func TestListClusters(t *testing.T) {
+	t.Run("Omits live clusters when live access is disabled", func(t *testing.T) {
+		handler := newDisabledLiveHandler(t, SessionStatusProcessed)
 
-	for _, c := range handler.listClusters(100) {
-		if c.SessionName == "live" {
-			t.Fatalf("listClusters returned a live entry for %s/%s while live clusters are disabled", c.Namespace, c.Name)
+		for _, c := range handler.listClusters(100) {
+			if c.SessionName == "live" {
+				t.Fatalf("listClusters returned a live entry for %s/%s while live clusters are disabled", c.Namespace, c.Name)
+			}
 		}
-	}
+	})
+
+	t.Run("Includes live clusters when live access is enabled", func(t *testing.T) {
+		handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+		handler.enableLiveClusters = true
+
+		for _, c := range handler.listClusters(100) {
+			if c.SessionName == "live" {
+				return
+			}
+		}
+		t.Fatal("listClusters returned no live entry while live clusters are enabled")
+	})
 }
 
-// TestListClustersIncludesLiveWhenEnabled keeps the gate from silently becoming unconditional.
-func TestListClustersIncludesLiveWhenEnabled(t *testing.T) {
-	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
-	handler.enableLiveClusters = true
+// TestEnterClusterWithLiveClustersDisabled checks how /enter_cluster answers while
+// --enable-live-clusters is off: a request that resolves to a running cluster is refused, and one
+// that resolves to a stored session still succeeds.
+func TestEnterClusterWithLiveClustersDisabled(t *testing.T) {
+	t.Run("Explicit live session is rejected", func(t *testing.T) {
+		restful.DefaultContainer = restful.NewContainer()
+		handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+		routerRayClusterSet(handler)
 
-	for _, c := range handler.listClusters(100) {
-		if c.SessionName == "live" {
-			return
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/live", nil)
+		resp := httptest.NewRecorder()
+		restful.DefaultContainer.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
 		}
-	}
-	t.Fatal("listClusters returned no live entry while live clusters are enabled")
-}
-
-// TestEnterClusterLiveSessionRejectedWhenDisabled covers an explicit request for the live sentinel.
-func TestEnterClusterLiveSessionRejectedWhenDisabled(t *testing.T) {
-	restful.DefaultContainer = restful.NewContainer()
-	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
-	routerRayClusterSet(handler)
-
-	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/live", nil)
-	resp := httptest.NewRecorder()
-	restful.DefaultContainer.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
-	}
-	for _, c := range resp.Result().Cookies() {
-		if c.Name == COOKIE_SESSION_NAME_KEY && c.Value == "live" {
-			t.Error("a live session cookie was handed out while live clusters are disabled")
+		for _, c := range resp.Result().Cookies() {
+			if c.Name == COOKIE_SESSION_NAME_KEY && c.Value == "live" {
+				t.Error("a live session cookie was handed out while live clusters are disabled")
+			}
 		}
-	}
-}
+	})
 
-// TestEnterClusterRunningClusterRejectedWhenDisabled covers the common path: the cluster is still
-// running, so its stored session has no replayable state and there is nothing to fall back to.
-func TestEnterClusterRunningClusterRejectedWhenDisabled(t *testing.T) {
-	restful.DefaultContainer = restful.NewContainer()
-	handler := newDisabledLiveHandler(t, SessionStatusLive)
-	routerRayClusterSet(handler)
+	t.Run("Running cluster is rejected with an explanation", func(t *testing.T) {
+		// A running cluster has no replayable state in memory, so once live access is refused there
+		// is nothing for the handler to fall back to.
+		restful.DefaultContainer = restful.NewContainer()
+		handler := newDisabledLiveHandler(t, SessionStatusLive)
+		routerRayClusterSet(handler)
 
-	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
-	resp := httptest.NewRecorder()
-	restful.DefaultContainer.ServeHTTP(resp, req)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
+		resp := httptest.NewRecorder()
+		restful.DefaultContainer.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
-	}
-	// The frontend surfaces this body verbatim, so it has to say why rather than just "not found".
-	if !strings.Contains(resp.Body.String(), "still running") {
-		t.Errorf("expected the body to explain the cluster is still running, got %q", resp.Body.String())
-	}
-}
-
-// TestEnterClusterStoredSessionStillWorksWhenDisabled guards the blast radius: turning live clusters
-// off must not disturb replay of a cluster that has already gone away.
-func TestEnterClusterStoredSessionStillWorksWhenDisabled(t *testing.T) {
-	restful.DefaultContainer = restful.NewContainer()
-	handler := newDisabledLiveHandler(t, SessionStatusProcessed)
-	routerRayClusterSet(handler)
-
-	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
-	resp := httptest.NewRecorder()
-	restful.DefaultContainer.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
-	}
-	for _, c := range resp.Result().Cookies() {
-		if c.Name == COOKIE_SESSION_NAME_KEY && c.Value != "session_2026-04-22_10-00-00_000000_1" {
-			t.Errorf("expected the stored session cookie, got %q", c.Value)
+		if resp.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
 		}
-	}
+		// The frontend surfaces this body verbatim, so it has to say why rather than just "not found".
+		if !strings.Contains(resp.Body.String(), "still running") {
+			t.Errorf("expected the body to explain the cluster is still running, got %q", resp.Body.String())
+		}
+	})
+
+	t.Run("Stored session of a dead cluster still works", func(t *testing.T) {
+		restful.DefaultContainer = restful.NewContainer()
+		handler := newDisabledLiveHandler(t, SessionStatusProcessed)
+		routerRayClusterSet(handler)
+
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-running/latest", nil)
+		resp := httptest.NewRecorder()
+		restful.DefaultContainer.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+		for _, c := range resp.Result().Cookies() {
+			if c.Name == COOKIE_SESSION_NAME_KEY && c.Value != "session_2026-04-22_10-00-00_000000_1" {
+				t.Errorf("expected the stored session cookie, got %q", c.Value)
+			}
+		}
+	})
 }

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -591,9 +591,7 @@ func newDisabledLiveHandler(t *testing.T, status SessionStatus) *ServerHandler {
 	return handler
 }
 
-// TestListClusters checks which entries listClusters returns. live RayClusters are read from the
-// Kubernetes API and carry the session name "live"; they are returned only when
-// --enable-live-clusters is set.
+// TestListClusters verifies live entries appear only when --enable-live-clusters is set.
 func TestListClusters(t *testing.T) {
 	t.Run("Omits live clusters when live access is disabled", func(t *testing.T) {
 		handler := newDisabledLiveHandler(t, SessionStatusProcessed)

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -151,7 +151,7 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 		return utils.ClusterInfo{}, false, fmt.Errorf("unsupported resource kind: %q (must be raycluster, rayjob, or rayservice)", resourceType)
 	}
 
-	// The "live" session does not exist when --enable-live-clusters are disabled. Return not-found here
+	// The "live" session does not exist when --enable-live-clusters is disabled. Return not-found here
 	// rather than falling through, so it is never matched against a stored session name.
 	if session == "live" && !s.enableLiveClusters {
 		return utils.ClusterInfo{}, false, nil

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -118,19 +118,21 @@ func crdLabelValueFor(kindLower string) string {
 func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	// Initial continuation marker
 	logrus.Debugf("Prepare to get list clusters info ...")
-	ctx := context.Background()
-	liveClusterNames := []string{}
 	liveClusterInfos := []utils.ClusterInfo{}
-	liveClusters, err := s.clientManager.ListRayClusters(ctx)
-	if err != nil {
-		logrus.Errorf("Failed to list live RayClusters: %v", err)
+	if s.enableLiveClusters {
+		ctx := context.Background()
+		liveClusterNames := []string{}
+		liveClusters, err := s.clientManager.ListRayClusters(ctx)
+		if err != nil {
+			logrus.Errorf("Failed to list live RayClusters: %v", err)
+		}
+		for _, liveCluster := range liveClusters {
+			liveClusterInfo := buildLiveClusterInfo(liveCluster)
+			liveClusterInfos = append(liveClusterInfos, liveClusterInfo)
+			liveClusterNames = append(liveClusterNames, liveCluster.Name)
+		}
+		logrus.Infof("live clusters: %v", liveClusterNames)
 	}
-	for _, liveCluster := range liveClusters {
-		liveClusterInfo := buildLiveClusterInfo(liveCluster)
-		liveClusterInfos = append(liveClusterInfos, liveClusterInfo)
-		liveClusterNames = append(liveClusterNames, liveCluster.Name)
-	}
-	logrus.Infof("live clusters: %v", liveClusterNames)
 	clusters := s.reader.List()
 	sort.Sort(utils.ClusterInfoList(clusters))
 	if limit > 0 && limit < len(clusters) {
@@ -149,8 +151,14 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 		return utils.ClusterInfo{}, false, fmt.Errorf("unsupported resource kind: %q (must be raycluster, rayjob, or rayservice)", resourceType)
 	}
 
+	// The "live" session does not exist when --enable-live-clusters are disabled. Return not-found here
+	// rather than falling through, so it is never matched against a stored session name.
+	if session == "live" && !s.enableLiveClusters {
+		return utils.ClusterInfo{}, false, nil
+	}
+
 	// Check live clusters first if applicable
-	if isLatestOrEmpty || session == "live" {
+	if s.enableLiveClusters && (isLatestOrEmpty || session == "live") {
 		if resTypeLower == utils.RayClusterKind {
 			liveCluster, err := s.clientManager.GetRayCluster(ctx, namespace, resourceName)
 			if err == nil {

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -151,8 +151,7 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 		return utils.ClusterInfo{}, false, fmt.Errorf("unsupported resource kind: %q (must be raycluster, rayjob, or rayservice)", resourceType)
 	}
 
-	// The "live" session does not exist when --enable-live-clusters is disabled. Return not-found here
-	// rather than falling through, so it is never matched against a stored session name.
+	// "live" is not a valid session while --enable-live-clusters is disabled.
 	if session == "live" && !s.enableLiveClusters {
 		return utils.ClusterInfo{}, false, nil
 	}

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -352,6 +352,12 @@ func routerRayClusterSet(s *ServerHandler) {
 			// Users might use the complete session name to enter a live cluster,
 			// so "live" sentinel is set to avoid querying empty in-memory state.
 			if live {
+				if !s.enableLiveClusters {
+					r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf(
+						"RayCluster %s/%s is still running, so session %q has no stored replay to serve; --enable-live-clusters is disabled on this History Server",
+						namespace, resolvedName, resolvedSession))
+					return
+				}
 				resolvedSession = "live"
 			}
 		}
@@ -413,7 +419,17 @@ func (s *ServerHandler) RegisterRouter() {
 }
 
 func (s *ServerHandler) redirectRequest(req *restful.Request, resp *restful.Response) {
-	svcInfo := req.Attribute(ATTRIBUTE_SERVICE_NAME).(ServiceInfo)
+	if !s.enableLiveClusters {
+		resp.WriteErrorString(http.StatusForbidden, "live cluster access is disabled on this History Server")
+		return
+	}
+
+	svcInfo, ok := req.Attribute(ATTRIBUTE_SERVICE_NAME).(ServiceInfo)
+	if !ok {
+		logrus.Errorf("Cannot proxy %s: head service info missing from the request context", req.Request.URL.String())
+		resp.WriteErrorString(http.StatusInternalServerError, "head service info missing from the request context")
+		return
+	}
 
 	var targetURL string
 	if s.useKubernetesProxy {
@@ -2036,6 +2052,12 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 	}
 	if ownerName.Value != "" && !fs.ValidPath(ownerName.Value) {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (owner_name=%s)", ownerName.Value))
+		return
+	}
+
+	if sessionName.Value == "live" && !s.enableLiveClusters {
+		logrus.Warnf("Rejected live session request for %s/%s: live cluster access is disabled", clusterNamespace.Value, clusterName.Value)
+		resp.WriteHeaderAndEntity(http.StatusForbidden, "live cluster access is disabled on this History Server")
 		return
 	}
 

--- a/historyserver/pkg/historyserver/server.go
+++ b/historyserver/pkg/historyserver/server.go
@@ -25,6 +25,7 @@ type ServerHandler struct {
 
 	useKubernetesProxy bool
 	useAuthTokenMode   bool
+	enableLiveClusters bool
 }
 
 func NewServerHandler(
@@ -35,7 +36,7 @@ func NewServerHandler(
 	sessionLoader *SessionLoader,
 	useKubernetesProxy bool,
 	useAuthTokenMode bool,
-) (*ServerHandler, error) {
+	enableLiveClusters bool) (*ServerHandler, error) {
 	handler := &ServerHandler{
 		reader:        reader,
 		clientManager: clientManager,
@@ -46,7 +47,8 @@ func NewServerHandler(
 		// TODO: make this configurable
 		maxClusters: 100,
 
-		useAuthTokenMode: useAuthTokenMode,
+		useAuthTokenMode:   useAuthTokenMode,
+		enableLiveClusters: enableLiveClusters,
 	}
 
 	if len(clientManager.configs) > 0 {

--- a/historyserver/test/e2e/historyserver_azureblob_test.go
+++ b/historyserver/test/e2e/historyserver_azureblob_test.go
@@ -50,7 +50,7 @@ func TestAzureHistoryServer(t *testing.T) {
 func testAzureLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -87,7 +87,7 @@ func testAzureDeadClusters(test Test, g *WithT, namespace *corev1.Namespace, azu
 func testAzureLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/e2e/historyserver_azureblob_test.go
+++ b/historyserver/test/e2e/historyserver_azureblob_test.go
@@ -50,7 +50,7 @@ func TestAzureHistoryServer(t *testing.T) {
 func testAzureLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -87,7 +87,7 @@ func testAzureDeadClusters(test Test, g *WithT, namespace *corev1.Namespace, azu
 func testAzureLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/e2e/historyserver_azureblob_test.go
+++ b/historyserver/test/e2e/historyserver_azureblob_test.go
@@ -50,7 +50,7 @@ func TestAzureHistoryServer(t *testing.T) {
 func testAzureLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath)
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -87,7 +87,7 @@ func testAzureDeadClusters(test Test, g *WithT, namespace *corev1.Namespace, azu
 func testAzureLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, azureClient *azblob.Client) {
 	rayCluster := PrepareAzureBlobTestEnv(test, g, namespace, azureClient)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath)
+	ApplyHistoryServer(test, g, namespace, AzureHistoryServerManifestPath, WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -156,7 +156,7 @@ func TestHistoryServer(t *testing.T) {
 func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -172,7 +172,7 @@ func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client
 func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -190,7 +190,7 @@ func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3C
 func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -207,7 +207,7 @@ func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, 
 func testLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1014,7 +1014,7 @@ func getEligibleWorkerPID(g *WithT, client *http.Client, historyServerURL string
 func testLogStreamEndpoint(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// Test 1: Live cluster - streaming should work
@@ -1363,7 +1363,7 @@ func countFiles(result map[string]interface{}) int {
 func testTimelineEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1730,7 +1730,7 @@ func testLiveClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2000,7 +2000,7 @@ func testLiveClusterNodes(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2094,7 +2094,7 @@ func testLiveClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
 
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2177,7 +2177,7 @@ func testDeadClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 // live Ray Dashboard and returns valid cluster metadata.
 func testLiveClusterMetadata(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2395,7 +2395,7 @@ func testLiveClusterTaskSummarize(test Test, g *WithT, namespace *corev1.Namespa
 	endpoint := EndpointTasksSummarize + "?summary_by=lineage"
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2475,7 +2475,7 @@ func testLiveClusterTaskSummarizeFuncName(test Test, g *WithT, namespace *corev1
 	endpoint := EndpointTasksSummarize
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3196,7 +3196,7 @@ func verifyNodesHostNameListSchema(test Test, g *WithT, nodesResp map[string]any
 func testEventsEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3391,7 +3391,7 @@ func testEventsEndpointDeadCluster(test Test, g *WithT, namespace *corev1.Namesp
 // 10. Delete S3 bucket to ensure test isolation
 func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// --- Live cluster ---
@@ -3458,7 +3458,7 @@ func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Names
 func testLiveClusterStatus(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
+	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -156,7 +156,7 @@ func TestHistoryServer(t *testing.T) {
 func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -172,7 +172,7 @@ func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client
 func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -190,7 +190,7 @@ func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3C
 func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -207,7 +207,7 @@ func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, 
 func testLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1014,7 +1014,7 @@ func getEligibleWorkerPID(g *WithT, client *http.Client, historyServerURL string
 func testLogStreamEndpoint(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// Test 1: Live cluster - streaming should work
@@ -1363,7 +1363,7 @@ func countFiles(result map[string]interface{}) int {
 func testTimelineEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1730,7 +1730,7 @@ func testLiveClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2000,7 +2000,7 @@ func testLiveClusterNodes(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2094,7 +2094,7 @@ func testLiveClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
 
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2177,7 +2177,7 @@ func testDeadClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 // live Ray Dashboard and returns valid cluster metadata.
 func testLiveClusterMetadata(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2395,7 +2395,7 @@ func testLiveClusterTaskSummarize(test Test, g *WithT, namespace *corev1.Namespa
 	endpoint := EndpointTasksSummarize + "?summary_by=lineage"
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2475,7 +2475,7 @@ func testLiveClusterTaskSummarizeFuncName(test Test, g *WithT, namespace *corev1
 	endpoint := EndpointTasksSummarize
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3196,7 +3196,7 @@ func verifyNodesHostNameListSchema(test Test, g *WithT, nodesResp map[string]any
 func testEventsEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3391,7 +3391,7 @@ func testEventsEndpointDeadCluster(test Test, g *WithT, namespace *corev1.Namesp
 // 10. Delete S3 bucket to ensure test isolation
 func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// --- Live cluster ---
@@ -3458,7 +3458,7 @@ func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Names
 func testLiveClusterStatus(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "", "--enable-live-clusters=true")
+	ApplyHistoryServer(test, g, namespace, "", EnableLiveClustersArg)
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -156,7 +156,7 @@ func TestHistoryServer(t *testing.T) {
 func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -172,7 +172,7 @@ func testLiveClusters(test Test, g *WithT, namespace *corev1.Namespace, s3Client
 func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -190,7 +190,7 @@ func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3C
 func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -207,7 +207,7 @@ func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, 
 func testLogFileEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1014,7 +1014,7 @@ func getEligibleWorkerPID(g *WithT, client *http.Client, historyServerURL string
 func testLogStreamEndpoint(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// Test 1: Live cluster - streaming should work
@@ -1363,7 +1363,7 @@ func countFiles(result map[string]interface{}) int {
 func testTimelineEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -1730,7 +1730,7 @@ func testLiveClusterTasks(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2000,7 +2000,7 @@ func testLiveClusterNodes(test Test, g *WithT, namespace *corev1.Namespace, s3Cl
 
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2094,7 +2094,7 @@ func testLiveClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
 
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2177,7 +2177,7 @@ func testDeadClusterNode(test Test, g *WithT, namespace *corev1.Namespace, s3Cli
 // live Ray Dashboard and returns valid cluster metadata.
 func testLiveClusterMetadata(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2395,7 +2395,7 @@ func testLiveClusterTaskSummarize(test Test, g *WithT, namespace *corev1.Namespa
 	endpoint := EndpointTasksSummarize + "?summary_by=lineage"
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -2475,7 +2475,7 @@ func testLiveClusterTaskSummarizeFuncName(test Test, g *WithT, namespace *corev1
 	endpoint := EndpointTasksSummarize
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3196,7 +3196,7 @@ func verifyNodesHostNameListSchema(test Test, g *WithT, nodesResp map[string]any
 func testEventsEndpointLiveCluster(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)
@@ -3391,7 +3391,7 @@ func testEventsEndpointDeadCluster(test Test, g *WithT, namespace *corev1.Namesp
 // 10. Delete S3 bucket to ensure test isolation
 func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	// --- Live cluster ---
@@ -3458,7 +3458,7 @@ func testLiveAndDeadClusterTimezone(test Test, g *WithT, namespace *corev1.Names
 func testLiveClusterStatus(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace, "")
+	ApplyHistoryServer(test, g, namespace, "", WithLiveClusters())
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)

--- a/historyserver/test/support/historyserver.go
+++ b/historyserver/test/support/historyserver.go
@@ -102,9 +102,7 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 
 	KubectlApplyYAML(test, manifestPath, namespace.Name)
 
-	if len(extraArgs) > 0 {
-		patchHistoryServerArgs(test, g, namespace, extraArgs)
-	}
+	appendHistoryServerArgs(test, g, namespace, extraArgs)
 
 	LogWithTimestamp(test.T(), "Waiting for HistoryServer to be ready")
 	g.Eventually(func(gg Gomega) {
@@ -115,7 +113,7 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 		)
 		gg.Expect(err).NotTo(HaveOccurred())
 		gg.Expect(pods.Items).NotTo(BeEmpty())
-		// Also require the args, otherwise the pod from before patchHistoryServerArgs can report
+		// Also require the args, otherwise the pod from before appendHistoryServerArgs can report
 		// ready and let the test run against a History Server without the requested flags.
 		for _, pod := range pods.Items {
 			gg.Expect(podHasArgs(pod, extraArgs)).To(BeTrue(),
@@ -126,37 +124,27 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 	LogWithTimestamp(test.T(), "HistoryServer is ready")
 }
 
-// patchHistoryServerArgs appends args to the History Server container.
-func patchHistoryServerArgs(test Test, g *WithT, namespace *corev1.Namespace, args []string) {
-	deployments, err := test.Client().Core().AppsV1().Deployments(namespace.Name).List(
-		test.Ctx(), metav1.ListOptions{LabelSelector: "app=historyserver"},
-	)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(deployments.Items).To(HaveLen(1))
+// appendHistoryServerArgs appends args to the History Server.
+func appendHistoryServerArgs(test Test, g *WithT, namespace *corev1.Namespace, args []string) {
+	if len(args) == 0 {
+		return
+	}
 
-	deployment := deployments.Items[0]
-	g.Expect(deployment.Spec.Template.Spec.Containers).NotTo(BeEmpty())
-	container := deployment.Spec.Template.Spec.Containers[0]
-
-	merged := append(append([]string{}, container.Args...), args...)
-	patch, err := json.Marshal(map[string]any{
-		"spec": map[string]any{
-			"template": map[string]any{
-				"spec": map[string]any{
-					"containers": []map[string]any{{
-						"name": container.Name,
-						"args": merged,
-					}},
-				},
-			},
-		},
-	})
+	ops := make([]map[string]any, 0, len(args))
+	for _, arg := range args {
+		ops = append(ops, map[string]any{
+			"op":    "add",
+			"path":  "/spec/template/spec/containers/0/args/-",
+			"value": arg,
+		})
+	}
+	patch, err := json.Marshal(ops)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	_, err = test.Client().Core().AppsV1().Deployments(namespace.Name).Patch(
-		test.Ctx(), deployment.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		test.Ctx(), "historyserver-demo", types.JSONPatchType, patch, metav1.PatchOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Patched HistoryServer args to %v", merged)
+	LogWithTimestamp(test.T(), "Appended args %v to the HistoryServer Deployment", args)
 }
 
 // podHasArgs reports whether every arg appears on the pod's first container.

--- a/historyserver/test/support/historyserver.go
+++ b/historyserver/test/support/historyserver.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
@@ -68,11 +69,32 @@ var HistoryServerEndpoints = []string{
 const HistoryServerEndpointPrometheusHealth = "/api/prometheus_health"
 const HistoryServerEndpointGrafanaHealth = "/api/grafana_health"
 
+// HistoryServerOption customizes the History Server deployment applied by ApplyHistoryServer.
+type HistoryServerOption func(*historyServerOptions)
+
+type historyServerOptions struct {
+	extraArgs []string
+}
+
+// WithLiveClusters starts the History Server with live RayCluster support enabled. The shipped
+// manifests leave it off, matching the binary default, so any test that enters a running cluster
+// has to opt in explicitly.
+func WithLiveClusters() HistoryServerOption {
+	return func(o *historyServerOptions) {
+		o.extraArgs = append(o.extraArgs, "--enable-live-clusters=true")
+	}
+}
+
 // ApplyHistoryServer deploys the HistoryServer and RBAC resources.
 // If manifestPath is empty, the default HistoryServerManifestPath is used.
-func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manifestPath string) {
+func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manifestPath string, opts ...HistoryServerOption) {
 	if manifestPath == "" {
 		manifestPath = HistoryServerManifestPath
+	}
+
+	options := historyServerOptions{}
+	for _, apply := range opts {
+		apply(&options)
 	}
 
 	sa, clusterRole, clusterRoleBinding := DeserializeRBACFromYAML(test, ServiceAccountManifestPath)
@@ -101,6 +123,10 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 
 	KubectlApplyYAML(test, manifestPath, namespace.Name)
 
+	if len(options.extraArgs) > 0 {
+		patchHistoryServerArgs(test, g, namespace, options.extraArgs)
+	}
+
 	LogWithTimestamp(test.T(), "Waiting for HistoryServer to be ready")
 	g.Eventually(func(gg Gomega) {
 		pods, err := test.Client().Core().CoreV1().Pods(namespace.Name).List(
@@ -110,9 +136,65 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 		)
 		gg.Expect(err).NotTo(HaveOccurred())
 		gg.Expect(pods.Items).NotTo(BeEmpty())
+		// Also require the args, otherwise the pod from before patchHistoryServerArgs can report
+		// ready and let the test run against a History Server without the requested flags.
+		for _, pod := range pods.Items {
+			gg.Expect(podHasArgs(pod, options.extraArgs)).To(BeTrue(),
+				"pod %s does not carry the requested args %v", pod.Name, options.extraArgs)
+		}
 		gg.Expect(AllPodsRunningAndReady(pods.Items)).To(BeTrue())
 	}, TestTimeoutMedium).Should(Succeed())
 	LogWithTimestamp(test.T(), "HistoryServer is ready")
+}
+
+// patchHistoryServerArgs appends args to the History Server container.
+func patchHistoryServerArgs(test Test, g *WithT, namespace *corev1.Namespace, args []string) {
+	deployments, err := test.Client().Core().AppsV1().Deployments(namespace.Name).List(
+		test.Ctx(), metav1.ListOptions{LabelSelector: "app=historyserver"},
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(deployments.Items).To(HaveLen(1))
+
+	deployment := deployments.Items[0]
+	g.Expect(deployment.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	merged := append(append([]string{}, container.Args...), args...)
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []map[string]any{{
+						"name": container.Name,
+						"args": merged,
+					}},
+				},
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	_, err = test.Client().Core().AppsV1().Deployments(namespace.Name).Patch(
+		test.Ctx(), deployment.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Patched HistoryServer args to %v", merged)
+}
+
+// podHasArgs reports whether every arg appears on the pod's first container.
+func podHasArgs(pod corev1.Pod, args []string) bool {
+	if len(pod.Spec.Containers) == 0 {
+		return false
+	}
+	present := make(map[string]bool, len(pod.Spec.Containers[0].Args))
+	for _, arg := range pod.Spec.Containers[0].Args {
+		present[arg] = true
+	}
+	for _, arg := range args {
+		if !present[arg] {
+			return false
+		}
+	}
+	return true
 }
 
 // GetHistoryServerURL sets up port-forwarding to the history server and waits for it to be ready.

--- a/historyserver/test/support/historyserver.go
+++ b/historyserver/test/support/historyserver.go
@@ -23,6 +23,9 @@ const (
 	HistoryServerManifestPath = "../../config/historyserver.yaml"
 	HistoryServerPort         = 30080
 
+	// EnableLiveClustersArg turns on access to live RayClusters
+	EnableLiveClustersArg = "--enable-live-clusters=true"
+
 	// Session name constants
 	LiveSessionName = "live"
 

--- a/historyserver/test/support/historyserver.go
+++ b/historyserver/test/support/historyserver.go
@@ -69,32 +69,11 @@ var HistoryServerEndpoints = []string{
 const HistoryServerEndpointPrometheusHealth = "/api/prometheus_health"
 const HistoryServerEndpointGrafanaHealth = "/api/grafana_health"
 
-// HistoryServerOption customizes the History Server deployment applied by ApplyHistoryServer.
-type HistoryServerOption func(*historyServerOptions)
-
-type historyServerOptions struct {
-	extraArgs []string
-}
-
-// WithLiveClusters starts the History Server with live RayCluster support enabled. The shipped
-// manifests leave it off, matching the binary default, so any test that enters a running cluster
-// has to opt in explicitly.
-func WithLiveClusters() HistoryServerOption {
-	return func(o *historyServerOptions) {
-		o.extraArgs = append(o.extraArgs, "--enable-live-clusters=true")
-	}
-}
-
 // ApplyHistoryServer deploys the HistoryServer and RBAC resources.
 // If manifestPath is empty, the default HistoryServerManifestPath is used.
-func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manifestPath string, opts ...HistoryServerOption) {
+func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manifestPath string, extraArgs ...string) {
 	if manifestPath == "" {
 		manifestPath = HistoryServerManifestPath
-	}
-
-	options := historyServerOptions{}
-	for _, apply := range opts {
-		apply(&options)
 	}
 
 	sa, clusterRole, clusterRoleBinding := DeserializeRBACFromYAML(test, ServiceAccountManifestPath)
@@ -123,8 +102,8 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 
 	KubectlApplyYAML(test, manifestPath, namespace.Name)
 
-	if len(options.extraArgs) > 0 {
-		patchHistoryServerArgs(test, g, namespace, options.extraArgs)
+	if len(extraArgs) > 0 {
+		patchHistoryServerArgs(test, g, namespace, extraArgs)
 	}
 
 	LogWithTimestamp(test.T(), "Waiting for HistoryServer to be ready")
@@ -139,8 +118,8 @@ func ApplyHistoryServer(test Test, g *WithT, namespace *corev1.Namespace, manife
 		// Also require the args, otherwise the pod from before patchHistoryServerArgs can report
 		// ready and let the test run against a History Server without the requested flags.
 		for _, pod := range pods.Items {
-			gg.Expect(podHasArgs(pod, options.extraArgs)).To(BeTrue(),
-				"pod %s does not carry the requested args %v", pod.Name, options.extraArgs)
+			gg.Expect(podHasArgs(pod, extraArgs)).To(BeTrue(),
+				"pod %s does not carry the requested args %v", pod.Name, extraArgs)
 		}
 		gg.Expect(AllPodsRunningAndReady(pods.Items)).To(BeTrue())
 	}, TestTimeoutMedium).Should(Succeed())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds `--enable-live-clusters`, defaulting to **false**, gating:

| Location | Behavior when disabled |
| --- | --- |
| `listClusters` | Skips the cluster-wide RayCluster list; `/clusters` returns stored sessions only |
| `resolveSession` | Prevents `session=live` from being resolved as a live cluster |
| `CookieHandle` | Rejects a `session_name=live` cookie with 403, before any Kubernetes or Secret reads |
| `redirectRequest` | Adds a defense-in-depth guard and replaces an unchecked type assertion |


`CookieHandle` is the primary security boundary for live-cluster access. Since the session cookie is user-controlled, this check ensures that a forged `session_name=live` cookie cannot reach a live RayCluster when live-cluster access is disabled.

The other guards are primarily for correctness and user experience: they prevent live clusters from being advertised as available or allow users to receive a clear error before entering a dashboard that would otherwise fail with 403s on every API request.

This also ensures that disabling live-cluster access does not affect historical session replay.


### User-facing behavior change

Entering a RayCluster that is still running now returns 404 with an explanation rather than proxying. `/clusters` no longer lists live clusters. Operators who rely on live mode must set `--enable-live-clusters=true`.

`select_cluster.html` now surfaces the response body on error; it previously showed only `statusText`, which could not distinguish "no such cluster" from "live cluster access is disabled".


### Manual test


I applied [historyserver/config/raycluster.yaml](https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml) and a [historyserver/config/rayjob.yaml](https://github.com/ray-project/kuberay/blob/master/historyserver/config/rayjob.yaml) for the testing.

Before:

<img width="1930" height="574" alt="image" src="https://github.com/user-attachments/assets/d23baacf-03ba-4d7f-acc0-bf5536d53c22" />


After:

The running RayCluster is no longer shown as a **Live** cluster when `--enable-live-clusters` is disabled.

<img width="1928" height="499" alt="image" src="https://github.com/user-attachments/assets/010b6549-5bf0-4297-8d1b-0ef21dd4471b" />


## Related issue number

Closes #5198

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
