### PR TITLE
ray-operator: remove ineffective clearing of WorkersToDelete

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1150,7 +1150,6 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 				r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, string(utils.DeletedWorkerPod), string(utils.DeleteAction), "Deleted pod %s/%s", pod.Namespace, pod.Name)
 			}
 		}
-		worker.ScaleStrategy.WorkersToDelete = []string{}
 
 		runningPods := corev1.PodList{}
 		for _, pod := range workerPods.Items {
@@ -1355,11 +1354,8 @@ func (r *RayClusterReconciler) reconcileMultiHostWorkerGroup(ctx context.Context
 			if err := r.deletePods(ctx, instance, podsToDel, worker.GroupName, "autoscaler scale-down request"); err != nil {
 				return err
 			}
-			worker.ScaleStrategy.WorkersToDelete = []string{}
 			return fmt.Errorf("deleted %d worker Pods based on ScaleStrategy, requeueing", len(podsToDel))
 		}
-		// Clear WorkersToDelete after deletion.
-		worker.ScaleStrategy.WorkersToDelete = []string{}
 	}
 
 	// 5. Calculate Pod diff for scaling up or down by NumOfHosts.


### PR DESCRIPTION
## Why are these changes needed?

These statements attempt to clear `ScaleStrategy.WorkersToDelete`, but they are ineffective because the loop uses a value copy of `WorkerGroupSpec`. Furthermore, this field is owned and cleared by the Ray Autoscaler, so these assignments are unnecessary and misleading.

## Related issue number

Closes #5206

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(