### PR TITLE
[History Server] Authenticate users against the Kubernetes TokenReview API

### DIFF
--- a/historyserver/README.md
+++ b/historyserver/README.md
@@ -69,6 +69,31 @@ The history server can be configured using command-line flags:
 - `--dashboard-dir`: Directory containing dashboard assets (default: "/dashboard")
 - `--storage-backend-config-path`: Path to storage backend configuration file
 
+#### Authentication
+
+Authentication is off by default, which serves every request unauthenticated.
+Enabling it makes the history server validate the caller's own Kubernetes token
+with the TokenReview API before any cluster data is served:
+
+- `--enable-auth`: Authenticate users against the Kubernetes TokenReview API (default: false)
+- `--auth-cache-ttl`: How long a successful review stays cached; a revoked token keeps working for at most
+  this long (default: 60s)
+- `--auth-cookie-secure`: Mark the session cookie `Secure`; set to false only for local plain-HTTP
+  development (default: true)
+- `--auth-cookie-max-age`: Lifetime of the session cookie issued after login (default: 10m)
+
+The TokenReview call needs the built-in `system:auth-delegator` ClusterRole:
+
+```bash
+kubectl apply -f config/service_account_auth.yaml
+```
+
+Browsers are redirected to `/login` to paste a token (for example
+`kubectl create token <serviceaccount>`); programmatic callers send
+`Authorization: Bearer <token>`. Note this is authentication only: any token the
+cluster accepts can read every session the history server holds, so authorize
+per namespace at the ingress in front of it if that is not acceptable.
+
 ### Collector Configuration
 
 The collector can be configured using command-line flags:

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -25,6 +25,10 @@ func main() {
 	dashboardDir := ""
 	useKubernetesProxy := false
 	useAuthTokenMode := false
+	enableAuth := false
+	authCookieSecure := true
+	authCacheTTL := historyserver.DefaultAuthCacheTTL
+	authCookieMaxAge := historyserver.DefaultAuthCookieMaxAge
 	qps := historyserver.DefaultKubeAPIQPS
 	burst := historyserver.DefaultKubeAPIBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
@@ -44,6 +48,10 @@ func main() {
 	flag.IntVar(&sessionCacheSize, "session-cache-size", historyserver.DefaultSessionCacheSize, "Max number of dead-session snapshots held in the LRU cache.")
 	flag.StringVar(&sessionCacheMaxMemory, "session-cache-max-memory", historyserver.DefaultSessionCacheMaxMemory, `Soft cap on memory held by cached snapshots, as a Kubernetes quantity (e.g. "1Gi"); tune under pod memory. "0" disables the bound.`)
 	flag.DurationVar(&sessionCacheTTL, "session-cache-ttl", historyserver.DefaultSessionCacheTTL, "How long a dead-session snapshot stays cached after last access. 0 disables TTL.")
+	flag.BoolVar(&enableAuth, "enable-auth", false, "Authenticate users against the Kubernetes TokenReview API before serving any cluster data.")
+	flag.DurationVar(&authCacheTTL, "auth-cache-ttl", historyserver.DefaultAuthCacheTTL, "How long a successful TokenReview result stays cached. A revoked token keeps working for at most this long.")
+	flag.BoolVar(&authCookieSecure, "auth-cookie-secure", true, "Mark the auth cookie Secure. Set to false only for local plain-HTTP development.")
+	flag.DurationVar(&authCookieMaxAge, "auth-cookie-max-age", historyserver.DefaultAuthCookieMaxAge, "Lifetime of the auth cookie issued after a successful login.")
 	flag.Parse()
 
 	if val := os.Getenv("STORAGE_BACKEND"); val != "" {
@@ -129,7 +137,13 @@ func main() {
 		close(stop)
 	}()
 
-	handler, err := historyserver.NewServerHandler(&globalConfig, dashboardDir, reader, cliMgr, sessionLoader, useKubernetesProxy, useAuthTokenMode)
+	handler, err := historyserver.NewServerHandler(&globalConfig, dashboardDir, reader, cliMgr, sessionLoader, useKubernetesProxy, useAuthTokenMode,
+		historyserver.AuthConfig{
+			Enabled:      enableAuth,
+			CacheTTL:     authCacheTTL,
+			CookieSecure: authCookieSecure,
+			CookieMaxAge: authCookieMaxAge,
+		})
 	if err != nil {
 		logrus.Fatalf("Failed to create server handler: %v", err)
 	}

--- a/historyserver/config/service_account_auth.yaml
+++ b/historyserver/config/service_account_auth.yaml
@@ -1,0 +1,21 @@
+# RBAC for user authentication (--enable-auth).
+#
+# The history server validates user-supplied Kubernetes tokens with the
+# TokenReview API. Kubernetes ships a built-in ClusterRole for exactly this
+# delegation (system:auth-delegator), so no custom rule set is needed.
+#
+# Apply alongside config/service_account.yaml:
+#   kubectl apply -f config/service_account.yaml
+#   kubectl apply -f config/service_account_auth.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: historyserver-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: historyserver
+  namespace: default

--- a/historyserver/pkg/historyserver/auth.go
+++ b/historyserver/pkg/historyserver/auth.go
@@ -1,0 +1,312 @@
+package historyserver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/emicklei/go-restful/v3"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/sirupsen/logrus"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// AuthCookieName holds the user's own Kubernetes bearer token. It never
+	// leaves the history server trust domain: the egress path strips it before
+	// proxying to a live Ray cluster.
+	AuthCookieName = "hs_auth_token"
+
+	// LoginPath and LogoutPath are raw handlers registered outside the
+	// go-restful filter chain, so they stay reachable without a credential.
+	LoginPath  = "/login"
+	LogoutPath = "/logout"
+
+	// authCacheSize bounds the number of cached TokenReview results.
+	authCacheSize = 1024
+)
+
+const (
+	// DefaultAuthCacheTTL caps how long a revoked token can still be accepted.
+	DefaultAuthCacheTTL = 60 * time.Second
+	// DefaultAuthCookieMaxAge matches the lifetime of the cluster context cookies.
+	DefaultAuthCookieMaxAge = 600 * time.Second
+)
+
+// Authenticator validates user-supplied Kubernetes bearer tokens via the
+// TokenReview API and caches the outcome for a short window.
+//
+// Failure semantics are deliberately asymmetric:
+//   - an invalid or expired token is a client error (401),
+//   - a TokenReview infrastructure failure is a server error (503), never a
+//     silent pass-through. Authentication fails closed.
+type Authenticator struct {
+	client kubernetes.Interface
+	// cache maps sha256(token) -> authenticated username, so raw credentials
+	// are not retained in memory.
+	cache *lru.LRU[string, string]
+}
+
+// NewAuthenticator builds an Authenticator from the primary cluster config.
+func NewAuthenticator(cfg *rest.Config, cacheTTL time.Duration) (*Authenticator, error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build kubernetes clientset for TokenReview: %w", err)
+	}
+	return &Authenticator{
+		client: clientset,
+		cache:  lru.NewLRU[string, string](authCacheSize, nil, cacheTTL),
+	}, nil
+}
+
+// hashToken keys the cache without retaining the raw credential.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// authError distinguishes "bad credential" from "cannot tell right now".
+type authError struct {
+	msg    string
+	status int
+}
+
+func (e *authError) Error() string { return e.msg }
+
+// authStatus returns the HTTP status an error should map to, defaulting to 401.
+func authStatus(err error) int {
+	var aerr *authError
+	if errors.As(err, &aerr) {
+		return aerr.status
+	}
+	return http.StatusUnauthorized
+}
+
+// Authenticate validates the token and returns the authenticated username.
+func (a *Authenticator) Authenticate(ctx context.Context, token string) (string, error) {
+	if token == "" {
+		return "", &authError{status: http.StatusUnauthorized, msg: "missing authentication token"}
+	}
+
+	key := hashToken(token)
+	if user, ok := a.cache.Get(key); ok {
+		return user, nil
+	}
+
+	review := &authv1.TokenReview{Spec: authv1.TokenReviewSpec{Token: token}}
+	result, err := a.client.AuthenticationV1().TokenReviews().Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		// The API server could not answer: refuse rather than guess.
+		logrus.Errorf("TokenReview request failed: %v", err)
+		return "", &authError{status: http.StatusServiceUnavailable, msg: "authentication backend unavailable"}
+	}
+	if !result.Status.Authenticated {
+		reason := result.Status.Error
+		if reason == "" {
+			reason = "token is not authenticated"
+		}
+		return "", &authError{status: http.StatusUnauthorized, msg: reason}
+	}
+
+	user := result.Status.User.Username
+	a.cache.Add(key, user)
+	return user, nil
+}
+
+// extractToken pulls the credential from the request, header first.
+//
+// A malformed Authorization header is a hard failure instead of falling back to
+// the cookie: a misconfigured client should fail loudly rather than silently
+// authenticate as whoever the browser session belongs to.
+func extractToken(req *http.Request) (string, error) {
+	if raw := req.Header.Get("Authorization"); raw != "" {
+		const prefix = "Bearer "
+		if !strings.HasPrefix(raw, prefix) {
+			return "", &authError{status: http.StatusUnauthorized, msg: "Authorization header must use the Bearer scheme"}
+		}
+		token := strings.TrimSpace(strings.TrimPrefix(raw, prefix))
+		if token == "" {
+			return "", &authError{status: http.StatusUnauthorized, msg: "Authorization header carries an empty bearer token"}
+		}
+		return token, nil
+	}
+	if cookie, err := req.Cookie(AuthCookieName); err == nil && cookie.Value != "" {
+		return cookie.Value, nil
+	}
+	return "", &authError{status: http.StatusUnauthorized, msg: "missing authentication token"}
+}
+
+// wantsHTML reports whether the request is a browser navigation, which should
+// be redirected to the login page instead of receiving a bare 401.
+func wantsHTML(req *http.Request) bool {
+	if req.Header.Get("X-Requested-With") != "" {
+		return false
+	}
+	if mode := req.Header.Get("Sec-Fetch-Mode"); mode != "" {
+		return mode == "navigate"
+	}
+	return strings.Contains(req.Header.Get("Accept"), "text/html")
+}
+
+// AuthFilter authenticates every request flowing through the go-restful
+// container. It runs before any handler, so dead-cluster serving and live
+// pass-through are both gated by it.
+func (s *ServerHandler) AuthFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	if s.authenticator == nil {
+		chain.ProcessFilter(req, resp)
+		return
+	}
+
+	token, err := extractToken(req.Request)
+	if err == nil {
+		var user string
+		if user, err = s.authenticator.Authenticate(req.Request.Context(), token); err == nil {
+			req.SetAttribute(ATTRIBUTE_AUTH_USER, user)
+			chain.ProcessFilter(req, resp)
+			return
+		}
+	}
+
+	status := authStatus(err)
+	// Browser navigations get a login round-trip so a single link keeps working;
+	// XHR callers get a machine-readable error instead of an HTML page.
+	if status == http.StatusUnauthorized && wantsHTML(req.Request) {
+		next := req.Request.URL.RequestURI()
+		http.Redirect(resp.ResponseWriter, req.Request, LoginPath+"?next="+url.QueryEscape(next), http.StatusFound)
+		return
+	}
+	writeAuthError(resp.ResponseWriter, status, err.Error())
+}
+
+// writeAuthError follows the repository-wide error contract {"code","message"}.
+func writeAuthError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", restful.MIME_JSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"code": status, "message": msg})
+}
+
+// authCookie builds the session cookie. It is HttpOnly so page scripts cannot
+// read the Kubernetes token, and SameSite=Lax so it survives a top-level
+// navigation arriving from an external link.
+func (s *ServerHandler) authCookie(value string, maxAge int) *http.Cookie {
+	return &http.Cookie{
+		Name:     AuthCookieName,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   s.authCookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// safeNext keeps the post-login redirect inside this origin, so a crafted link
+// cannot bounce a freshly authenticated browser to another host.
+func safeNext(raw string) string {
+	if raw == "" {
+		return "/"
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.IsAbs() || u.Host != "" || !strings.HasPrefix(u.Path, "/") {
+		return "/"
+	}
+	return u.String()
+}
+
+// routerAuth registers /login and /logout as raw handlers, deliberately outside
+// the go-restful filter chain so they remain reachable while unauthenticated.
+func routerAuth(s *ServerHandler) {
+	http.HandleFunc(LoginPath, func(w http.ResponseWriter, r *http.Request) {
+		if s.authenticator == nil {
+			http.Redirect(w, r, safeNext(r.URL.Query().Get("next")), http.StatusFound)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'")
+			w.Write(loginPageHTML(safeNext(r.URL.Query().Get("next"))))
+		case http.MethodPost:
+			if err := r.ParseForm(); err != nil {
+				writeAuthError(w, http.StatusBadRequest, "cannot parse login form")
+				return
+			}
+			token := strings.TrimSpace(r.PostFormValue("token"))
+			next := safeNext(r.PostFormValue("next"))
+
+			// Validate before setting any cookie: a rejected credential must not
+			// leave state behind in the browser.
+			if _, err := s.authenticator.Authenticate(r.Context(), token); err != nil {
+				writeAuthError(w, authStatus(err), err.Error())
+				return
+			}
+
+			http.SetCookie(w, s.authCookie(token, int(s.authCookieMaxAge.Seconds())))
+			http.Redirect(w, r, next, http.StatusFound)
+		default:
+			w.Header().Set("Allow", "GET, POST")
+			writeAuthError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	http.HandleFunc(LogoutPath, func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, s.authCookie("", -1))
+		http.Redirect(w, r, LoginPath, http.StatusFound)
+	})
+}
+
+// loginPageHTML renders the token entry form. The token is submitted as a form
+// field over POST so it never lands in a URL, the browser history, or logs.
+func loginPageHTML(next string) []byte {
+	return []byte(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Ray History Server sign in</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; background: #f5f6f8; margin: 0;
+         display: flex; align-items: center; justify-content: center; height: 100vh; }
+  .card { background: #fff; padding: 32px 36px; border-radius: 8px; width: 420px;
+          box-shadow: 0 1px 4px rgba(0,0,0,.12); }
+  h1 { font-size: 18px; margin: 0 0 6px; }
+  p { color: #5b6472; font-size: 13px; line-height: 1.5; margin: 0 0 18px; }
+  code { background: #f0f1f3; padding: 1px 5px; border-radius: 3px; }
+  textarea { width: 100%; box-sizing: border-box; height: 96px; font-family: ui-monospace, monospace;
+             font-size: 12px; padding: 8px; border: 1px solid #d0d4da; border-radius: 4px; resize: vertical; }
+  button { margin-top: 14px; width: 100%; padding: 9px; font-size: 14px; color: #fff;
+           background: #1668dc; border: 0; border-radius: 4px; cursor: pointer; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>Ray History Server</h1>
+    <p>Paste a Kubernetes token, for example
+       <code>kubectl create token &lt;serviceaccount&gt;</code>.</p>
+    <form method="POST" action="` + LoginPath + `">
+      <input type="hidden" name="next" value="` + htmlAttrEscape(next) + `">
+      <textarea name="token" placeholder="eyJhbGciOi..." autofocus required></textarea>
+      <button type="submit">Sign in</button>
+    </form>
+  </div>
+</body>
+</html>`)
+}
+
+// htmlAttrEscape escapes a value interpolated into an HTML attribute.
+func htmlAttrEscape(s string) string {
+	return html.EscapeString(s)
+}

--- a/historyserver/pkg/historyserver/auth_test.go
+++ b/historyserver/pkg/historyserver/auth_test.go
@@ -1,0 +1,271 @@
+package historyserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/emicklei/go-restful/v3"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newTestAuthenticator wires an Authenticator onto a fake clientset whose
+// TokenReview reaction is supplied by the caller.
+func newTestAuthenticator(t *testing.T, reaction k8stesting.ReactionFunc) *Authenticator {
+	t.Helper()
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", reaction)
+	return &Authenticator{
+		client: client,
+		cache:  lru.NewLRU[string, string](authCacheSize, nil, time.Minute),
+	}
+}
+
+func authenticatedReaction(user string) k8stesting.ReactionFunc {
+	return func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: true,
+				User:          authv1.UserInfo{Username: user},
+			},
+		}, nil
+	}
+}
+
+func TestAuthenticateRejectsInvalidTokenWith401(t *testing.T) {
+	a := newTestAuthenticator(t, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{Authenticated: false, Error: "token expired"},
+		}, nil
+	})
+
+	_, err := a.Authenticate(context.Background(), "bad-token")
+	if err == nil {
+		t.Fatal("expected an error for a rejected token")
+	}
+	if got := authStatus(err); got != http.StatusUnauthorized {
+		t.Fatalf("invalid token must map to 401, got %d", got)
+	}
+}
+
+func TestAuthenticateFailsClosedWith503WhenBackendIsDown(t *testing.T) {
+	// A TokenReview outage must never be mistaken for a valid credential.
+	a := newTestAuthenticator(t, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver unreachable")
+	})
+
+	_, err := a.Authenticate(context.Background(), "some-token")
+	if err == nil {
+		t.Fatal("expected an error when TokenReview fails")
+	}
+	if got := authStatus(err); got != http.StatusServiceUnavailable {
+		t.Fatalf("backend failure must map to 503, got %d", got)
+	}
+}
+
+func TestAuthenticateCachesSuccessfulReview(t *testing.T) {
+	calls := 0
+	a := newTestAuthenticator(t, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		return authenticatedReaction("alice")(action)
+	})
+
+	for i := 0; i < 3; i++ {
+		user, err := a.Authenticate(context.Background(), "good-token")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if user != "alice" {
+			t.Fatalf("expected alice, got %q", user)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("expected the review to be cached after the first call, got %d calls", calls)
+	}
+}
+
+func TestExtractTokenPrefersHeaderAndFailsHardOnBadScheme(t *testing.T) {
+	cookie := &http.Cookie{Name: AuthCookieName, Value: "cookie-token"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/", nil)
+	req.Header.Set("Authorization", "Bearer header-token")
+	req.AddCookie(cookie)
+	got, err := extractToken(req)
+	if err != nil || got != "header-token" {
+		t.Fatalf("header must win over cookie, got %q err=%v", got, err)
+	}
+
+	// A malformed header must not silently fall back to the cookie: that would
+	// authenticate a misconfigured client as the browser's user.
+	req = httptest.NewRequest(http.MethodGet, "/api/jobs/", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	req.AddCookie(cookie)
+	if _, err = extractToken(req); err == nil {
+		t.Fatal("a non-Bearer Authorization header must be a hard failure")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/jobs/", nil)
+	req.AddCookie(cookie)
+	got, err = extractToken(req)
+	if err != nil || got != "cookie-token" {
+		t.Fatalf("cookie fallback failed: %q err=%v", got, err)
+	}
+}
+
+func TestStripAuthCookieRemovesOnlyTheAuthCookie(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"removes auth cookie", "a=1; " + AuthCookieName + "=secret; b=2", "a=1; b=2"},
+		{"only auth cookie", AuthCookieName + "=secret", ""},
+		{"no auth cookie", "cluster_name=c1; session_name=live", "cluster_name=c1; session_name=live"},
+		{"keeps similarly named cookie", AuthCookieName + "_other=v", AuthCookieName + "_other=v"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripAuthCookie(tc.in); got != tc.want {
+				t.Fatalf("stripAuthCookie(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeNextRejectsOffOriginRedirects(t *testing.T) {
+	tests := map[string]string{
+		"/#/overview":           "/#/overview",
+		"/enter_cluster/ns/c/s": "/enter_cluster/ns/c/s",
+		"https://evil.test/x":   "/",
+		"//evil.test/x":         "/",
+		"javascript:alert(1)":   "/",
+		"":                      "/",
+	}
+	for in, want := range tests {
+		if got := safeNext(in); got != want {
+			t.Fatalf("safeNext(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAuthFilterRedirectsBrowserButReturnsJSONToXHR(t *testing.T) {
+	s := &ServerHandler{authenticator: newTestAuthenticator(t, authenticatedReaction("alice"))}
+
+	// Browser navigation without a credential: keep the single-link flow working.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/enter_cluster/ns/raycluster/c/s", nil)
+	req.Header.Set("Accept", "text/html")
+	s.AuthFilter(restfulRequest(req), restfulResponse(rec), emptyChain())
+	if rec.Code != http.StatusFound {
+		t.Fatalf("browser navigation should redirect, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc == "" || loc[:len(LoginPath)] != LoginPath {
+		t.Fatalf("expected redirect to %s, got %q", LoginPath, loc)
+	}
+
+	// XHR without a credential: machine-readable 401, no HTML.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/jobs/", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	s.AuthFilter(restfulRequest(req), restfulResponse(rec), emptyChain())
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("XHR should get 401, got %d", rec.Code)
+	}
+}
+
+func TestSelectClusterAuthentication(t *testing.T) {
+	t.Run("unauthenticated request redirects to login", func(t *testing.T) {
+		s := &ServerHandler{authenticator: newTestAuthenticator(t, authenticatedReaction("alice"))}
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/select_cluster?from=test", nil)
+		selectClusterHandler(s).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Fatalf("unauthenticated selector should redirect, got %d", rec.Code)
+		}
+		if got, want := rec.Header().Get("Location"), "/login?next=%2Fselect_cluster%3Ffrom%3Dtest"; got != want {
+			t.Fatalf("redirect location = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("authenticated request renders selector", func(t *testing.T) {
+		s := &ServerHandler{authenticator: newTestAuthenticator(t, authenticatedReaction("alice"))}
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/select_cluster", nil)
+		req.AddCookie(&http.Cookie{Name: AuthCookieName, Value: "good-token"})
+		selectClusterHandler(s).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("authenticated selector should render, got %d", rec.Code)
+		}
+	})
+
+	t.Run("TokenReview failure returns service unavailable", func(t *testing.T) {
+		s := &ServerHandler{authenticator: newTestAuthenticator(t, func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("apiserver unavailable")
+		})}
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/select_cluster", nil)
+		req.AddCookie(&http.Cookie{Name: AuthCookieName, Value: "token"})
+		selectClusterHandler(s).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("TokenReview failure should return 503, got %d", rec.Code)
+		}
+	})
+
+	t.Run("auth disabled renders selector", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		selectClusterHandler(&ServerHandler{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/select_cluster", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("selector should render when auth is disabled, got %d", rec.Code)
+		}
+	})
+}
+
+func TestAuthFilterPassesThroughWhenAuthDisabled(t *testing.T) {
+	s := &ServerHandler{} // authenticator nil => --enable-auth off
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/", nil)
+
+	called := false
+	chain := chainCalling(&called)
+	s.AuthFilter(restfulRequest(req), restfulResponse(rec), chain)
+
+	if !called {
+		t.Fatal("with auth disabled the request must reach the handler chain")
+	}
+}
+
+// --- go-restful test helpers -------------------------------------------------
+
+func restfulRequest(r *http.Request) *restful.Request {
+	return restful.NewRequest(r)
+}
+
+func restfulResponse(w http.ResponseWriter) *restful.Response {
+	return restful.NewResponse(w)
+}
+
+// emptyChain fails the test if the filter lets an unauthenticated request pass.
+func emptyChain() *restful.FilterChain {
+	return &restful.FilterChain{
+		Target: func(_ *restful.Request, _ *restful.Response) {
+			panic("handler must not be reached for an unauthenticated request")
+		},
+	}
+}
+
+// chainCalling records whether the filter forwarded the request.
+func chainCalling(called *bool) *restful.FilterChain {
+	return &restful.FilterChain{
+		Target: func(_ *restful.Request, _ *restful.Response) { *called = true },
+	}
+}

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"mime"
 	"net/http"
+	"net/url"
 	"path"
 	"sort"
 	"strconv"
@@ -38,6 +39,8 @@ const (
 
 	ATTRIBUTE_SERVICE_NAME = "cluster_service_name"
 	ATTRIBUTE_AUTH_TOKEN   = "cluster_auth_token"
+	// ATTRIBUTE_AUTH_USER carries the authenticated username resolved by AuthFilter.
+	ATTRIBUTE_AUTH_USER = "authenticated_user"
 )
 
 // handleMissingSnapshot responds 503 when the session snapshot is not in the cache.
@@ -277,16 +280,37 @@ func routerHealthz(s *ServerHandler) {
 
 }
 
-func routerSelectCluster(s *ServerHandler) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
+func selectClusterHandler(s *ServerHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Serving the page unauthenticated looks like an empty history list
+		// because its fetch('/clusters') receives a 401. Redirect before rendering
+		// so the user sees the real cause and returns to the selector after login.
+		if s.authenticator != nil {
+			token, err := extractToken(r)
+			if err == nil {
+				_, err = s.authenticator.Authenticate(r.Context(), token)
+			}
+			if err != nil {
+				status := authStatus(err)
+				if status == http.StatusUnauthorized {
+					http.Redirect(w, r, LoginPath+"?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+					return
+				}
+				writeAuthError(w, status, err.Error())
+				return
+			}
+		}
 		logrus.Infof("Serving cluster selector page: %s %s", r.Method, r.URL.String())
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'")
 		w.Write(html.ClusterSelectorHTML)
-	}
-	http.HandleFunc("/select_cluster", handler)
+	})
+}
+
+func routerSelectCluster(s *ServerHandler) {
+	http.Handle("/select_cluster", selectClusterHandler(s))
 }
 
 func routerLogical(s *ServerHandler) {
@@ -399,6 +423,14 @@ func routerRayClusterSet(s *ServerHandler) {
 }
 
 func (s *ServerHandler) RegisterRouter() {
+	// Authentication runs as a container-level filter so every go-restful
+	// WebService is gated before its handler executes. /select_cluster performs
+	// the same check explicitly; only /login, /logout and the probes remain
+	// unauthenticated.
+	if s.authenticator != nil {
+		restful.Filter(s.AuthFilter)
+	}
+	routerAuth(s)
 	routerRayClusterSet(s)
 	routerClusters(s)
 	routerTimezone(s)
@@ -410,6 +442,24 @@ func (s *ServerHandler) RegisterRouter() {
 	// routerHomepage(s)
 	routerHealthz(s)
 	routerLogical(s)
+}
+
+// stripAuthCookie removes the history server's own auth cookie from an outgoing
+// Cookie header, leaving every other cookie untouched. Returns "" when nothing
+// remains.
+func stripAuthCookie(header string) string {
+	parts := strings.Split(header, ";")
+	kept := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name, _, _ := strings.Cut(strings.TrimSpace(part), "=")
+		if name == AuthCookieName {
+			continue
+		}
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			kept = append(kept, trimmed)
+		}
+	}
+	return strings.Join(kept, "; ")
 }
 
 func (s *ServerHandler) redirectRequest(req *restful.Request, resp *restful.Response) {
@@ -447,7 +497,10 @@ func (s *ServerHandler) redirectRequest(req *restful.Request, resp *restful.Resp
 		}
 		// In auth-token mode, drop the client-supplied x-ray-authorization so it cannot bypass
 		// the server-managed token injected below.
-		if s.useAuthTokenMode && strings.EqualFold(key, utils.RayAuthHeader) {
+		// Under --enable-auth the strip is unconditional: it closes the legacy
+		// combination (auth-token mode off + direct dial) where a client-supplied
+		// header would otherwise reach Ray untouched.
+		if (s.useAuthTokenMode || s.authenticator != nil) && strings.EqualFold(key, utils.RayAuthHeader) {
 			continue
 		}
 		// Authorization has to be dropped in two cases. In auth-token mode, Ray only falls back to
@@ -456,7 +509,18 @@ func (s *ServerHandler) redirectRequest(req *restful.Request, resp *restful.Resp
 		// instead of Ray, and client-go's transport skips injecting the service account token when
 		// Authorization is already set, so forwarding it would make the proxied request fail
 		// authentication.
-		if (s.useAuthTokenMode || s.useKubernetesProxy) && strings.EqualFold(key, "authorization") {
+		if (s.useAuthTokenMode || s.useKubernetesProxy || s.authenticator != nil) && strings.EqualFold(key, "authorization") {
+			continue
+		}
+		if strings.EqualFold(key, "cookie") {
+			// Ray does not authenticate with cookies, so dropping ours costs nothing
+			// functionally; the point is that the user's Kubernetes token must never
+			// reach a live cluster's dashboard process.
+			for _, value := range values {
+				if stripped := stripAuthCookie(value); stripped != "" {
+					proxyReq.Header.Add(key, stripped)
+				}
+			}
 			continue
 		}
 		for _, value := range values {

--- a/historyserver/pkg/historyserver/server.go
+++ b/historyserver/pkg/historyserver/server.go
@@ -25,6 +25,20 @@ type ServerHandler struct {
 
 	useKubernetesProxy bool
 	useAuthTokenMode   bool
+
+	// User authentication (user -> history server). nil when --enable-auth is
+	// off, which keeps the pre-auth behaviour intact.
+	authenticator    *Authenticator
+	authCookieSecure bool
+	authCookieMaxAge time.Duration
+}
+
+// AuthConfig carries the user-authentication knobs from the command line.
+type AuthConfig struct {
+	Enabled      bool
+	CacheTTL     time.Duration
+	CookieSecure bool
+	CookieMaxAge time.Duration
 }
 
 func NewServerHandler(
@@ -35,6 +49,7 @@ func NewServerHandler(
 	sessionLoader *SessionLoader,
 	useKubernetesProxy bool,
 	useAuthTokenMode bool,
+	authConfig AuthConfig,
 ) (*ServerHandler, error) {
 	handler := &ServerHandler{
 		reader:        reader,
@@ -47,6 +62,9 @@ func NewServerHandler(
 		maxClusters: 100,
 
 		useAuthTokenMode: useAuthTokenMode,
+
+		authCookieSecure: authConfig.CookieSecure,
+		authCookieMaxAge: authConfig.CookieMaxAge,
 	}
 
 	if len(clientManager.configs) > 0 {
@@ -76,6 +94,19 @@ func NewServerHandler(
 			handler.useKubernetesProxy = false
 		}
 	}
+	if authConfig.Enabled {
+		if len(clientManager.configs) == 0 {
+			return nil, fmt.Errorf("--enable-auth requires a Kubernetes config for TokenReview")
+		}
+		authenticator, err := NewAuthenticator(clientManager.configs[0], authConfig.CacheTTL)
+		if err != nil {
+			return nil, err
+		}
+		handler.authenticator = authenticator
+		logrus.Infof("Authentication enabled: TokenReview cache TTL %s, secure cookie %t",
+			authConfig.CacheTTL, authConfig.CookieSecure)
+	}
+
 	return handler, nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?

The History Server serves stored session data -- job logs, actor state, node and
event history -- to anyone who can reach its port. There is no authentication of
its own today: the only credential in the codebase is the one it presents *to* a
live cluster's dashboard (`--use-auth-token-mode`). Anything already collected
into object storage is readable by any caller.

This adds an opt-in check of the caller's own Kubernetes identity in front of
every data path, via the TokenReview API. It is off by default (`--enable-auth`),
so existing deployments are unaffected.

The two credentials stay separate: the user's Kubernetes token is never derived
from, nor forwarded as, the Ray auth token, and the egress path strips it before
proxying.

What's in it:

- `auth.go`: TokenReview-backed `Authenticator` with a hash-keyed expirable LRU,
  so raw tokens are never retained; a container-level `AuthFilter` gating every
  go-restful WebService; `/login` and `/logout` registered outside the filter
  chain so they stay reachable while unauthenticated
- **fail-closed semantics**: an invalid token is 401, but a TokenReview outage is
  503 -- an unreachable API server must never be mistaken for a valid token
- **header-first extraction**: a non-Bearer `Authorization` header is a hard 401
  rather than a silent fallback to the cookie, so a misconfigured client cannot
  end up authenticated as whoever the browser session belongs to
- browser navigations get `302 /login?next=...`, XHR callers get the
  `{code,message}` JSON error contract. `/select_cluster` checks explicitly rather
  than rendering a selector whose `fetch('/clusters')` would 401
- login validates the token before issuing any `Set-Cookie`, and the post-login
  redirect target is constrained to this origin
- **egress hardening**: with auth enabled, the `Authorization` /
  `x-ray-authorization` strip on the proxy path becomes unconditional, and
  `hs_auth_token` is removed from the outgoing `Cookie` header
- `config/service_account_auth.yaml` binds the built-in `system:auth-delegator`
  ClusterRole, which is all TokenReview needs

### Scope, and where I'd like input

**This is authentication, not authorization.** Any token the cluster accepts can
read every session the History Server holds -- which matches how the server reads
storage today: one identity, unaware of who is asking. Restricting a user to the
namespaces they can already see needs a SubjectAccessReview per request against
the owning RayCluster; I left that for a follow-up and said so in the README, so
nobody mistakes `--enable-auth` for tenant isolation. Happy to fold it into this
PR instead if you'd rather it land as one piece.

Two other things I'd rather settle in review than defend later:

1. **The built-in login page.** It exists so a single link keeps working in a
   browser, and it takes a pasted `kubectl create token` value. The alternative is
   to serve only 401/403 and let an OIDC-aware proxy in front handle the human
   flow. I went with the self-contained option because it needs no extra
   infrastructure, but I'll drop it if you'd rather not own login UI here.
2. **`restful.Filter` as the gate.** A container-level filter means new
   WebServices are authenticated by default rather than by remembering to opt in.
   The cost is that `/select_cluster`, which is a raw `http.Handle`, needs the
   same check written out explicitly.

## Related issue number

None.

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

(No label permissions here. This is user-facing but off by default and documented
in `historyserver/README.md`; `doc-updates-required` may still be worth adding at
release time. Not breaking.)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests

`auth_test.go` covers 401 vs 503 mapping, review caching, header precedence and
the hard failure on a bad scheme, cookie stripping (including a similarly named
cookie that must survive), off-origin redirect rejection, the browser-vs-XHR
branch, and the selector's four states (unauthenticated, authenticated,
TokenReview down, auth disabled).

```
go test ./pkg/...        # whole module passes
gofmt -l / go vet        # clean on the touched files
```
