### PR TITLE
[History Server] Cache snapshot struct in the session LRU instead of JSON bytes

### DIFF
--- a/historyserver/config/historyserver-azureblob.yaml
+++ b/historyserver/config/historyserver-azureblob.yaml
@@ -45,12 +45,10 @@ spec:
         - --storage-backend=azureblob
         ports:
         - containerPort: 8080
-        args:
-        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
-        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
-        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
-        - --session-cache-max-memory=4Gi
+        # Cache is soft-bounded at 8 GiB; 12 GiB leaves headroom for cold loads, responses, and GC.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
+        args:
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver-azureblob.yaml
+++ b/historyserver/config/historyserver-azureblob.yaml
@@ -45,10 +45,12 @@ spec:
         - --storage-backend=azureblob
         ports:
         - containerPort: 8080
-        # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
-        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-memory=8Gi
+        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
+        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
+        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
+        - --session-cache-max-memory=4Gi
+        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -44,10 +44,12 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
-        # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
-        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-memory=8Gi
+        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
+        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
+        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
+        - --session-cache-max-memory=4Gi
+        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -44,12 +44,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
-        args:
-        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
-        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
-        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
-        - --session-cache-max-memory=4Gi
+        # Cache is soft-bounded at 8 GiB; 12 GiB leaves headroom for cold loads, responses, and GC.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
+        args:
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -63,12 +63,10 @@ spec:
         # - --use-auth-token-mode=true
         ports:
         - containerPort: 8080
-        args:
-        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
-        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
-        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
-        - --session-cache-max-memory=4Gi
+        # Cache is soft-bounded at 8 GiB; 12 GiB leaves headroom for cold loads, responses, and GC.
         # The 2 GiB request keeps examples schedulable; size production requests to residency.
+        args:
+        - --session-cache-max-memory=8Gi
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/config/historyserver.yaml
+++ b/historyserver/config/historyserver.yaml
@@ -63,10 +63,12 @@ spec:
         # - --use-auth-token-mode=true
         ports:
         - containerPort: 8080
-        # Cache is soft-bounded at 8 GiB; 12 GiB leaves decode headroom.
-        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         args:
-        - --session-cache-max-memory=8Gi
+        # We store Go structs in the cache but estimate their size by JSON length, and the actual heap size can be ~2.5x the estimate.
+        # Set the cache soft bound to 4 GiB. The worst-case usage is 4 GiB * 2.5 = 10 GiB, leaving ~2 GiB of the 12 GiB limit as headroom.
+        # Ref for the estimate: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
+        - --session-cache-max-memory=4Gi
+        # The 2 GiB request keeps examples schedulable; size production requests to residency.
         resources:
           requests:
             cpu: "500m"

--- a/historyserver/pkg/eventserver/snapshot.go
+++ b/historyserver/pkg/eventserver/snapshot.go
@@ -6,7 +6,8 @@ import (
 )
 
 // SessionSnapshot is the in-memory representation of a dead session's processed
