### PR TITLE
[History Server] Verify Secret ownership before injecting a Ray auth token

### DIFF
--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
@@ -125,6 +126,15 @@ func (c *ClientManager) GetAuthTokenForRayCluster(ctx context.Context, namespace
 		return "", fmt.Errorf("failed to get auth secret %s/%s: %w", namespace, secretName, err)
 	}
 
+	// Defence in depth: only consume a Secret that demonstrably belongs to this
+	// RayCluster. A user who can create a RayCluster can already read any
+	// Secret in the namespace via podTemplate references, so this does not close
+	// a new hole -- what it does is keep the history server from becoming an
+	// unattributable read path for arbitrary Secrets under its own identity.
+	if err := verifySecretOwnership(secret, rayCluster); err != nil {
+		return "", err
+	}
+
 	tokenBytes, exists := secret.Data[AuthTokenSecretKey]
 	if !exists {
 		return "", fmt.Errorf("%s key not found in secret %s/%s", AuthTokenSecretKey, namespace, secretName)
@@ -137,6 +147,24 @@ func (c *ClientManager) GetAuthTokenForRayCluster(ctx context.Context, namespace
 	}
 
 	return token, nil
+}
+
+// verifySecretOwnership checks that the Secret is tied to the given RayCluster,
+// either through the label the operator stamps on the Secrets it generates or
+// through a controller ownerReference. Operator-generated Secrets carry both; a
+// Secret referenced through a user-supplied authOptions.secretName must be
+// labelled by an administrator to be usable.
+func verifySecretOwnership(secret *corev1.Secret, rayCluster *rayv1.RayCluster) error {
+	if secret.Labels[rayutils.RayClusterLabelKey] == rayCluster.Name {
+		return nil
+	}
+	for _, ref := range secret.GetOwnerReferences() {
+		if ref.Kind == "RayCluster" && ref.Name == rayCluster.Name && ref.UID == rayCluster.UID {
+			return nil
+		}
+	}
+	return fmt.Errorf("secret %s/%s is not owned by RayCluster %s: it must carry the label %s=%s or an ownerReference to the cluster",
+		secret.Namespace, secret.Name, rayCluster.Name, rayutils.RayClusterLabelKey, rayCluster.Name)
 }
 
 // GetSvcInfo looks up the cluster's head service routing info, using a short-lived cache to reduce

--- a/historyserver/pkg/historyserver/clientmanager_test.go
+++ b/historyserver/pkg/historyserver/clientmanager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,9 @@ func TestGetAuthTokenForCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: namespace,
+			// Mirrors what the operator stamps on the Secrets it generates; the
+			// ownership check rejects Secrets that carry no tie to the cluster.
+			Labels: map[string]string{rayutils.RayClusterLabelKey: clusterName},
 		},
 		Data: map[string][]byte{AuthTokenSecretKey: []byte(secretKey)},
 	}
@@ -193,4 +197,71 @@ func TestGetSvcInfo(t *testing.T) {
 	}
 	_, err = emptyMgr.GetSvcInfo(clusterName, namespace)
 	assert.Error(t, err)
+}
+
+func TestVerifySecretOwnership(t *testing.T) {
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns", UID: "cluster-uid"},
+	}
+
+	secretWith := func(labels map[string]string, refs []metav1.OwnerReference) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "s1", Namespace: "ns", Labels: labels, OwnerReferences: refs,
+		}}
+	}
+
+	tests := []struct {
+		name    string
+		secret  *corev1.Secret
+		wantErr bool
+	}{
+		{
+			name:   "operator label accepted",
+			secret: secretWith(map[string]string{rayutils.RayClusterLabelKey: "c1"}, nil),
+		},
+		{
+			name: "controller ownerReference accepted",
+			secret: secretWith(nil, []metav1.OwnerReference{
+				{Kind: "RayCluster", Name: "c1", UID: "cluster-uid"},
+			}),
+		},
+		{
+			name:    "unrelated secret rejected",
+			secret:  secretWith(nil, nil),
+			wantErr: true,
+		},
+		{
+			name:    "label pointing at another cluster rejected",
+			secret:  secretWith(map[string]string{rayutils.RayClusterLabelKey: "other"}, nil),
+			wantErr: true,
+		},
+		{
+			// A stale or forged reference reusing the name must not pass: the UID
+			// is what actually ties the Secret to this cluster instance.
+			name: "ownerReference with mismatched UID rejected",
+			secret: secretWith(nil, []metav1.OwnerReference{
+				{Kind: "RayCluster", Name: "c1", UID: "someone-else"},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "ownerReference of another kind rejected",
+			secret: secretWith(nil, []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "c1", UID: "cluster-uid"},
+			}),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifySecretOwnership(tc.secret, cluster)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected the secret to be rejected")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected the secret to be accepted, got %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Why are these changes needed?

`GetAuthTokenForRayCluster` reads `auth_token` out of a Secret chosen by name --
either `utils.CheckName(cluster)` or whatever `authOptions.secretName` points at --
and injects the value as a bearer token towards that cluster's dashboard. Nothing
checks that the Secret actually belongs to the cluster, so the History Server will
read any Secret in the namespace that happens to match the name and carry an
`auth_token` key, under its own ServiceAccount identity.

This is hardening rather than a closed hole: whoever can create a RayCluster in a
namespace can already consume any Secret there through podTemplate references, and
the operator itself injects the referenced `auth_token` into the head pod via
`secretKeyRef`. What it prevents is the History Server becoming an unattributable
read path for arbitrary namespace Secrets, and it stops `authOptions.secretName`
from silently resolving to an unrelated Secret.

The check accepts either marker that a genuine cluster Secret carries:

- the `ray.io/cluster` label the operator stamps in `createAuthSecret`, or
- a `RayCluster` ownerReference matching both name **and** UID -- the UID is
  compared so a stale or forged reference that merely reuses a cluster name does
  not pass.

`createAuthSecret` sets both, so operator-generated Secrets pass either way.
Mismatches fail closed.

## Related issue number

None.

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

**Worth a maintainer's call:** there is a narrow behaviour change on the
`authOptions.secretName` path. The operator does not label Secrets it did not
create, so a hand-managed Secret now needs `ray.io/cluster=<cluster>` to be usable
for pass-through. Only History Server pass-through to a live auth-enabled cluster
is affected -- the cluster itself keeps working, since the operator reads that
Secret by name and does not go through this code. I have no label permissions
here; flagging it in case you consider that breaking, or would rather the check
be skipped when `secretName` is set explicitly (the argument being that an
explicit reference in the CR is itself the attribution).

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests

`TestVerifySecretOwnership` covers the label path, the ownerReference path, an
unrelated Secret, a label pointing at another cluster, a name-matching
ownerReference with the wrong UID, and an ownerReference of another kind. The
existing `TestGetAuthTokenForCluster` fixture built a bare Secret with no
ownership marker, which no operator-generated Secret ever looks like; it now
carries the label, matching production objects.

```
go test ./pkg/historyserver/ -run 'TestVerifySecretOwnership|TestGetAuthToken'
```
