### PR TITLE
[RayCluster] [Fix] RayCluster suspend leaks the Volcano PodGroup, leaving queue resources reserved

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/interface/interface.go
+++ b/ray-operator/controllers/ray/batchscheduler/interface/interface.go
@@ -24,11 +24,15 @@ type BatchScheduler interface {
 	// For example, setting labels for queues / priority, and setting schedulerName.
 	AddMetadataToChildResource(ctx context.Context, parent metav1.Object, child metav1.Object, groupName string)
 
-	// CleanupOnCompletion handles cleanup when the RayJob reaches terminal state (Complete/Failed).
-	// For batch schedulers like Volcano, this deletes the PodGroup to release queue resources.
+	// CleanupOnCompletion handles cleanup when the RayJob no longer needs the capacity it
+	// reserved: it reached a terminal state (Complete/Failed) or was suspended.
+	// For batch schedulers like Volcano, this releases the PodGroup's reserved queue resources.
 	// This is a no-op for schedulers that don't need cleanup.
 	// Returns (didCleanup, error) where didCleanup indicates whether actual cleanup was performed.
 	CleanupOnCompletion(ctx context.Context, object metav1.Object) (didCleanup bool, err error)
+
+	// CleanupOnSuspend releases the capacity reserved for a suspended RayCluster.
+	CleanupOnSuspend(ctx context.Context, object metav1.Object) (didCleanup bool, err error)
 }
 
 // BatchSchedulerFactory handles initial setup of the scheduler plugin by registering the
@@ -65,6 +69,10 @@ func (d *DefaultBatchScheduler) AddMetadataToChildResource(_ context.Context, _ 
 }
 
 func (d *DefaultBatchScheduler) CleanupOnCompletion(_ context.Context, _ metav1.Object) (bool, error) {
+	return false, nil
+}
+
+func (d *DefaultBatchScheduler) CleanupOnSuspend(_ context.Context, _ metav1.Object) (bool, error) {
 	return false, nil
 }
 

--- a/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
@@ -75,6 +75,11 @@ func (k *KaiScheduler) CleanupOnCompletion(_ context.Context, _ metav1.Object) (
 	return false, nil
 }
 
+func (k *KaiScheduler) CleanupOnSuspend(_ context.Context, _ metav1.Object) (bool, error) {
+	// KaiScheduler doesn't need cleanup
+	return false, nil
+}
+
 func (kf *KaiSchedulerFactory) New(_ context.Context, _ *rest.Config, _ client.Client) (schedulerinterface.BatchScheduler, error) {
 	return &KaiScheduler{}, nil
 }

--- a/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha2/kubernetes_was_v1alpha2.go
+++ b/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha2/kubernetes_was_v1alpha2.go
@@ -85,6 +85,11 @@ func (k *KubernetesWASV1Alpha2Scheduler) CleanupOnCompletion(ctx context.Context
 	return k.deleteSchedulingResources(ctx, rayCluster)
 }
 
+func (k *KubernetesWASV1Alpha2Scheduler) CleanupOnSuspend(_ context.Context, _ metav1.Object) (bool, error) {
+	// The Workload and PodGroup reserve nothing without Pods and are reused on resume.
+	return false, nil
+}
+
 // The methods below adapt this package to kuberneteswas.Provider.
 
 func (p *Provider) GroupVersion() schema.GroupVersion {

--- a/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins.go
+++ b/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins.go
@@ -118,6 +118,11 @@ func (k *KubeScheduler) CleanupOnCompletion(_ context.Context, _ metav1.Object) 
 	return false, nil
 }
 
