### PR TITLE
[CI] [History Server] Build collector and history server images in CI

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -339,6 +339,13 @@ jobs:
         run: make test
         working-directory: ${{env.working-directory}}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+
+      - name: Build Docker Images - Historyserver and Collector
+        run: make localimage-build
+        working-directory: ${{env.working-directory}}
+
       - name: Log in to Quay.io
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We need to add a build docker image CI pipeline for historyserver

## Related issue number

Part of #4813 (task 1 - build and verify Dockerfiles in CI). Task 2 (`golangci-lint` for `historyserver`) is handled in #5247.

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Ran the exact command the new CI step runs, and both images build successfully:

```bash
cd historyserver
make localimage-build
```