### PR TITLE
fix: sync scheduler-plugins PodGroup on updates

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins.go
+++ b/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +89,14 @@ func (k *KubeScheduler) DoBatchSchedulingOnSubmission(ctx context.Context, objec
 				return nil
 			}
 			return fmt.Errorf("failed to create PodGroup: %w", err)
+		}
+	}
+	desiredPodGroup := createPodGroup(app)
+	if podGroup.Spec.MinMember != desiredPodGroup.Spec.MinMember ||
+		!apiequality.Semantic.DeepEqual(podGroup.Spec.MinResources, desiredPodGroup.Spec.MinResources) {
+		podGroup.Spec = desiredPodGroup.Spec
+		if err := k.cli.Update(ctx, podGroup); err != nil {
+			return fmt.Errorf("failed to update PodGroup: %w", err)
 		}
 	}
 	return nil

--- a/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/scheduler-plugins/scheduler_plugins_test.go
@@ -5,12 +5,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 func createTestRayCluster(numOfHosts int32) rayv1.RayCluster {
@@ -115,6 +121,30 @@ func TestCreatePodGroupWithMultipleHosts(t *testing.T) {
 
 	// 1 head and 4 workers
 	a.Equal(int32(5), podGroup.Spec.MinMember)
+}
+
+func TestDoBatchSchedulingOnSubmissionUpdatesExistingPodGroup(t *testing.T) {
+	cluster := createTestRayCluster(1)
+	cluster.Labels = map[string]string{utils.RayGangSchedulingEnabled: "true"}
+
+	// Create the PodGroup for the original replica count, then scale the cluster
+	// down before the next reconciliation.
+	stalePodGroup := createPodGroup(&cluster)
+	cluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](1)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stalePodGroup).Build()
+	scheduler := &KubeScheduler{cli: fakeClient}
+
+	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(context.Background(), &cluster))
+
+	updatedPodGroup := &v1alpha1.PodGroup{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(stalePodGroup), updatedPodGroup))
+	assert.Equal(t, int32(2), updatedPodGroup.Spec.MinMember)
+	assert.Equal(t, "512m", updatedPodGroup.Spec.MinResources.Cpu().String())
+	assert.Equal(t, "512Mi", updatedPodGroup.Spec.MinResources.Memory().String())
 }
 
 func TestAddMetadataToChildResource(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

`KubeScheduler.DoBatchSchedulingOnSubmission` only created a scheduler-plugins `PodGroup` when it was missing. After a RayCluster scale change, `MinMember` and `MinResources` could remain stale, leaving gang scheduling with an outdated admission requirement.

This change recalculates the desired PodGroup spec during reconciliation and updates an existing PodGroup only when its desired fields differ. Existing metadata and status are preserved.

## Related issue number

Fixes #5205

## Checks

- [x] I have made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests

Validated locally:
- `go test ./controllers/ray/batchscheduler/scheduler-plugins -count=1`
- `go test ./controllers/ray/batchscheduler/... -count=1`
- `go vet ./controllers/ray/batchscheduler/...`
- `gofmt` on changed files
- `git diff --check`

The full `go test ./... -count=1` suite could not complete in this Windows environment because the repository envtest/e2e tests require a Kubernetes control plane (`kubebuilder` etcd and a kubeconfig). All relevant unit packages passed.