### PR TITLE
[Refactor][History Server] Prefix entity status constants to avoid name conflicts

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -229,7 +229,7 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 			}
 
 			stateEvents = append(stateEvents, types.ActorStateEvent{
-				State:      types.StateType(state),
+				State:      types.ActorState(state),
 				Timestamp:  timestamp,
 				NodeID:     nodeId,
 				WorkerID:   workerId,
@@ -284,7 +284,7 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 			// --- UPDATE ADDRESS from ALIVE state ---
 			// NodeID and WorkerID are only populated in ALIVE state
 			for i := len(a.Events) - 1; i >= 0; i-- {
-				if a.Events[i].State == types.ALIVE && a.Events[i].NodeID != "" {
+				if a.Events[i].State == types.ACTOR_ALIVE && a.Events[i].NodeID != "" {
 					a.Address.NodeID = a.Events[i].NodeID
 					a.Address.WorkerID = a.Events[i].WorkerID
 					break
@@ -299,7 +299,7 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 			// --- CALCULATE StartTime (first ALIVE timestamp) ---
 			if a.StartTime.IsZero() {
 				for _, e := range a.Events {
-					if e.State == types.ALIVE {
+					if e.State == types.ACTOR_ALIVE {
 						a.StartTime = e.Timestamp
 						break
 					}
@@ -307,7 +307,7 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 			}
 
 			// --- HANDLE DEAD state ---
-			if lastEvent.State == types.DEAD {
+			if lastEvent.State == types.ACTOR_DEAD {
 				a.EndTime = lastEvent.Timestamp
 
 				// Parse deathCause to extract PID, IP, errorMessage
@@ -335,7 +335,7 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 			// --- COUNT RESTARTS ---
 			restartCount := 0
 			for _, e := range a.Events {
-				if e.State == types.RESTARTING {
+				if e.State == types.ACTOR_RESTARTING {
 					restartCount++
 				}
 			}
@@ -495,14 +495,14 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 
 			if j.StartTime.IsZero() {
 				for _, t := range j.StateTransitions {
-					if t.State == types.CREATED {
+					if t.State == types.JOB_CREATED {
 						j.StartTime = t.Timestamp
 						break
 					}
 				}
 			}
 
-			if lastStateTransition.State == types.JOBFINISHED {
+			if lastStateTransition.State == types.JOB_FINISHED {
 				j.EndTime = lastStateTransition.Timestamp
 			}
 		})
@@ -864,15 +864,15 @@ func (h *EventHandler) handleTaskLifecycleEvent(eventMap map[string]any, cluster
 		// Ref: https://github.com/ray-project/ray/blob/d0b1d151d8ea964a711e451d0ae736f8bf95b629/python/ray/util/state/common.py#L1660-L1685
 		for _, tr := range task.StateTransitions {
 			switch tr.State {
-			case types.PENDING_ARGS_AVAIL:
+			case types.TASK_PENDING_ARGS_AVAIL:
 				if task.CreationTime.IsZero() {
 					task.CreationTime = tr.Timestamp
 				}
-			case types.RUNNING:
+			case types.TASK_RUNNING:
 				if task.StartTime.IsZero() {
 					task.StartTime = tr.Timestamp
 				}
-			case types.FINISHED, types.FAILED:
+			case types.TASK_FINISHED, types.TASK_FAILED:
 				// Take the latest timestamp as the end time.
 				task.EndTime = tr.Timestamp
 			}

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -353,79 +353,79 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 		{
 			name: "Scenario 1: Normal deduplication - same events processed twice",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 2000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 2000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("PENDING_NODE_ASSIGNMENT", 1000), // Duplicate
 				makeTransition("RUNNING", 2000),                 // Duplicate
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 2000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 2000),
 			},
-			wantState: types.RUNNING,
+			wantState: types.TASK_RUNNING,
 		},
 		{
 			name: "Scenario 2: Out-of-order events - B(t=2) arrives after A(t=1), C(t=3)",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000), // A
-				makeStateEvent(types.FINISHED, 3000),                // C
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000), // A
+				makeStateEvent(types.TASK_FINISHED, 3000),                // C
 			},
 			newTransitions: []map[string]any{
 				makeTransition("RUNNING", 2000), // B - should be inserted in the middle
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000), // A
-				makeStateEvent(types.RUNNING, 2000),                 // B - now in correct position
-				makeStateEvent(types.FINISHED, 3000),                // C
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000), // A
+				makeStateEvent(types.TASK_RUNNING, 2000),                 // B - now in correct position
+				makeStateEvent(types.TASK_FINISHED, 3000),                // C
 			},
-			wantState: types.FINISHED,
+			wantState: types.TASK_FINISHED,
 		},
 		{
 			name: "Scenario 3: Same timestamp, different states - both should be kept",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("RUNNING", 1000), // Same timestamp, different state
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 1000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 1000),
 			},
-			wantState: types.RUNNING, // Last after sort (order of same timestamp is stable)
+			wantState: types.TASK_RUNNING, // Last after sort (order of same timestamp is stable)
 		},
 		{
 			name: "Scenario 4: Exact duplicate event - only one should remain",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.RUNNING, 1000),
+				makeStateEvent(types.TASK_RUNNING, 1000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("RUNNING", 1000), // Exact duplicate
 				makeTransition("RUNNING", 1000), // Another duplicate
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.RUNNING, 1000), // Only one
+				makeStateEvent(types.TASK_RUNNING, 1000), // Only one
 			},
-			wantState: types.RUNNING,
+			wantState: types.TASK_RUNNING,
 		},
 		{
 			name: "Scenario 5: Partial overlap - existing [A,B], new [B,C] -> result [A,B,C]",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000), // A
-				makeStateEvent(types.RUNNING, 2000),                 // B
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000), // A
+				makeStateEvent(types.TASK_RUNNING, 2000),                 // B
 			},
 			newTransitions: []map[string]any{
 				makeTransition("RUNNING", 2000),  // B - duplicate
 				makeTransition("FINISHED", 3000), // C - new
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000), // A
-				makeStateEvent(types.RUNNING, 2000),                 // B
-				makeStateEvent(types.FINISHED, 3000),                // C
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000), // A
+				makeStateEvent(types.TASK_RUNNING, 2000),                 // B
+				makeStateEvent(types.TASK_FINISHED, 3000),                // C
 			},
