### PR TITLE
fix(dashboard): add missing kind segment to enter_cluster URL

### DIFF
--- a/dashboard/src/hooks/api/useHistoryClusters.ts
+++ b/dashboard/src/hooks/api/useHistoryClusters.ts
@@ -3,6 +3,14 @@ import { historyServerFetcher } from "@/utils/fetch";
 import type { HistoryClusterInfoList } from "@/types/historyserver";
 import { config } from "@/utils/constants";
 
+// The history server's /enter_cluster route takes a {kind} segment
+// (raycluster, rayjob, or rayservice; see historyserver/pkg/historyserver/router.go).
+// Every entry returned by GET /clusters represents a RayCluster resource -
+// OwnerKind/OwnerName on that response describe the RayJob/RayService that
+// *owns* the cluster, not the kind of the entry itself - so this is always
+// "raycluster" here.
+const HISTORY_CLUSTER_KIND = "raycluster";
+
 const isClusterScopedHistoryKey = (key: unknown) =>
   typeof key === "string" &&
   (key === "/api/v0/tasks" ||
@@ -24,7 +32,7 @@ export const useHistoryClusters = (refreshInterval: number = 5000) => {
   ) => {
     const proxyEndpoint = (await config.getHistoryServerUrl()).proxyEndpoint;
     const res = await fetch(
-      `${proxyEndpoint}/enter_cluster/${encodeURIComponent(namespace)}/${encodeURIComponent(cluster)}/${encodeURIComponent(sessionName)}`,
+      `${proxyEndpoint}/enter_cluster/${encodeURIComponent(namespace)}/${HISTORY_CLUSTER_KIND}/${encodeURIComponent(cluster)}/${encodeURIComponent(sessionName)}`,
       { method: "GET", credentials: "include" },
     );
 


### PR DESCRIPTION
## Summary
`dashboard/src/hooks/api/useHistoryClusters.ts:27` built `/enter_cluster/{namespace}/{cluster}/{session}`, but since #4918 the history server route is `/enter_cluster/{namespace}/{kind}/{name}/{session}` (`historyserver/pkg/historyserver/router.go:385`). The 3-segment form the hook sent instead matches the "session defaults to latest" route (`router.go:373`), so the cluster name landed in `{kind}` and got rejected:

```
400 unsupported resource kind: "raycluster-historyserver"
```

No cluster cookie is set in that case, so every following cluster-scoped call returns "Cluster Cookie not found". The History tab lists sessions fine, but Tasks and Logs stay permanently empty.

## Fix
Insert the missing `kind` segment. Every entry returned by `GET /clusters` represents a RayCluster resource — the response's `OwnerKind`/`OwnerName` (`historyserver/pkg/utils/types.go`) describe the RayJob/RayService that *owns* the cluster, not the kind of the list entry itself — so the segment is always `"raycluster"`, matching `utils.RayClusterKind` on the backend (`historyserver/pkg/utils/constant.go:15`).

Fixes #5172

## Test plan
- [x] `npx eslint src/hooks/api/useHistoryClusters.ts` and `npx prettier --check` clean
- [x] `npx tsc --noEmit` — no new errors from this change (the 5 pre-existing errors are unrelated missing static-asset imports from a sparse checkout, not from this file)
- [ ] Manual repro from the issue (`curl .../enter_cluster/default/raycluster-historyserver/$SESSION` → 200, matching the reported fix) — could not run the full historyserver + kind cluster setup in this environment