-// event state.
+// event state. It is cached and shared across requests, so treat it as
+// immutable and clone a field before modifying it.
 type SessionSnapshot struct {
 	SessionKey string `json:"sessionKey"`
 

--- a/historyserver/pkg/historyserver/session_cache_integration_test.go
+++ b/historyserver/pkg/historyserver/session_cache_integration_test.go
@@ -18,14 +18,14 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
-// TestByteCache_ReadEndpointsRoundTripIsLossless is an in-process HTTP test:
+// TestSessionCache_ReadEndpointsRoundTripIsLossless is an in-process HTTP test:
 //
 // 1. Wire ServerHandler with a fake processor.
 // 2. Register routers for /enter_cluster and the dead-session read endpoints.
-// 3. GET /enter_cluster to trigger cold load and encode snapshot into the byte cache.
-// 4. GET each read endpoint to decode from cache and serve.
+// 3. GET /enter_cluster to trigger cold load and store the snapshot in the session cache.
+// 4. GET each read endpoint to serve the cached snapshot.
 // 5. Assert each response still contains the richSnapshot sentinel values (including nested CustomFields).
-func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
+func TestSessionCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
 	restful.DefaultContainer = restful.NewContainer()
 
 	const (

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -33,9 +33,19 @@ const (
 	// Real usage can exceed it in three ways:
 	//   - add-then-evict: cache momentarily holds oldTotal + newEntry
 	//   - one large session: a single snapshot bigger than the whole budget is kept
-	//   - size proxy: entries are measured by JSON length, which undercounts the live Go object graph
+	//   - size proxy: entries are charged JSON length * sessionSnapshotHeapFactor, an estimate of the live heap
 	DefaultSessionCacheMaxMemory = "2Gi"
+	// sessionSnapshotHeapFactor scales a snapshot's JSON length to its live Go heap.
+	// Measured at 1.1x to 2.1x on a small sample of real Ray events; 2.5 leaves
+	// margin for real-world data.
+	// Ref: https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
+	sessionSnapshotHeapFactor = 2.5
 )
+
+// estimateHeapBytes approximates the live heap of a snapshot from its JSON length.
+func estimateHeapBytes(jsonLen int) int {
+	return int(float64(jsonLen) * sessionSnapshotHeapFactor)
+}
 
 // ParseSessionCacheMaxMemory converts a Kubernetes quantity into a
 // byte count.
@@ -58,7 +68,7 @@ type processor interface {
 	ProcessSession(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error)
 }
 
-// cacheEntry is a cached snapshot plus its JSON size for the byte budget.
+// cacheEntry is a cached snapshot plus its estimated heap size for the byte budget.
 type cacheEntry struct {
 	snap *eventserver.SessionSnapshot
 	size int
@@ -183,7 +193,7 @@ func (s *SessionLoader) doLoadSession(ctx context.Context, info utils.ClusterInf
 	}
 }
 
-// putSnapshot caches a snapshot. It is marshaled once only to measure its size.
+// putSnapshot caches a snapshot. It is marshaled once only to estimate its size.
 func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.SessionSnapshot) error {
 	encoded, err := json.Marshal(snap)
 	if err != nil {
@@ -193,7 +203,7 @@ func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cache.Add(clusterSessionKey, cacheEntry{snap: snap, size: len(encoded)})
+	s.cache.Add(clusterSessionKey, cacheEntry{snap: snap, size: estimateHeapBytes(len(encoded))})
 	s.evictToByteBudget()
 	return nil
 }

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -33,7 +33,7 @@ const (
 	// Real usage can exceed it in three ways:
 	//   - add-then-evict: cache momentarily holds oldTotal + newEntry
 	//   - one large session: a single snapshot bigger than the whole budget is kept
-	//   - per-request decode: every GET unmarshals cached bytes into a full *SessionSnapshot
+	//   - size proxy: entries are measured by JSON length, which undercounts the live Go object graph
 	DefaultSessionCacheMaxMemory = "2Gi"
 )
 
@@ -58,12 +58,18 @@ type processor interface {
 	ProcessSession(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error)
 }
 
+// cacheEntry is a cached snapshot plus its JSON size for the byte budget.
+type cacheEntry struct {
+	snap *eventserver.SessionSnapshot
+	size int
+}
+
 // SessionLoader caches dead-session snapshots in a size-bounded LRU with optional
 // TTL expiry and triggers session processing on cache miss. Concurrent callers
 // for the same session are coalesced via singleflight.
 type SessionLoader struct {
 	processor processor
-	cache     *expirable.LRU[string, []byte]
+	cache     *expirable.LRU[string, cacheEntry]
 	maxBytes  int
 	// mu guards only the byte-budget read-modify-write; expirable.LRU is
 	// independently thread-safe. A lone Get/Add/Peek does not need mu.
@@ -77,33 +83,22 @@ type SessionLoader struct {
 func NewSessionLoader(p processor, serverCtx context.Context, processTimeout time.Duration, cacheSize, cacheMaxBytes int, cacheTTL time.Duration) *SessionLoader {
 	return &SessionLoader{
 		processor:      p,
-		cache:          expirable.NewLRU[string, []byte](cacheSize, nil, cacheTTL),
+		cache:          expirable.NewLRU[string, cacheEntry](cacheSize, nil, cacheTTL),
 		maxBytes:       cacheMaxBytes,
 		serverCtx:      serverCtx,
 		processTimeout: processTimeout,
 	}
 }
 
-// GetSnapshot returns a per-request view of the cached snapshot, which is
-// a freshly decoded copy, safe for concurrent use.
+// GetSnapshot returns the cached snapshot. It is shared by all callers and
+// must be treated as read-only.
 func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.SessionSnapshot, bool) {
-	encoded, ok := s.cache.Get(clusterSessionKey)
+	entry, ok := s.cache.Get(clusterSessionKey)
 	if !ok {
 		return nil, false
 	}
 	s.renewTTL(clusterSessionKey)
-
-	snap, err := decodeSnapshot(encoded)
-	if err != nil {
-		// A corrupt entry should be impossible since we encoded it ourselves.
-		// If it ever happens, report a miss so it can be re-processed.
-		logrus.Errorf("Dropping corrupt cache entry for session %q: %v", clusterSessionKey, err)
-		s.mu.Lock()
-		s.cache.Remove(clusterSessionKey)
-		s.mu.Unlock()
-		return nil, false
-	}
-	return snap, true
+	return entry.snap, true
 }
 
 // renewTTL extends ExpiresAt for a cache hit.
@@ -188,9 +183,9 @@ func (s *SessionLoader) doLoadSession(ctx context.Context, info utils.ClusterInf
 	}
 }
 
-// putSnapshot stores encoded session snapshot bytes in the LRU cache.
+// putSnapshot caches a snapshot. It is marshaled once only to measure its size.
 func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.SessionSnapshot) error {
-	encoded, err := encodeSnapshot(snap)
+	encoded, err := json.Marshal(snap)
 	if err != nil {
 		logrus.Errorf("Failed to encode snapshot for session %q: %v", clusterSessionKey, err)
 		return fmt.Errorf("encode snapshot for session %q: %w", clusterSessionKey, err)
@@ -198,7 +193,7 @@ func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cache.Add(clusterSessionKey, encoded)
+	s.cache.Add(clusterSessionKey, cacheEntry{snap: snap, size: len(encoded)})
 	s.evictToByteBudget()
 	return nil
 }
@@ -226,28 +221,11 @@ func (s *SessionLoader) evictToByteBudget() {
 	}
 }
 
-// totalBytes sums the length of every cached entry.
+// totalBytes sums the size of every cached entry.
 func (s *SessionLoader) totalBytes() int {
 	total := 0
-	for _, encoded := range s.cache.Values() {
-		total += len(encoded)
+	for _, entry := range s.cache.Values() {
+		total += entry.size
 	}
 	return total
-}
-
-// encodeSnapshot serializes a snapshot to its cached byte form.
-//
-// Use JSON, not gob since snapshots have map[string]any CustomFields and gob requires
-// registering concrete types and fails to round-trip the arbitrary nested values reliably.
-func encodeSnapshot(snap *eventserver.SessionSnapshot) ([]byte, error) {
-	return json.Marshal(snap)
-}
-
-// decodeSnapshot reconstructs a snapshot from its cached byte form.
-func decodeSnapshot(encoded []byte) (*eventserver.SessionSnapshot, error) {
-	var snap eventserver.SessionSnapshot
-	if err := json.Unmarshal(encoded, &snap); err != nil {
-		return nil, err
-	}
-	return &snap, nil
 }

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -504,7 +504,7 @@ func TestCache_ByteBudgetEviction(t *testing.T) {
 
 	// Budget large enough for one richSnapshot but not two.
 	enc1, _ := json.Marshal(s1)
-	maxBytes := len(enc1) + 1
+	maxBytes := estimateHeapBytes(len(enc1)) + 1
 	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1000, maxBytes: maxBytes})
 
 	sl.putSnapshot(olderKey, s1)

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -1,9 +1,11 @@
 package historyserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -393,6 +395,51 @@ func TestGetSnapshot_ConcurrentReadsAreThreadSafe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestSnapshotConsumers_DoNotMutateSharedSnapshot runs the snapshot consumers
+// concurrently on one cached snapshot and verifies it is unchanged afterwards.
+func TestSnapshotConsumers_DoNotMutateSharedSnapshot(t *testing.T) {
+	key := testClusterSessionKey()
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	stored := richSnapshot(key)
+	// Store tasks out of order so an in-place sort would actually move elements.
+	slices.Reverse(stored.Tasks)
+	sl.putSnapshot(key, stored)
+	snap, ok := sl.GetSnapshot(key)
+	if !ok {
+		t.Fatal("GetSnapshot: ok=false")
+	}
+
+	// Marshal freezes an independent copy of the snapshot's state as bytes for
+	// before/after comparison.
+	before, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			utils.ApplyTaskFilters(snap.Tasks, utils.ListAPIOptions{Limit: utils.DefaultLimit})
+			getTasksTimeline(snap, "")
+			GetLastTimestamp(snap.Tasks, nil)
+			b := NewClusterStatusBuilder()
+			b.AddFailedNodesFromNodes(snap.Nodes)
+			b.AddPendingDemandsFromTasks(snap.Tasks)
+		}()
+	}
+	wg.Wait()
+
+	after, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("a snapshot consumer mutated the shared snapshot")
+	}
 }
 
 // TestGetSnapshot_LRUEviction verifies that once capacity is exceeded, the

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -1,10 +1,9 @@
 package historyserver
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -311,6 +310,24 @@ func TestGetSnapshot_PutThenGet(t *testing.T) {
 	}
 }
 
