### PR TITLE
[Bug][Cleanup] Remove no-op WorkersToDelete resets in RayCluster controller

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1150,7 +1150,6 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 				r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, string(utils.DeletedWorkerPod), string(utils.DeleteAction), "Deleted pod %s/%s", pod.Namespace, pod.Name)
 			}
 		}
-		worker.ScaleStrategy.WorkersToDelete = []string{}
 
 		runningPods := corev1.PodList{}
 		for _, pod := range workerPods.Items {
@@ -1355,11 +1354,8 @@ func (r *RayClusterReconciler) reconcileMultiHostWorkerGroup(ctx context.Context
 			if err := r.deletePods(ctx, instance, podsToDel, worker.GroupName, "autoscaler scale-down request"); err != nil {
 				return err
 			}
-			worker.ScaleStrategy.WorkersToDelete = []string{}
 			return fmt.Errorf("deleted %d worker Pods based on ScaleStrategy, requeueing", len(podsToDel))
 		}
-		// Clear WorkersToDelete after deletion.
-		worker.ScaleStrategy.WorkersToDelete = []string{}
 	}
 
 	// 5. Calculate Pod diff for scaling up or down by NumOfHosts.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

 `RayClusterReconciler` had three statements that try to clear `ScaleStrategy.WorkersToDelete` but they’re ineffective, so these statements should not appear. 
Also, clearing `WorkersToDelete` is owned by the Ray Autoscaler, not the operator. Keeping these ineffective code is misleading.


## Related issue number
Closes #5206

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
