### PR TITLE
fix: report unmatched RayJob deletion rules

### DIFF
--- a/ray-operator/config/samples/ray-job.deletion-rules.yaml
+++ b/ray-operator/config/samples/ray-job.deletion-rules.yaml
@@ -28,16 +28,16 @@ spec:
     # 3. After 90 seconds, the RayJob custom resource itself is deleted, removing it from the Kubernetes API server.
     deletionRules:
     - condition:
-        jobStatus: FAILED
-        ttlSeconds: 30
+        jobDeploymentStatus: Failed
+      ttlSeconds: 30
       policy: DeleteWorkers
     - condition:
-        jobStatus: FAILED
-        ttlSeconds: 60
+        jobDeploymentStatus: Failed
+      ttlSeconds: 60
       policy: DeleteCluster
     - condition:
-        jobStatus: FAILED
-        ttlSeconds: 90
+        jobDeploymentStatus: Failed
+      ttlSeconds: 90
       policy: DeleteSelf
     - condition:
         jobStatus: SUCCEEDED

--- a/ray-operator/config/samples/ray-job.deletion-rules.yaml
+++ b/ray-operator/config/samples/ray-job.deletion-rules.yaml
@@ -29,15 +29,15 @@ spec:
     deletionRules:
     - condition:
         jobDeploymentStatus: Failed
-      ttlSeconds: 30
+        ttlSeconds: 30
       policy: DeleteWorkers
     - condition:
         jobDeploymentStatus: Failed
-      ttlSeconds: 60
+        ttlSeconds: 60
       policy: DeleteCluster
     - condition:
         jobDeploymentStatus: Failed
-      ttlSeconds: 90
+        ttlSeconds: 90
       policy: DeleteSelf
     - condition:
         jobStatus: SUCCEEDED

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1416,6 +1416,7 @@ func (r *RayJobReconciler) handleDeletionRules(ctx context.Context, rayJob *rayv
 
 	var overdueRules []rayv1.DeletionRule
 	var nextRequeueTime *time.Time
+	var matchedRule bool
 
 	// Categorize all applicable and incomplete rules into "overdue" or "pending".
 	for _, rule := range rayJob.Spec.DeletionStrategy.DeletionRules {
@@ -1423,6 +1424,7 @@ func (r *RayJobReconciler) handleDeletionRules(ctx context.Context, rayJob *rayv
 		if !isDeletionRuleMatched(rule, rayJob) {
 			continue
 		}
+		matchedRule = true
 
 		deletionTime := rayJob.Status.EndTime.Add(time.Duration(rule.Condition.TTLSeconds) * time.Second)
 		// Track the earliest requeue time to re-check later.
@@ -1461,6 +1463,18 @@ func (r *RayJobReconciler) handleDeletionRules(ctx context.Context, rayJob *rayv
 		requeueAfter := requeueDelayFor(*nextRequeueTime)
 		logger.Info("Requeuing for the next scheduled rule", "requeueAfter", requeueAfter)
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+	if !matchedRule {
+		message := fmt.Sprintf(
+			"No deletion rule matched terminal status: jobStatus=%q, jobDeploymentStatus=%q. No cleanup action will be taken.",
+			rayJob.Status.JobStatus,
+			rayJob.Status.JobDeploymentStatus,
+		)
+		logger.Info("No deletion rule matched terminal RayJob; no cleanup action will be taken.",
+			"jobStatus", rayJob.Status.JobStatus,
+			"jobDeploymentStatus", rayJob.Status.JobDeploymentStatus)
+		r.Recorder.Eventf(rayJob, nil, corev1.EventTypeWarning, string(utils.NoMatchingDeletionRule), string(utils.CleanupAction), message)
+		return ctrl.Result{}, nil
 	}
 
 	logger.Info("All applicable deletion rules have been processed.")

--- a/ray-operator/controllers/ray/rayjob_deletion_rules_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_deletion_rules_unit_test.go
@@ -1,0 +1,54 @@
+package ray
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+func TestHandleDeletionRulesReportsUnmatchedTerminalStatus(t *testing.T) {
+	recorder := events.NewFakeRecorder(1)
+	reconciler := &RayJobReconciler{Recorder: recorder}
+	jobStatus := rayv1.JobStatusRunning
+	ruleJobStatus := rayv1.JobStatusSucceeded
+	jobDeploymentStatus := rayv1.JobDeploymentStatusFailed
+	rayJob := &rayv1.RayJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rayjob-unmatched-rule",
+			Namespace: "default",
+		},
+		Spec: rayv1.RayJobSpec{
+			DeletionStrategy: &rayv1.DeletionStrategy{
+				DeletionRules: []rayv1.DeletionRule{{
+					Condition: rayv1.DeletionCondition{JobStatus: &ruleJobStatus},
+					Policy:    rayv1.DeleteCluster,
+				}},
+			},
+		},
+		Status: rayv1.RayJobStatus{
+			JobStatus:           jobStatus,
+			JobDeploymentStatus: jobDeploymentStatus,
+		},
+	}
+
+	result, err := reconciler.handleDeletionRules(context.Background(), rayJob)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "Warning")
+		assert.Contains(t, event, string(utils.NoMatchingDeletionRule))
+		assert.Contains(t, event, "jobDeploymentStatus=\"Failed\"")
+		assert.Contains(t, event, "No cleanup action will be taken")
+	default:
+		t.Fatal("expected an unmatched deletion rule warning event, got none")
+	}
+}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -464,6 +464,7 @@ const (
 	FailedToDeleteRayCluster      K8sEventType = "FailedToDeleteRayCluster"
 	FailedToUpdateRayCluster      K8sEventType = "FailedToUpdateRayCluster"
 	RayClusterNotFound            K8sEventType = "RayClusterNotFound"
+	NoMatchingDeletionRule        K8sEventType = "NoMatchingDeletionRule"
 
 	// Batch scheduler event list
 	BatchSchedulerCleanedUp       K8sEventType = "BatchSchedulerCleanedUp"


### PR DESCRIPTION
## Why are these changes needed?

When a terminal RayJob status matches no configured deletion rule, the controller currently logs the same success message as a fully processed rule set and takes no cleanup action. This can leave the RayCluster and RayJob resources behind without a visible signal, for example when `activeDeadlineSeconds` sets `jobDeploymentStatus=Failed` while `jobStatus` remains `RUNNING`.

This change:

- tracks whether any deletion rule matched;
- emits a Warning event with the terminal statuses when none matched;
- writes a distinct log message for the no-match case; and
- updates the deletion-rules sample to use `jobDeploymentStatus: Failed` for failure cleanup, covering infrastructure failures as well as application failures.

Deletion behavior is unchanged for matching rules.

## Related issue number

Fixes #5184

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Validated locally:

- `go test ./controllers/ray -run '^TestHandleDeletionRulesReportsUnmatchedTerminalStatus$' -count=1`
- `go vet ./controllers/ray/...`
- `gofmt` on changed Go files
- `git diff --check`