+// TestGetSnapshot_ReturnsCachedPointer verifies that GetSnapshot hands out the
+// cached snapshot itself (no per-request decode or copy).
+func TestGetSnapshot_ReturnsCachedPointer(t *testing.T) {
+	key := testClusterSessionKey()
+
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	stored := testSnapshot(key)
+	sl.putSnapshot(key, stored)
+
+	got, ok := sl.GetSnapshot(key)
+	if !ok {
+		t.Fatal("GetSnapshot: ok=false")
+	}
+	if got != stored {
+		t.Fatal("GetSnapshot should return the cached snapshot pointer, not a copy")
+	}
+}
+
 // TestGetSnapshot_ColdMiss verifies that a miss returns (nil, false).
 func TestGetSnapshot_ColdMiss(t *testing.T) {
 	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
@@ -339,8 +356,8 @@ func TestGetSnapshot_PutOverwrites(t *testing.T) {
 	}
 }
 
-// TestGetSnapshot_ConcurrentReadsAreThreadSafe verifies the thread-safety
-// of the byte cache under data race detection (-race).
+// TestGetSnapshot_ConcurrentReadsAreThreadSafe verifies that concurrent
+// putSnapshot/GetSnapshot calls are free of data races (-race).
 func TestGetSnapshot_ConcurrentReadsAreThreadSafe(t *testing.T) {
 	key := testClusterSessionKey()
 
@@ -364,48 +381,18 @@ func TestGetSnapshot_ConcurrentReadsAreThreadSafe(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			mine, ok := sl.GetSnapshot(key)
+			snap, ok := sl.GetSnapshot(key)
 			if !ok {
 				t.Errorf("GetSnapshot: unexpected miss")
 				return
 			}
-			mine.Actors["actor-e2e-cafe"] = eventtypes.Actor{ActorID: "MUTATED"}
-			delete(mine.Nodes, "node-e2e-dead")
-			mine.Jobs["injected"] = eventtypes.Job{}
-
-			fresh, ok := sl.GetSnapshot(key)
-			if !ok {
-				t.Errorf("GetSnapshot: unexpected miss on re-read")
-				return
-			}
-			if fresh.Actors["actor-e2e-cafe"].ActorID != "actor-e2e-cafe" {
-				t.Errorf("Actors map leaked across requests")
-			}
-			if _, ok := fresh.Nodes["node-e2e-dead"]; !ok {
-				t.Errorf("Nodes map leaked across requests")
-			}
-			if _, ok := fresh.Jobs["injected"]; ok {
-				t.Errorf("Jobs map leaked across requests")
+			if snap.Actors["actor-e2e-cafe"].ActorID != "actor-e2e-cafe" {
+				t.Errorf("unexpected snapshot content")
 			}
 		}()
 	}
 
 	wg.Wait()
-}
-
-// TestGetSnapshot_CorruptEntry_TreatedAsMiss verifies that a non-decodable cache
-// entry is dropped and reported as a miss instead of panicking.
-func TestGetSnapshot_CorruptEntry_TreatedAsMiss(t *testing.T) {
-	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
-	sl.cache.Add("corrupt", []byte("{not valid json"))
-
-	snap, ok := sl.GetSnapshot("corrupt")
-	if ok || snap != nil {
-		t.Fatalf("corrupt entry: got (%v, %v), want (nil, false)", snap, ok)
-	}
-	if _, stillCached := sl.cache.Get("corrupt"); stillCached {
-		t.Fatal("corrupt entry should have been dropped")
-	}
 }
 
 // TestGetSnapshot_LRUEviction verifies that once capacity is exceeded, the