-			wantState: types.FINISHED,
+			wantState: types.TASK_FINISHED,
 		},
 		{
 			name:           "Scenario 6: Empty initial events - add new events",
@@ -435,17 +435,17 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 				makeTransition("RUNNING", 2000),
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 2000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 2000),
 			},
-			wantState: types.RUNNING,
+			wantState: types.TASK_RUNNING,
 		},
 		{
 			name: "Scenario 7: Multiple reprocessing cycles - events should not grow",
 			existingEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 2000),
-				makeStateEvent(types.FINISHED, 3000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 2000),
+				makeStateEvent(types.TASK_FINISHED, 3000),
 			},
 			newTransitions: []map[string]any{
 				// Simulating reprocess of same file
@@ -454,11 +454,11 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 				makeTransition("FINISHED", 3000),
 			},
 			wantEvents: []types.TaskStateTransition{
-				makeStateEvent(types.PENDING_NODE_ASSIGNMENT, 1000),
-				makeStateEvent(types.RUNNING, 2000),
-				makeStateEvent(types.FINISHED, 3000),
+				makeStateEvent(types.TASK_PENDING_NODE_ASSIGNMENT, 1000),
+				makeStateEvent(types.TASK_RUNNING, 2000),
+				makeStateEvent(types.TASK_FINISHED, 3000),
 			},
-			wantState: types.FINISHED,
+			wantState: types.TASK_FINISHED,
 		},
 	}
 
@@ -575,7 +575,7 @@ func TestTaskLogInfoLifecycleReplay(t *testing.T) {
 			require.Len(t, tasks, 1)
 			assert.Equal(t, want, tasks[0].TaskLogInfo)
 			assert.Equal(t, "bench_task", tasks[0].TaskName)
-			assert.Equal(t, types.RUNNING, tasks[0].State)
+			assert.Equal(t, types.TASK_RUNNING, tasks[0].State)
 		})
 	}
 
@@ -647,7 +647,7 @@ func TestStoreRay256TaskLogInfoJSONL(t *testing.T) {
 	require.Len(t, tasks, 1)
 	task := tasks[0]
 	assert.Equal(t, "bench_task", task.TaskName)
-	assert.Equal(t, types.FINISHED, task.State)
+	assert.Equal(t, types.TASK_FINISHED, task.State)
 	assert.NotEmpty(t, task.NodeID)
 	assert.NotEmpty(t, task.WorkerID)
 	require.NotNil(t, task.TaskLogInfo)
@@ -668,7 +668,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 	)
 
 	// Helper to create an ActorStateEvent
