### PR TITLE
[History server] Skip directory markers when listing storage

### DIFF
--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -105,6 +105,9 @@ func (r *RayLogsHandler) _listFiles(prefix string, delimiter string, onlyBase bo
 		logrus.Infof("[ListFiles]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", prefix+"/", len(page.Contents),
 			len(page.CommonPrefixes))
 		for _, objects := range page.Contents {
+			if utils.IsDirectoryMarker(*objects.Key) {
+				continue
+			}
 			objName := *objects.Key
 			if onlyBase {
 				objName = path.Base(*objects.Key)
@@ -167,6 +170,9 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 			logrus.Infof("[List]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", prefix, len(page.Contents),
 				len(page.CommonPrefixes))
 			for _, objects := range page.Contents {
+				if utils.IsDirectoryMarker(*objects.Key) {
+					continue
+				}
 				c, err := clustermetadata.DecodePath(*objects.Key, r.OssRootDir)
 				if err != nil {
 					logrus.Errorf("Failed to parse meta file path: %s, error: %v", *objects.Key, err)

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -104,6 +104,9 @@ func (r *RayLogsHandler) _listFiles(prefix string, delimiter string, onlyBase bo
 				prefix+"/", len(page.Contents), len(page.CommonPrefixes))
 
 			for _, object := range page.Contents {
+				if utils.IsDirectoryMarker(*object.Key) {
+					continue
+				}
 				objName := *object.Key
 				if onlyBase {
 					objName = path.Base(*object.Key)
@@ -169,6 +172,9 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 					prefix, len(page.Contents), len(page.CommonPrefixes))
 
 				for _, object := range page.Contents {
+					if utils.IsDirectoryMarker(*object.Key) {
+						continue
+					}
 					c, err := clustermetadata.DecodePath(*object.Key, r.S3RootDir)
 					if err != nil {
 						logrus.Errorf("Failed to parse meta file path: %s, error: %v", *object.Key, err)

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -49,6 +49,12 @@ func EndpointPathToStorageKey(endpointPath string) string {
 	return "restful__" + strings.ReplaceAll(trimmed, "/", "__")
 }
 
+// IsDirectoryMarker reports whether key is an empty directory placeholder
+// rather than a real object.
+func IsDirectoryMarker(key string) bool {
+	return strings.HasSuffix(key, "/")
+}
+
 const (
 	// connector is the separator for creating flat storage keys.
 	//


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the History Server reads cluster metadata from object storage, directory marker objects created by `StorageWriter.CreateDirectory` are returned alongside the actual session markers.

```
S3 bucket
│
├── cluster-metadata/rayjob/default_rayjob-historyserver_rayjob-historyserver-5qj8v/
│   └── 0 bytes  ← directory marker
│
└── cluster-metadata/rayjob/default_rayjob-historyserver_rayjob-historyserver-5qj8v/session_xxx
               └── 0 bytes  ← session marker
```

The directory marker is a 0-byte object, not a metadata file, but `List()` passes it to `DecodePath()`, causing a misleading error:
```
time="2026-09-03T03:20:04Z" level=error msg="Failed to parse meta file path: cluster-metadata/rayjob/default_rayjob-historyserver_rayjob-historyserver-5qj8v/, error: invalid path segment count for cluster metadata structure: cluster-metadata/rayjob/default_rayjob-historyserver_rayjob-historyserver-5qj8v/"
```

- `List()`: a placeholder has one path segment too few for DecodePath, so every /clusters and /enter_cluster request logged one parse error per cluster in the bucket.

https://github.com/ray-project/kuberay/blob/215b98f416c220af6a20056316b116a86d920a7e/historyserver/pkg/storage/clustermetadata/clustermetadata.go#L40-L54

- `_listFiles()`: a placeholder surfaced as an entry named after its own directory, leaking into /api/v0/logs?glob=** as "events/events".
<img width="771" height="620" alt="image" src="https://github.com/user-attachments/assets/3b090545-dffa-4e08-8e39-955f11ecdd8f" />



Changes:

- Add `utils.IsDirectoryMarker`.
- Skip markers in the object loops of `s3`, `aliyunoss`, in both `List()` and `_listFiles()`.
- GCS unchanged: `List()` already filters them via MatchGlob, and _listFiles() via HasSuffix.
- Azure Blob unchanged: `CreateDirectory` is a no-op, so it does not create directory marker objects.


## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