@@ -469,7 +456,7 @@ func TestCache_ByteBudgetEviction(t *testing.T) {
 	s1 := richSnapshot(olderKey)
 
 	// Budget large enough for one richSnapshot but not two.
-	enc1, _ := encodeSnapshot(s1)
+	enc1, _ := json.Marshal(s1)
 	maxBytes := len(enc1) + 1
 	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1000, maxBytes: maxBytes})
 
@@ -493,47 +480,6 @@ func TestCache_ByteBudgetKeepsOversizedSoleEntry(t *testing.T) {
 	requireSnapshotCached(t, sl, key, true)
 	if entries, total := sl.cache.Len(), sl.totalBytes(); entries != 1 || total <= sl.maxBytes {
 		t.Fatalf("oversized sole entry: got (entries=%d, bytes=%d), want (1, >%d)", entries, total, sl.maxBytes)
-	}
-}
-
-// TestSnapshotCache_RoundTripPreservesData verifies the encode/decode round-trip
-// is lossless.
-func TestSnapshotCache_RoundTripPreservesData(t *testing.T) {
-	snap := richSnapshot(testClusterSessionKey())
-
-	b1, err := encodeSnapshot(snap)
-	if err != nil {
-		t.Fatalf("encode: %v", err)
-	}
-	got, err := decodeSnapshot(b1)
-	if err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	b2, err := encodeSnapshot(got)
-	if err != nil {
-		t.Fatalf("re-encode: %v", err)
-	}
-	if !bytes.Equal(b1, b2) {
-		t.Fatalf("round-trip changed the snapshot:\n before=%s\n  after=%s", b1, b2)
-	}
-
-	// byte equality can hide int to float64 drift inside map[string]any after JSON unmarshal.
-	wantCF := snap.LogEventsByJobID["job-e2e-aaaa"][0].CustomFields
-	gotCF := got.LogEventsByJobID["job-e2e-aaaa"][0].CustomFields
-	if !reflect.DeepEqual(wantCF, gotCF) {
-		t.Fatalf("CustomFields round-trip mismatch:\n want=%#v\n  got=%#v", wantCF, gotCF)
-	}
-
-	wantTask, gotTask := snap.Tasks[0], got.Tasks[0]
-	if gotTask.State != wantTask.State ||
-		!gotTask.CreationTime.Equal(wantTask.CreationTime) ||
-		!gotTask.StartTime.Equal(wantTask.StartTime) ||
-		!gotTask.EndTime.Equal(wantTask.EndTime) {
-		t.Fatalf("Task derived fields lost in round-trip:\n want=%+v\n  got=%+v", wantTask, gotTask)
-	}
-	if got.Actors["actor-e2e-cafe"].State != snap.Actors["actor-e2e-cafe"].State {
-		t.Fatalf("Actor.State lost in round-trip: want=%q got=%q",
-			snap.Actors["actor-e2e-cafe"].State, got.Actors["actor-e2e-cafe"].State)
 	}
 }
 