-	makeActorStateEvent := func(state types.StateType, timestampNano int64) types.ActorStateEvent {
+	makeActorStateEvent := func(state types.ActorState, timestampNano int64) types.ActorStateEvent {
 		return types.ActorStateEvent{
 			State:     state,
 			Timestamp: time.Unix(0, timestampNano),
@@ -704,44 +704,44 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		existingEvents []types.ActorStateEvent
 		newTransitions []map[string]any
 		wantEvents     []types.ActorStateEvent
-		wantState      types.StateType
+		wantState      types.ActorState
 	}{
 		{
 			name: "Actor: Normal deduplication",
 			existingEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
-				makeActorStateEvent(types.ALIVE, 2000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 2000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("PENDING_CREATION", 1000),
 				makeTransition("ALIVE", 2000),
 			},
 			wantEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
-				makeActorStateEvent(types.ALIVE, 2000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 2000),
 			},
-			wantState: types.ALIVE,
+			wantState: types.ACTOR_ALIVE,
 		},
 		{
 			name: "Actor: Out-of-order with sort",
 			existingEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
-				makeActorStateEvent(types.DEAD, 3000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_DEAD, 3000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("ALIVE", 2000), // Should be inserted between
 			},
 			wantEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
-				makeActorStateEvent(types.ALIVE, 2000),
-				makeActorStateEvent(types.DEAD, 3000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 2000),
+				makeActorStateEvent(types.ACTOR_DEAD, 3000),
 			},
-			wantState: types.DEAD,
+			wantState: types.ACTOR_DEAD,
 		},
 		{
 			name: "Actor: Exact duplicate should not increase count",
 			existingEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.ALIVE, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 1000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("ALIVE", 1000),
@@ -749,23 +749,23 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 				makeTransition("ALIVE", 1000),
 			},
 			wantEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.ALIVE, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 1000),
 			},
-			wantState: types.ALIVE,
+			wantState: types.ACTOR_ALIVE,
 		},
 		{
 			name: "Actor: Same timestamp different states should both be kept",
 			existingEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("ALIVE", 1000), // Same timestamp, different state
 			},
 			wantEvents: []types.ActorStateEvent{
-				makeActorStateEvent(types.PENDING_CREATION, 1000),
-				makeActorStateEvent(types.ALIVE, 1000),
+				makeActorStateEvent(types.ACTOR_PENDING_CREATION, 1000),
+				makeActorStateEvent(types.ACTOR_ALIVE, 1000),
 			},
-			wantState: types.ALIVE,
+			wantState: types.ACTOR_ALIVE,
 		},
 	}
 
@@ -850,7 +850,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 
 	tests := []struct {
 		name string
-		// Available Job States are UNSPECIFIED, CREATED, JOBFINISHED
+		// Available Job States are JOB_UNSPECIFIED, JOB_CREATED, JOB_FINISHED
 		existingTransitions []types.JobStateTransition
 		newTransitions      []map[string]any
 		wantTransitions     []types.JobStateTransition
@@ -859,18 +859,18 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		{
 			name: "Driver Job: Same event is processed twice",
 			existingTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("UNSPECIFIED", 1000),
 				makeTransition("CREATED", 2000),
 			},
 			wantTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
 			},
-			wantState: types.CREATED,
+			wantState: types.JOB_CREATED,
 		},
 		{
 			name:                "Driver Job: Empty existing transitions",
@@ -881,32 +881,32 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				makeTransition("FINISHED", 3000),
 			},
 			wantTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
-				makeDriverJobStateTransitionEvent(types.JOBFINISHED, 3000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_FINISHED, 3000),
 			},
-			wantState: types.JOBFINISHED,
+			wantState: types.JOB_FINISHED,
 		},
 		{
 			name: "Driver Job: Out of order transition event",
 			existingTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.JOBFINISHED, 3000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_FINISHED, 3000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("CREATED", 2000),
 			},
 			wantTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
-				makeDriverJobStateTransitionEvent(types.JOBFINISHED, 3000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_FINISHED, 3000),
 			},
-			wantState: types.JOBFINISHED,
+			wantState: types.JOB_FINISHED,
 		},
 		{
 			name: "Driver Job: Multiple duplicate of same transition event",
 			existingTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("CREATED", 2000),
@@ -915,14 +915,14 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				makeTransition("CREATED", 2000),
 			},
 			wantTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
 			},