+func (k *KubeScheduler) CleanupOnSuspend(_ context.Context, _ metav1.Object) (bool, error) {
+	// KubeScheduler doesn't need cleanup
+	return false, nil
+}
+
 func (kf *KubeSchedulerFactory) New(_ context.Context, _ *rest.Config, cli client.Client) (schedulerinterface.BatchScheduler, error) {
 	if err := v1alpha1.AddToScheme(cli.Scheme()); err != nil {
 		return nil, err

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -267,12 +267,35 @@ func (v *VolcanoBatchScheduler) AddMetadataToChildResource(_ context.Context, pa
 	addSchedulerName(child, v.Name())
 }
 
-// CleanupOnCompletion recalculates and updates the PodGroup resources when a RayJob finishes.
-// This is called when the RayJob reaches terminal state (Complete/Failed).
+// CleanupOnSuspend zeroes out a suspended RayCluster's PodGroup so it stops reserving queue
+// capacity. The suspended RayCluster still exists, so its OwnerReference cannot do this.
+func (v *VolcanoBatchScheduler) CleanupOnSuspend(ctx context.Context, object metav1.Object) (bool, error) {
+	rayCluster, ok := object.(*rayv1.RayCluster)
+	if !ok {
+		return false, nil
+	}
+
+	// A RayCluster created by a RayJob shares the RayJob's PodGroup, which the RayJob reconciler owns.
+	if crdType, ok := rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey]; ok && crdType == utils.RayOriginatedFromCRDLabelValue(utils.RayJobCRD) {
+		return false, nil
+	}
+
+	// A cluster without a PodGroup reserves nothing; don't let syncPodGroup create an empty one.
+	podGroupName := getAppPodGroupName(rayCluster)
+	if err := v.cli.Get(ctx, types.NamespacedName{Namespace: rayCluster.Namespace, Name: podGroupName}, &volcanoschedulingv1beta1.PodGroup{}); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return v.syncPodGroup(ctx, rayCluster, 0, corev1.ResourceList{})
+}
+
+// CleanupOnCompletion recalculates and updates the PodGroup resources when the RayJob no longer
+// needs the capacity it reserved: it reached a terminal state (Complete/Failed) or was suspended.
 //
-// For RayCluster objects, this is a no-op because the PodGroup is cleaned up by the OwnerReference of the RayCluster.
-//
-// For RayJob objects, the PodGroup's MinMember and MinResources are recalculated based on the
+// The PodGroup's MinMember and MinResources are recalculated based on the
 // live RayCluster state. This correctly handles deletion strategies:
 //   - If workers are suspended by DeleteWorkers policy, calculatePodGroupParams automatically
 //     excludes suspended groups, so the PodGroup reflects only the head pod.
@@ -281,7 +304,7 @@ func (v *VolcanoBatchScheduler) AddMetadataToChildResource(_ context.Context, pa
 func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object metav1.Object) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName(pluginName)
 
-	// Only handle RayJob. RayCluster PodGroups will be cleaned up by the OwnerReference.
+	// Only handle RayJob. RayCluster PodGroups are handled by CleanupOnSuspend and the OwnerReference.
 	rayJob, ok := object.(*rayv1.RayJob)
 	if !ok {
 		return false, nil

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -579,8 +580,8 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 	})
 }
 