--- a/historyserver/pkg/utils/filter.go
+++ b/historyserver/pkg/utils/filter.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 
@@ -178,7 +179,8 @@ func ApplyTaskFilters(tasks []eventtypes.Task, listAPIOptions ListAPIOptions) ([
 		return []eventtypes.Task{}, 0
 	}
 
-	// Sort tasks by task_id and task_attempt.
+	// The caller's slice may be a shared cached snapshot; never sort it in place.
+	tasks = slices.Clone(tasks)
 	sort.Slice(tasks, func(i, j int) bool {
 		return tasks[i].TaskID < tasks[j].TaskID || (tasks[i].TaskID == tasks[j].TaskID && tasks[i].TaskAttempt < tasks[j].TaskAttempt)
 	})

--- a/historyserver/pkg/utils/filter_test.go
+++ b/historyserver/pkg/utils/filter_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+)
+
+// TestApplyTaskFiltersDoesNotMutateInput verifies that sorting never writes
+// into the caller's slice, which may alias a shared cached snapshot.
+func TestApplyTaskFiltersDoesNotMutateInput(t *testing.T) {
+	tasks := []eventtypes.Task{
+		{TaskID: "c", TaskAttempt: 0},
+		{TaskID: "a", TaskAttempt: 1},
+		{TaskID: "a", TaskAttempt: 0},
+		{TaskID: "b", TaskAttempt: 0},
+	}
+	original := make([]eventtypes.Task, len(tasks))
+	copy(original, tasks)
+
+	// ExcludeDriver=false with no filters is the path where the input would
+	// otherwise be sorted in place.
+	sorted, numFiltered := ApplyTaskFilters(tasks, ListAPIOptions{ExcludeDriver: false, Limit: DefaultLimit})
+
+	assert.Equal(t, original, tasks, "input slice must not be mutated")
+	assert.Equal(t, len(original), numFiltered)
+	assert.Equal(t, []eventtypes.Task{
+		{TaskID: "a", TaskAttempt: 0},
+		{TaskID: "a", TaskAttempt: 1},
+		{TaskID: "b", TaskAttempt: 0},
+		{TaskID: "c", TaskAttempt: 0},
+	}, sorted)
+}