-			wantState: types.CREATED,
+			wantState: types.JOB_CREATED,
 		},
 		{
 			name: "Driver Job: Different transition events with same time stamp, all be kept",
 			existingTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
 			},
 			newTransitions: []map[string]any{
 				makeTransition("CREATED", 1000),
@@ -930,12 +930,12 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				makeTransition("FINISHED", 2000),
 			},
 			wantTransitions: []types.JobStateTransition{
-				makeDriverJobStateTransitionEvent(types.UNSPECIFIED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 1000),
-				makeDriverJobStateTransitionEvent(types.CREATED, 2000),
-				makeDriverJobStateTransitionEvent(types.JOBFINISHED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_UNSPECIFIED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 1000),
+				makeDriverJobStateTransitionEvent(types.JOB_CREATED, 2000),
+				makeDriverJobStateTransitionEvent(types.JOB_FINISHED, 2000),
 			},
-			wantState: types.JOBFINISHED,
+			wantState: types.JOB_FINISHED,
 		},
 	}
 

--- a/historyserver/pkg/eventserver/types/actor.go
+++ b/historyserver/pkg/eventserver/types/actor.go
@@ -5,14 +5,14 @@ import (
 	"time"
 )
 
-type StateType string
+type ActorState string
 
 const (
-	DEPENDENCIES_UNREADY StateType = "DEPENDENCIES_UNREADY"
-	PENDING_CREATION     StateType = "PENDING_CREATION"
-	ALIVE                StateType = "ALIVE"
-	RESTARTING           StateType = "RESTARTING"
-	DEAD                 StateType = "DEAD"
+	ACTOR_DEPENDENCIES_UNREADY ActorState = "DEPENDENCIES_UNREADY"
+	ACTOR_PENDING_CREATION     ActorState = "PENDING_CREATION"
+	ACTOR_ALIVE                ActorState = "ALIVE"
+	ACTOR_RESTARTING           ActorState = "RESTARTING"
+	ACTOR_DEAD                 ActorState = "DEAD"
 )
 
 type Address struct {
@@ -32,7 +32,7 @@ type Address struct {
 // - ReprName: actor repr name (may change during lifecycle)
 // - DeathCause: JSON string containing death details (only in DEAD state)
 type ActorStateEvent struct {
-	State      StateType `json:"state"`
+	State      ActorState `json:"state"`
 	Timestamp  time.Time `json:"timestamp"`
 	NodeID     string    `json:"nodeId,omitempty"`
 	WorkerID   string    `json:"workerId,omitempty"`
@@ -44,7 +44,7 @@ type Actor struct {
 	ActorID          string `json:"actorId"`
 	JobID            string `json:"jobId"`
 	PlacementGroupID string `json:"placementGroupId,omitempty"`
-	State            StateType
+	State            ActorState
 
 	// PID is extracted from deathCause.actorDiedErrorContext.pid (not from definition event)
 	PID int `json:"pid,omitempty"`

--- a/historyserver/pkg/eventserver/types/job.go
+++ b/historyserver/pkg/eventserver/types/job.go
@@ -9,13 +9,11 @@ import (
 type JobStatus string
 
 const (
-	SUCCEEDED JobStatus = "SUCCEEDED"
-	PENDING   JobStatus = "PENDING"
-	STOPPED   JobStatus = "STOPPED"
-	// FAILED is already used in the package, using JOBFAILED
-	JOBFAILED JobStatus = "FAILED"
-	// RUNNING is already used in the package, using JOBRUNNING
-	JOBRUNNING JobStatus = "RUNNING"
+	JOB_SUCCEEDED JobStatus = "SUCCEEDED"
+	JOB_PENDING   JobStatus = "PENDING"
+	JOB_STOPPED   JobStatus = "STOPPED"
+	JOB_FAILED    JobStatus = "FAILED"
+	JOB_RUNNING   JobStatus = "RUNNING"
 )
 
 type JobStatusTransition struct {
@@ -27,10 +25,9 @@ type JobStatusTransition struct {
 type JobState string
 
 const (
-	UNSPECIFIED JobState = "UNSPECIFIED"
-	CREATED     JobState = "CREATED"
-	// FINISHED is already used in package, using JOBFINSIHED
-	JOBFINISHED JobState = "FINISHED"
+	JOB_UNSPECIFIED JobState = "UNSPECIFIED"
+	JOB_CREATED     JobState = "CREATED"
+	JOB_FINISHED    JobState = "FINISHED"
 )
 
 type JobStateTransition struct {

--- a/historyserver/pkg/eventserver/types/task.go
+++ b/historyserver/pkg/eventserver/types/task.go
@@ -66,22 +66,21 @@ type TaskStatus string
 // The following statuses follow a rough chronological order of transition.
 // For typical order of states, please refer to:
 // https://github.com/ray-project/ray/blob/d0b1d151d8ea964a711e451d0ae736f8bf95b629/src/ray/protobuf/common.proto#L884-L899.
-// TODO(jiangjiawei1103): Each entity (actor, task, job, node) should have its own const def with entity name prepended to avoid conflicts.
 const (
-	NIL                                        TaskStatus = "NIL"
-	PENDING_ARGS_AVAIL                         TaskStatus = "PENDING_ARGS_AVAIL"
-	PENDING_NODE_ASSIGNMENT                    TaskStatus = "PENDING_NODE_ASSIGNMENT"
-	PENDING_OBJ_STORE_MEM_AVAIL                TaskStatus = "PENDING_OBJ_STORE_MEM_AVAIL"
-	PENDING_ARGS_FETCH                         TaskStatus = "PENDING_ARGS_FETCH"
-	SUBMITTED_TO_WORKER                        TaskStatus = "SUBMITTED_TO_WORKER"
-	PENDING_ACTOR_TASK_ARGS_FETCH              TaskStatus = "PENDING_ACTOR_TASK_ARGS_FETCH"
-	PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY TaskStatus = "PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY"
-	RUNNING                                    TaskStatus = "RUNNING"
-	RUNNING_IN_RAY_GET                         TaskStatus = "RUNNING_IN_RAY_GET"
-	RUNNING_IN_RAY_WAIT                        TaskStatus = "RUNNING_IN_RAY_WAIT"
-	FINISHED                                   TaskStatus = "FINISHED"
-	FAILED                                     TaskStatus = "FAILED"
-	GETTING_AND_PINNING_ARGS                   TaskStatus = "GETTING_AND_PINNING_ARGS"
+	TASK_NIL                                        TaskStatus = "NIL"
+	TASK_PENDING_ARGS_AVAIL                         TaskStatus = "PENDING_ARGS_AVAIL"
+	TASK_PENDING_NODE_ASSIGNMENT                    TaskStatus = "PENDING_NODE_ASSIGNMENT"
+	TASK_PENDING_OBJ_STORE_MEM_AVAIL                TaskStatus = "PENDING_OBJ_STORE_MEM_AVAIL"
+	TASK_PENDING_ARGS_FETCH                         TaskStatus = "PENDING_ARGS_FETCH"
+	TASK_SUBMITTED_TO_WORKER                        TaskStatus = "SUBMITTED_TO_WORKER"
+	TASK_PENDING_ACTOR_TASK_ARGS_FETCH              TaskStatus = "PENDING_ACTOR_TASK_ARGS_FETCH"
+	TASK_PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY TaskStatus = "PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY"
+	TASK_RUNNING                                    TaskStatus = "RUNNING"
+	TASK_RUNNING_IN_RAY_GET                         TaskStatus = "RUNNING_IN_RAY_GET"
+	TASK_RUNNING_IN_RAY_WAIT                        TaskStatus = "RUNNING_IN_RAY_WAIT"
+	TASK_FINISHED                                   TaskStatus = "FINISHED"
+	TASK_FAILED                                     TaskStatus = "FAILED"
+	TASK_GETTING_AND_PINNING_ARGS                   TaskStatus = "GETTING_AND_PINNING_ARGS"
 )
 
 // TaskStateTransition represents a change in a task's state at a specific timestamp.
@@ -322,7 +321,7 @@ func (t *Task) GetFuncName() string {
 // GetLastState returns the last state of the task.
 func (t *Task) GetLastState() TaskStatus {
 	if len(t.StateTransitions) == 0 {
-		return NIL
+		return TASK_NIL
 	}
 	return t.StateTransitions[len(t.StateTransitions)-1].State
 }

--- a/historyserver/pkg/historyserver/cluster_status.go
+++ b/historyserver/pkg/historyserver/cluster_status.go
@@ -287,19 +287,19 @@ func (b *ClusterStatusBuilder) mergeDemands(demandMap map[string]*ResourceDemand
 //	+--------------------------------------------+---------------------+----------------------+-------------------------+
 func isPendingTaskState(state types.TaskStatus) bool {
 	switch state {
-	case types.PENDING_ARGS_AVAIL,
-		types.PENDING_NODE_ASSIGNMENT,
-		types.PENDING_OBJ_STORE_MEM_AVAIL,
-		types.PENDING_ARGS_FETCH:
+	case types.TASK_PENDING_ARGS_AVAIL,
+		types.TASK_PENDING_NODE_ASSIGNMENT,
+		types.TASK_PENDING_OBJ_STORE_MEM_AVAIL,
+		types.TASK_PENDING_ARGS_FETCH:
 		return true
 	default:
 		return false
 	}
 }
 
-func isPendingActorState(state types.StateType) bool {
+func isPendingActorState(state types.ActorState) bool {
 	switch state {
-	case types.PENDING_CREATION, types.DEPENDENCIES_UNREADY:
+	case types.ACTOR_PENDING_CREATION, types.ACTOR_DEPENDENCIES_UNREADY:
 		return true
 	default:
 		return false

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -884,11 +884,11 @@ func formatJobForResponse(job eventtypes.Job) map[string]interface{} {
 		}
 	}
 	if status == "" {
-		// Only infer RUNNING from CREATED state. JOBFINISHED does not imply SUCCEEDED
+		// Only infer RUNNING from CREATED state. JOB_FINISHED does not imply SUCCEEDED
 		// (the driver may have crashed or been stopped), so we leave it empty rather
 		// than showing a misleading status.
-		if job.State == eventtypes.CREATED {
-			status = string(eventtypes.JOBRUNNING)
+		if job.State == eventtypes.JOB_CREATED {
+			status = string(eventtypes.JOB_RUNNING)
 		}
 	}
 

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -549,7 +549,7 @@ func richSnapshot(clusterSessionKey string) *eventserver.SessionSnapshot {
 				TaskID: "task-e2e-1111", TaskAttempt: 0, JobID: "job-e2e-aaaa",
 				TaskName: "task-e2e-name", RequiredResources: map[string]float64{"CPU": 2},
 				// Set derived lifecycle fields so the round-trip test proves they survive encoding/decoding.
-				State:        eventtypes.RUNNING,
+				State:        eventtypes.TASK_RUNNING,
 				CreationTime: time.Unix(1770635700, 0).UTC(),
 				StartTime:    time.Unix(1770635705, 0).UTC(),
 				EndTime:      time.Unix(1770635710, 0).UTC(),
@@ -557,7 +557,7 @@ func richSnapshot(clusterSessionKey string) *eventserver.SessionSnapshot {
 			{TaskID: "task-e2e-2222", TaskAttempt: 1, JobID: "job-e2e-aaaa"},
 		},
 		Actors: map[string]eventtypes.Actor{
-			"actor-e2e-cafe": {ActorID: "actor-e2e-cafe", JobID: "job-e2e-aaaa", ActorClass: "MyActor", Name: "actorname-e2e", NumRestarts: 3, State: eventtypes.ALIVE},
+			"actor-e2e-cafe": {ActorID: "actor-e2e-cafe", JobID: "job-e2e-aaaa", ActorClass: "MyActor", Name: "actorname-e2e", NumRestarts: 3, State: eventtypes.ACTOR_ALIVE},
 		},
 		Jobs: map[string]eventtypes.Job{
 			"job-e2e-aaaa": {JobID: "job-e2e-aaaa", SubmissionID: "sub-e2e-bbbb", JobType: "SUBMISSION", EntryPoint: "python main.py", RuntimeEnv: map[string]string{"pip": "ray"}},


### PR DESCRIPTION
… package-level name conflicts

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently,Ray entity status constants such as task, actor, job, node live in the same Go package, so they cannot share identifiers such as `RUNNING` or `ALIVE`. Task and actor took the unprefixed names first, and job/node then used inconsistent naming (`JOBRUNNING` vs `NODE_ALIVE`). So, I make sure every entity a consistent `ENTITY_` prefix (e.g. `TASK_RUNNING`, `ACTOR_ALIVE`, `JOB_RUNNING`)

## Related issue number

Closes #5237 

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
