### PR TITLE
[Test][History Server] Fix Build historyserver flaky unit test: TestShutdown_DrainsRetriedTasks

### DIFF
--- a/historyserver/pkg/collector/eventcollector/eventcollector_test.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector_test.go
@@ -591,9 +591,6 @@ func TestShutdown_DrainsRetriedTasks(t *testing.T) {
 	// First upload attempt fails, scheduling a backoff retry.
 	writer.failNext = true
 
-	ec.consumerWG.Add(1)
-	go ec.compressionUploadWorker()
-
 	task := rotationTask{
 		path:        jsonlPath,
 		category:    categoryNodeEvents,
@@ -602,12 +599,18 @@ func TestShutdown_DrainsRetriedTasks(t *testing.T) {
 		createdAt:   time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
 		size:        int64(len(payload)),
 	}
-	ec.rotationQueue <- task
 
-	// Wait until the worker has consumed the injected failure, so the retry
-	// goroutine exists before shutdown begins.
-	require.Eventually(t, func() bool { return !writer.failPending() },
-		2*time.Second, 10*time.Millisecond)
+	// Drive the first attempt synchronously so retryProcess has registered
+	// the backoff goroutine on consumerWG before shutdown begins.
+	// failPending() flips false inside WriteFile, before that registration.
+	ec.processRotatedFile(task)
+	require.False(t, writer.failPending(), "first attempt should consume the injected failure")
+	require.Empty(t, writer.fileKeys(), "first attempt must not have uploaded")
+
+	// Start the worker so shutdown can close the queue and wait for the
+	// consumer, matching the production pipeline.
+	ec.consumerWG.Add(1)
+	go ec.compressionUploadWorker()
 
 	// Run's real shutdown sequence. Closing stopProducers cuts the retry's
 	// backoff short and triggers its final attempt.

--- a/historyserver/pkg/collector/eventcollector/eventcollector_test.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector_test.go
@@ -600,17 +600,12 @@ func TestShutdown_DrainsRetriedTasks(t *testing.T) {
 		size:        int64(len(payload)),
 	}
 
-	// Drive the first attempt synchronously so retryProcess has registered
-	// the backoff goroutine on consumerWG before shutdown begins.
-	// failPending() flips false inside WriteFile, before that registration.
+	// When this returns, retryProcess has already registered the backoff goroutine
+	// on consumerWG, so shutdown below will wake it for a final attempt.
 	ec.processRotatedFile(task)
+	// Check that the injected failure was hit and nothing was uploaded.
 	require.False(t, writer.failPending(), "first attempt should consume the injected failure")
 	require.Empty(t, writer.fileKeys(), "first attempt must not have uploaded")
-
-	// Start the worker so shutdown can close the queue and wait for the
-	// consumer, matching the production pipeline.
-	ec.consumerWG.Add(1)
-	go ec.compressionUploadWorker()
 
 	// Run's real shutdown sequence. Closing stopProducers cuts the retry's
 	// backoff short and triggers its final attempt.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After checking the log, I found that `TestShutdown_DrainsRetriedTasks` was flaky in the Build historyserver job. Before the fix, the test waited on `!writer.failPending()` before calling `shutdown()`. That flag becomes false inside the failed `WriteFile`, before `retryProcess` registers the backoff goroutine on `consumerWG`. If `shutdown()` closes `stopProducers` in that window, `retryProcess` logs `Giving up on retrying ... during shutdown and never uploaded`.
So I suggested driving the first failed attempt synchronously via `processRotatedFile`, ensuring the retry is registered with `consumerWG` before `shutdown()` is called. The test then starts the upload worker and runs the real shutdown path: closing `stopProducers` cuts the backoff short, and `consumerWG` waits for the final attempt. there is no longer a window where shutdown() can race with retry registration.

## Related issue number
Closes #5243
<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

I reproduced the CI failure locally by inserting a 50ms sleep between the failed `WriteFile` and `retryProcess` in `historyserver/pkg/collector/eventcollector/eventcollector.go`, which widens the same race. From `historyserver/`, I ran:
`go test -race -count=20 ./pkg/collector/eventcollector/ -run TestShutdown_DrainsRetriedTasks -v`
The original test then failed consistently (20/20 runs) with `Giving up on retrying ... during shutdown` and `retried task never uploaded`, matching the CI failure log. 
After the fix, the same command with the same sleep passed consistently (20/20 runs) because the retry is already registered before `shutdown()`. 