-func TestCleanupOnCompletion(t *testing.T) {
-	t.Run("RayCluster - should be no-op", func(t *testing.T) {
+func TestCleanupOnSuspend(t *testing.T) {
+	t.Run("RayCluster - no PodGroup - should be no-op", func(t *testing.T) {
 		a := assert.New(t)
 		require := require.New(t)
 
@@ -593,10 +594,137 @@ func TestCleanupOnCompletion(t *testing.T) {
 
 		ctx := context.Background()
 
-		// Call CleanupOnCompletion with RayCluster - should be no-op
+		// Nothing is reserved, so there is nothing to release and no PodGroup to create.
+		didUpdate, err := scheduler.CleanupOnSuspend(ctx, &rayCluster)
+		require.NoError(err)
+		a.False(didUpdate)
+
+		podGroup := volcanoschedulingv1beta1.PodGroup{}
+		err = fakeCli.Get(ctx, client.ObjectKey{Namespace: rayCluster.Namespace, Name: getAppPodGroupName(&rayCluster)}, &podGroup)
+		a.True(errors.IsNotFound(err), "CleanupOnSuspend must not create a PodGroup, got err=%v", err)
+	})
+
+	// Regression test for https://github.com/ray-project/kuberay/issues/5183.
+	t.Run("RayCluster - suspended - releases the reserved capacity", func(t *testing.T) {
+		a := assert.New(t)
+		require := require.New(t)
+
+		rayCluster := createTestRayCluster(1)
+		scheme := runtime.NewScheme()
+		a.NoError(rayv1.AddToScheme(scheme))
+		a.NoError(volcanoschedulingv1beta1.AddToScheme(scheme))
+		fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		scheduler := &VolcanoBatchScheduler{cli: fakeCli}
+
+		ctx := context.Background()
+
+		// The running cluster reserves its full size.
+		require.NoError(scheduler.DoBatchSchedulingOnSubmission(ctx, &rayCluster))
+
+		podGroupKey := client.ObjectKey{Namespace: rayCluster.Namespace, Name: getAppPodGroupName(&rayCluster)}
+		podGroup := volcanoschedulingv1beta1.PodGroup{}
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &podGroup))
+		require.Equal(utils.CalculateDesiredReplicas(&rayCluster)+1, podGroup.Spec.MinMember)
+		require.NotEmpty(*podGroup.Spec.MinResources)
+
+		// Suspending it must hand that capacity back.
+		didUpdate, err := scheduler.CleanupOnSuspend(ctx, &rayCluster)
+		require.NoError(err)
+		a.True(didUpdate)
+
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &podGroup))
+		a.Equal(int32(0), podGroup.Spec.MinMember)
+		a.Empty(*podGroup.Spec.MinResources)
+
+		// Idempotent, so a suspended cluster does not write (or emit an event) every reconcile.
+		didUpdate, err = scheduler.CleanupOnSuspend(ctx, &rayCluster)
+		require.NoError(err)
+		a.False(didUpdate)
+	})
+
+	t.Run("RayCluster - originated from a RayJob - should be no-op", func(t *testing.T) {
+		a := assert.New(t)
+		require := require.New(t)
+
+		// The cluster shares the RayJob's PodGroup, so it must not zero out the RayJob's reservation.
+		rayJob := createTestRayJob(1)
+		rayCluster := createTestRayClusterWithLabels(map[string]string{
+			utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayJobCRD),
+			utils.RayOriginatedFromCRNameLabelKey: rayJob.Name,
+		})
+
+		scheme := runtime.NewScheme()
+		a.NoError(rayv1.AddToScheme(scheme))
+		a.NoError(volcanoschedulingv1beta1.AddToScheme(scheme))
+		fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		scheduler := &VolcanoBatchScheduler{cli: fakeCli}
+
+		ctx := context.Background()
+
+		require.NoError(scheduler.DoBatchSchedulingOnSubmission(ctx, &rayJob))
+
+		podGroupKey := client.ObjectKey{Namespace: rayJob.Namespace, Name: getAppPodGroupName(&rayJob)}
+		before := volcanoschedulingv1beta1.PodGroup{}
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &before))
+		require.NotEmpty(*before.Spec.MinResources)
+
+		didUpdate, err := scheduler.CleanupOnSuspend(ctx, &rayCluster)
+		require.NoError(err)
+		a.False(didUpdate)
+
+		after := volcanoschedulingv1beta1.PodGroup{}
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &after))
+		a.Equal(before.Spec.MinMember, after.Spec.MinMember)
+		a.Equal(before.Spec.MinResources, after.Spec.MinResources)
+	})
+
+	t.Run("RayJob - should be no-op", func(t *testing.T) {
+		a := assert.New(t)
+		require := require.New(t)
+
+		// RayJob capacity is released through CleanupOnCompletion by the RayJob reconciler.
+		rayJob := createTestRayJob(1)
+		scheme := runtime.NewScheme()
+		a.NoError(rayv1.AddToScheme(scheme))
+		a.NoError(volcanoschedulingv1beta1.AddToScheme(scheme))
+		fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		scheduler := &VolcanoBatchScheduler{cli: fakeCli}
+
+		didUpdate, err := scheduler.CleanupOnSuspend(context.Background(), &rayJob)
+		require.NoError(err)
+		a.False(didUpdate)
+	})
+}
+
+func TestCleanupOnCompletion(t *testing.T) {
+	t.Run("RayCluster - should be no-op", func(t *testing.T) {
+		a := assert.New(t)
+		require := require.New(t)
+
+		// RayCluster capacity is released through CleanupOnSuspend by the RayCluster reconciler.
+		rayCluster := createTestRayCluster(1)
+		scheme := runtime.NewScheme()
+		a.NoError(rayv1.AddToScheme(scheme))
+		a.NoError(volcanoschedulingv1beta1.AddToScheme(scheme))
+		fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		scheduler := &VolcanoBatchScheduler{cli: fakeCli}
+
+		ctx := context.Background()
+
+		require.NoError(scheduler.DoBatchSchedulingOnSubmission(ctx, &rayCluster))
+
+		podGroupKey := client.ObjectKey{Namespace: rayCluster.Namespace, Name: getAppPodGroupName(&rayCluster)}
+		before := volcanoschedulingv1beta1.PodGroup{}
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &before))
+
 		didUpdate, err := scheduler.CleanupOnCompletion(ctx, &rayCluster)
 		require.NoError(err)
-		a.False(didUpdate) // No cleanup should have happened for RayCluster
+		a.False(didUpdate)
+
+		after := volcanoschedulingv1beta1.PodGroup{}
+		require.NoError(fakeCli.Get(ctx, podGroupKey, &after))
+		a.Equal(before.Spec.MinMember, after.Spec.MinMember)
+		a.Equal(before.Spec.MinResources, after.Spec.MinResources)
 	})
 
 	t.Run("RayJob - RayJob has been deleted before calling CleanupOnCompletion", func(t *testing.T) {

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler.go
@@ -141,6 +141,11 @@ func (y *YuniKornScheduler) CleanupOnCompletion(_ context.Context, _ metav1.Obje
 	return false, nil
 }
 
+func (y *YuniKornScheduler) CleanupOnSuspend(_ context.Context, _ metav1.Object) (bool, error) {
+	// YuniKorn doesn't need cleanup
+	return false, nil
+}
+
 func (yf *YuniKornSchedulerFactory) New(_ context.Context, _ *rest.Config, _ client.Client) (schedulerinterface.BatchScheduler, error) {
 	return &YuniKornScheduler{}, nil
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -928,6 +928,34 @@ func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, ins
 	return nil
 }
 
+// releaseBatchSchedulerResources releases the capacity the batch scheduler reserved for this
+// suspended RayCluster (e.g. a Volcano PodGroup). Callers must propagate the error to requeue,
+// since the capacity stays reserved until this succeeds.
+func (r *RayClusterReconciler) releaseBatchSchedulerResources(ctx context.Context, instance *rayv1.RayCluster) error {
+	if r.options.BatchSchedulerManager == nil {
+		return nil
+	}
+
+	scheduler, err := r.options.BatchSchedulerManager.GetScheduler()
+	if err != nil {
+		return err
+	}
+
+	didCleanup, err := scheduler.CleanupOnSuspend(ctx, instance)
+	if err != nil {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, string(utils.FailedToCleanupBatchScheduler), string(utils.CleanupAction),
+			"Failed releasing batch scheduler resources for suspended RayCluster %s/%s, %v",
+			instance.Namespace, instance.Name, err)
+		return err
+	}
+	if didCleanup {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, string(utils.BatchSchedulerCleanedUp), string(utils.CleanupAction),
+			"Released batch scheduler resources for suspended RayCluster %s/%s",
+			instance.Namespace, instance.Name)
+	}
+	return nil
+}
+
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -952,12 +980,14 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, string(utils.DeletedPod), string(utils.DeleteAction),
 			"Deleted Pods for RayCluster %s/%s due to suspension",
 			instance.Namespace, instance.Name)