### PR DESCRIPTION
## Why are these changes needed?

`SessionLoader` cached dead-session snapshots as JSON bytes and ran `json.Unmarshal` on every `GetSnapshot` call, so each HTTP request paid a full decode and allocated a complete new `SessionSnapshot`. This PR stores the `SessionSnapshot` struct directly and returns the shared pointer, making the read path zero-decode / zero-alloc.


Changes:
- `SessionLoader`:
    - LRU now holds `cacheEntry{snap, size}`
    - `putSnapshot` marshals once only to estimate size for the byte budget.
    - `GetSnapshot` returns the cached pointer.
- size held in `cacheEntry` is the marshaled JSON size * `sessionSnapshotHeapFactor` (2.5). The value is based on the discussion here https://github.com/ray-project/kuberay/pull/5208#discussion_r3890261932
- Snapshots are now shared across requests and must be treated as immutable (documented on `SessionSnapshot` and `GetSnapshot`).
- `utils.ApplyTaskFilters`: This was the only consumer that mutated the snapshot in place. Updated to clone before sorting.

### Benchmark

- Before: on master branch
- After: this branch

Columns:
- n: snapshot size -> n tasks, n actors, and n log events
- ns/op     time (ns) per operation           (lower is better)
- B/op       heap bytes allocated per op  (lower is better)
- allocs/op  heap allocations per op      (lower is better)

**Read path (`GetSnapshot`, one HTTP request)**
- Read cost is now O(1) regardless of snapshot size

| n | ns/op before | ns/op after | B/op before | B/op after | allocs/op before | allocs/op after |
|---|---|---|---|---|---|---|
| 100 | 605.5k | 140 | 354.0k | 0 | 5.6k | 0 |
| 1000 | 5.8M | 140 | 3.7M | 0 | 55.1k | 0 |
| 10000 | 57.6M | 140 | 45.9M | 0 | 550.2k | 0 |

**Write path (`putSnapshot`, one cold load)** 
- No meaningful change, as we still need to encode to get the size

| n | ns/op before | ns/op after | B/op before | B/op after | allocs/op before | allocs/op after |
|---|---|---|---|---|---|---|
| 100 | 239.0k | 231.9k | 215.4k | 215.4k | 2.6k | 2.6k |
| 1000 | 2.4M | 2.3M | 2.1M | 2.1M | 26.0k | 26.0k |
| 10000 | 24.2M | 22.9M | 21.8M | 21.7M | 260.0k | 260.0k |


## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
