### PR TITLE
[RayService] Preserve serve port appProtocol during incremental upgrade

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -215,10 +215,27 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 	// Include ports named "serve" or with the prefix "serve-" (e.g., "serve-grpc") to support
 	// multiple serving protocols such as HTTP and gRPC.
 	portsInt := getServicePorts(rayCluster)
+
+	// Carry AppProtocol (e.g. "kubernetes.io/h2c" for gRPC) from a user-provided ServeService
+	// onto the auto-detected serving ports by name. The custom ServeService branch below is
+	// skipped during an incremental upgrade because each per-cluster Service needs a unique
+	// name, so without this the per-cluster serve Service would lose AppProtocol.
+	userAppProtocol := make(map[string]*string)
+	if isRayService && rayService.Spec.ServeService != nil {
+		for _, p := range rayService.Spec.ServeService.Spec.Ports {
+			if p.AppProtocol != nil {
+				userAppProtocol[p.Name] = p.AppProtocol
+			}
+		}
+	}
+
 	ports := make([]corev1.ServicePort, 0)
 	for name, port := range portsInt {
 		if isServingPort(name) {
 			svcPort := corev1.ServicePort{Name: name, Port: port}
+			if appProtocol, ok := userAppProtocol[name]; ok {
+				svcPort.AppProtocol = appProtocol
+			}
 			ports = append(ports, svcPort)
 		}
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 var (
@@ -768,6 +770,67 @@ func TestUserSpecifiedServeServiceAppProtocolPreserved(t *testing.T) {
 	// gRPC port preserves user-specified appProtocol
 	require.NotNil(t, portsByName["serve-grpc"].AppProtocol)
 	assert.Equal(t, "kubernetes.io/h2c", *portsByName["serve-grpc"].AppProtocol)
+}
+
+// During an incremental upgrade the custom ServeService branch is skipped because each
+// per-cluster Service needs a unique name, so AppProtocol must still be carried onto the
+// auto-detected serving ports. Otherwise the Gateway treats gRPC traffic as HTTP/1.1.
+func TestServeServiceIncrementalUpgradePreservesAppProtocol(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+
+	cluster := rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "raycluster-incremental-grpc",
+			Namespace: "default",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "ray-head",
+								Ports: []corev1.ContainerPort{
+									{ContainerPort: 8000, Name: utils.ServingPortName},
+									{ContainerPort: 9000, Name: "serve-grpc"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	h2c := "kubernetes.io/h2c"
+	testRayService := serviceInstance.DeepCopy()
+	testRayService.Spec.UpgradeStrategy = &rayv1.RayServiceUpgradeStrategy{
+		Type: ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
+	}
+	testRayService.Spec.ServeService = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-serve-service"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: utils.ServingPortName, Port: 8000},
+				{Name: "serve-grpc", Port: 9000, AppProtocol: &h2c},
+			},
+		},
+	}
+
+	svc, err := BuildServeServiceForRayService(context.Background(), *testRayService, cluster)
+	require.NoError(t, err)
+
+	// The per-cluster Service keeps its generated name, not the custom ServeService name.
+	assert.Equal(t, utils.GenerateServeServiceName(cluster.Name), svc.Name)
+
+	portsByName := map[string]corev1.ServicePort{}
+	for _, port := range svc.Spec.Ports {
+		portsByName[port.Name] = port
+	}
+
+	require.NotNil(t, portsByName["serve-grpc"].AppProtocol)
+	assert.Equal(t, "kubernetes.io/h2c", *portsByName["serve-grpc"].AppProtocol)
+	assert.Nil(t, portsByName[utils.ServingPortName].AppProtocol)
 }
 
 func TestUserSpecifiedServeServiceFallbackPreservesAppProtocol(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

When `RayServiceNewClusterWithIncrementalUpgrade` is enabled, `BuildServeService` deliberately skips the custom `ServeService` branch, because each per-cluster serve Service needs its own generated name rather than the user-supplied one. A side effect is that everything else the user configured on that `ServeService` — including `appProtocol` on individual ports — is silently dropped, and the per-cluster Service is built purely from the auto-detected container ports.

That breaks gRPC serving behind the Gateway. A serving port only negotiates HTTP/2 cleartext upstream if its Service port carries `appProtocol: kubernetes.io/h2c`. Without it, the gateway falls back to HTTP/1.1 and gRPC requests fail with a protocol error — on `gke-l7-rilb` this shows up as the client receiving a protocol error even though the exact same RayService works when incremental upgrade is turned off.

This change carries `AppProtocol` from the user-provided `ServeService` onto the auto-detected serving ports, matched by port name. The per-cluster Service still gets its generated name and its auto-detected ports; it just no longer loses `appProtocol` on the way. Ports the user did not annotate are unaffected.

```yaml
serveService:
  metadata:
    name: my-serve-svc
  spec:
    ports:
      - name: serve
        port: 8000
      - name: serve-grpc
        port: 9000
        appProtocol: kubernetes.io/h2c   # previously dropped under incremental upgrade
```

This is a prerequisite for routing gRPC traffic through the incremental-upgrade Gateway; the routing side is a separate follow-up.

## Related issue number

N/A

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

`TestServeServiceIncrementalUpgradePreservesAppProtocol` covers it: with incremental upgrade enabled and a `ServeService` declaring `appProtocol: kubernetes.io/h2c` on `serve-grpc`, the built Service keeps the generated per-cluster name, keeps `h2c` on `serve-grpc`, and leaves `serve` without an `appProtocol`. Reverting the change makes the test fail on the nil `AppProtocol`.