-		return nil
+		return r.releaseBatchSchedulerResources(ctx, instance)
 	}
 
 	if statusConditionGateEnabled {
 		if suspendStatus == rayv1.RayClusterSuspended {
-			return nil // stop reconcilePods because the cluster is suspended.
+			// Also release here: a cluster suspended before this operator started never went
+			// through the Suspending branch above.
+			return r.releaseBatchSchedulerResources(ctx, instance)
 		}
 		// (suspendStatus != rayv1.RayClusterSuspending) is always true here because it has been checked above.
 		if instance.Spec.Suspend != nil && *instance.Spec.Suspend {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/expectations"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics/mocks"
@@ -4656,4 +4657,138 @@ func TestReconcile_TLSAutoGenerate_RejectsWithoutCertManager(t *testing.T) {
 		}
 	}
 	assert.True(t, foundEvent, "expected a warning event about cert-manager")
+}
+
+// TestReconcilePodsReleasesBatchSchedulerOnSuspend is a regression test for
+// https://github.com/ray-project/kuberay/issues/5183. reconcilePods returns early on suspend, so
+// each of those early returns has to release the batch scheduler's reservation explicitly.
+func TestReconcilePodsReleasesBatchSchedulerOnSuspend(t *testing.T) {
+	setupTest(t)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	trueCondition := func(condType rayv1.RayClusterConditionType) []metav1.Condition {
+		return []metav1.Condition{{
+			Type:               string(condType),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(condType),
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+
+	tests := []struct {
+		name                string
+		suspendErr          error
+		conditions          []metav1.Condition
+		statusConditions    bool
+		suspend             bool
+		expectSuspendCalled bool
+		expectErr           bool
+	}{
+		{
+			name:                "suspending releases the reserved capacity",
+			statusConditions:    true,
+			suspend:             true,
+			conditions:          trueCondition(rayv1.RayClusterSuspending),
+			expectSuspendCalled: true,
+		},
+		{
+			// A cluster suspended before this operator started never goes through the Suspending branch.
+			name:                "already suspended releases the reserved capacity",
+			statusConditions:    true,
+			suspend:             true,
+			conditions:          trueCondition(rayv1.RayClusterSuspended),
+			expectSuspendCalled: true,
+		},
+		{
+			name:                "suspended with the status condition gate disabled",
+			statusConditions:    false,
+			suspend:             true,
+			expectSuspendCalled: true,
+		},
+		{
+			name:                "a failure is surfaced so the reconcile is requeued",
+			statusConditions:    true,
+			suspend:             true,
+			conditions:          trueCondition(rayv1.RayClusterSuspended),
+			suspendErr:          errors.New("failed to update PodGroup"),
+			expectSuspendCalled: true,
+			expectErr:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, tc.statusConditions)
+
+			cluster := testRayCluster.DeepCopy()
+			cluster.Spec.Suspend = new(tc.suspend)
+			cluster.Status.Conditions = tc.conditions
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(cluster).
+				Build()
+
+			fakeScheduler := &fakeBatchScheduler{suspendDidUpdate: true, suspendErr: tc.suspendErr}
+			reconciler := &RayClusterReconciler{
+				Client:                     fakeClient,
+				Recorder:                   events.NewFakeRecorder(100),
+				Scheme:                     newScheme,
+				rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+				options: RayClusterReconcilerOptions{
+					BatchSchedulerManager: batchscheduler.NewSchedulerManagerForTest(fakeScheduler),
+				},
+			}
+
+			err := reconciler.reconcilePods(context.Background(), cluster)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectSuspendCalled, fakeScheduler.suspendCalled)
+			assert.False(t, fakeScheduler.cleanupCalled, "suspending a RayCluster must not run the RayJob completion cleanup")
+			if tc.expectSuspendCalled {
+				require.NotNil(t, fakeScheduler.suspendObject)
+				assert.Equal(t, cluster.Name, fakeScheduler.suspendObject.GetName())
+				assert.Equal(t, cluster.Namespace, fakeScheduler.suspendObject.GetNamespace())
+			}
+		})
+	}
+}
+
+// TestReconcilePodsKeepsBatchSchedulerReservationWhenRunning is the counterpart to
+// TestReconcilePodsReleasesBatchSchedulerOnSuspend: a running gang must keep its reservation.
+func TestReconcilePodsKeepsBatchSchedulerReservationWhenRunning(t *testing.T) {
+	setupTest(t)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	cluster := testRayCluster.DeepCopy()
+	cluster.Spec.Suspend = new(false)
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	fakeScheduler := &fakeBatchScheduler{suspendDidUpdate: true}
+	reconciler := &RayClusterReconciler{
+		Client:                     fakeClient,
+		Recorder:                   events.NewFakeRecorder(100),
+		Scheme:                     newScheme,
+		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+		options: RayClusterReconcilerOptions{
+			BatchSchedulerManager: batchscheduler.NewSchedulerManagerForTest(fakeScheduler),
+		},
+	}
+
+	require.NoError(t, reconciler.reconcilePods(context.Background(), cluster))
+	assert.False(t, fakeScheduler.suspendCalled, "a running RayCluster must keep its reserved capacity")
 }

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -42,12 +42,22 @@ type fakeBatchScheduler struct {
 	cleanupObject    metav1.Object
 	cleanupDidUpdate bool
 	cleanupErr       error
+	suspendCalled    bool
+	suspendObject    metav1.Object
+	suspendDidUpdate bool
+	suspendErr       error
 }
 
 func (f *fakeBatchScheduler) CleanupOnCompletion(_ context.Context, object metav1.Object) (bool, error) {
 	f.cleanupCalled = true
 	f.cleanupObject = object
 	return f.cleanupDidUpdate, f.cleanupErr
+}
+
+func (f *fakeBatchScheduler) CleanupOnSuspend(_ context.Context, object metav1.Object) (bool, error) {
+	f.suspendCalled = true
+	f.suspendObject = object
+	return f.suspendDidUpdate, f.suspendErr
 }
 
 func TestCreateRayJobSubmitterIfNeed(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Suspending a RayCluster deletes every Pod, but its Volcano PodGroup keeps the pre-suspend `minMember` and `minResources`. Volcano goes on reserving that capacity for a cluster with zero Pods, which can block other workloads sharing the queue.

### Two things were missing:

1. `reconcilePods` returns early on suspend, *before* `DoBatchSchedulingOnSubmission`, so the scheduler was never told. And unlike deleting a RayCluster, suspending keeps the object alive, so the OwnerReference does not garbage-collect the PodGroup either — both cleanup paths were broken.
2. `calculatePodGroupParams` only skips worker groups whose own `spec.workerGroupSpecs[].suspend` is set; it never looks at cluster-level `spec.suspend`. So simply recomputing would have returned the same `minMember` and `minResources`.

### Changes
Add new `BatchScheduler.CleanupOnSuspend` hook. Both suspend early-returns in `reconcilePods` call it, and Volcano implements it by zeroing out the PodGroup.

## Related issue number
Closes #5183
<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions
Set up a cluster with Volcano, build the operator image from this branch, and install it:

```bash
kind create cluster
kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/master/installer/volcano-development.yaml
kubectl -n volcano-system wait --for=condition=Available deploy --all --timeout=300s

cd ray-operator && make docker-image IMG=kuberay/operator:nightly && cd ..
kind load docker-image kuberay/operator:nightly

helm install kuberay-operator ./helm-chart/kuberay-operator \
  --set batchScheduler.name=volcano \
  --set image.repository=kuberay/operator --set image.tag=nightly
```

To observe the **Before** behavior instead, install with the chart's default image (the current nightly, which does not have this fix): `helm install kuberay-operator ./helm-chart/kuberay-operator --set batchScheduler.name=volcano`.

Create the queue and a first cluster. The queue is capped at `cpu: 4`, and each cluster needs `cpu: 3, memory: 4Gi`, so it fits exactly one:

```bash
kubectl apply -f ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
kubectl wait --for=condition=Ready pod -l ray.io/cluster=test-cluster-0 --timeout=300s
```

Suspend it and wait until its Pods are gone before creating the next cluster, so the suspended cluster's PodGroup is the only enqueue candidate Volcano sees:

```bash
kubectl patch raycluster test-cluster-0 --type merge -p '{"spec":{"suspend":true}}'
kubectl wait --for=delete pod -l ray.io/cluster=test-cluster-0 --timeout=120s
```

Now submit a fresh cluster into the same queue:

```bash
sed 's/test-cluster-0/test-cluster-2/' \
  ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml | kubectl apply -f -
```

**Before this PR** — the queue has zero running Pods, yet `test-cluster-2` cannot be admitted, because the suspended cluster's PodGroup sits in `Inqueue` holding its full pre-suspend reservation:

```console
$ kubectl get podgroup -o custom-columns=NAME:.metadata.name,MINMEMBER:.spec.minMember,MINRES:.spec.minResources,PHASE:.status.phase
NAME                    MINMEMBER   MINRES                  PHASE
ray-test-cluster-0-pg   3           map[cpu:3 memory:4Gi]   Inqueue
ray-test-cluster-2-pg   3           map[cpu:3 memory:4Gi]   Pending

$ kubectl get pod -l ray.io/cluster=test-cluster-2
NAME                                 READY   STATUS    RESTARTS   AGE
test-cluster-2-head-ns9zw            0/1     Pending   0          53s
test-cluster-2-worker-worker-97hbr   0/1     Pending   0          53s
test-cluster-2-worker-worker-msjpb   0/1     Pending   0          53s

$ kubectl describe podgroup ray-test-cluster-2-pg | tail -2
  Normal   Unschedulable  volcano  queue resource quota insufficient: insufficient cpu, insufficient memory
  Warning  Unschedulable  volcano  3/3 tasks in gang unschedulable: pod group is not ready, 3 Pending, 3 minAvailable; Pending: 3 Unschedulable

$ kubectl describe podgroup ray-test-cluster-0-pg | tail -1
  Warning  Unschedulable  volcano  0/0 tasks in gang unschedulable: pod group is not ready, 3 minAvailable
```

That last line is the leak in one sentence: zero tasks in the gang, still 3 `minAvailable`.

**After this PR** — the suspended cluster releases its reservation and `test-cluster-2` starts. The zeroed PodGroup shows `MINMEMBER` as `<none>` because `minMember: 0` is dropped by `omitempty`, and Volcano moves the empty gang to `Completed`:

```console
$ kubectl get podgroup -o custom-columns=NAME:.metadata.name,MINMEMBER:.spec.minMember,MINRES:.spec.minResources,PHASE:.status.phase
NAME                    MINMEMBER   MINRES                  PHASE
ray-test-cluster-0-pg   <none>      map[]                   Completed
ray-test-cluster-2-pg   3           map[cpu:3 memory:4Gi]   Running

$ kubectl get pod -l ray.io/cluster=test-cluster-2
NAME                                 READY   STATUS    RESTARTS   AGE
test-cluster-2-head-hqhmm            1/1     Running   0          21s
test-cluster-2-worker-worker-2b7vp   1/1     Running   0          21s
test-cluster-2-worker-worker-6hq4s   1/1     Running   0          21s
```

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->

