### PR TITLE
comply the cncf requirements on the maintainers table

### DIFF
--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -80,7 +80,11 @@ committer, but all of them will be considered together.
 
 ### Committers
 
-* @kevin85421
-* @andrewsykim
-* @rueian
-* @MortalHappiness
+KubeRay committers are the project maintainers. They have merge access and are responsible for the project.
+
+| Name | GitHub ID | Company/Organization |
+| ---- | --------- | -------------------- |
+| Kai-Hsun Chen | kevin85421 | Hark |
+| Andrew Sy Kim | andrewsykim | Google |
+| Jui-An Huang | rueian | Anyscale |
+| Chi-Sheng Liu | MortalHappiness | Anyscale |


### PR DESCRIPTION
To comply with CNCF requirements on the maintainers table, extend the KubeRay committers section to have Name | GitHub ID | Company/Organization columns.