### PR TITLE
[Feature][Volcano] Populate SubGroupPolicy from Ray worker replicas

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -216,8 +216,9 @@ func (v *VolcanoBatchScheduler) calculatePodGroupParams(rayClusterSpec *rayv1.Ra
 // calculateSubGroupPolicy maps every required logical Ray replica to a Volcano subgroup.
 // A subgroup contains NumOfHosts Pods, and MinSubGroups follows the same autoscaling or
 // effective desired replica semantics used to calculate the PodGroup's global MinMember.
+// Pre-v1.14 Volcano CRDs prune this field and retain the legacy global PodGroup settings.
 func calculateSubGroupPolicy(owner metav1.Object, rayClusterSpec *rayv1.RayClusterSpec) []volcanoschedulingv1beta1.SubGroupPolicySpec {
-	if !features.Enabled(features.VolcanoSubGroupPolicy) || !features.Enabled(features.RayMultiHostIndexing) {
+	if !features.Enabled(features.RayMultiHostIndexing) {
 		return nil
 	}
 

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -61,13 +61,14 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(ctx context.Contex
 
 // handleRayCluster calculates the PodGroup MinMember and MinResources for a RayCluster
 func (v *VolcanoBatchScheduler) handleRayCluster(ctx context.Context, raycluster *rayv1.RayCluster) error {
-	// Check if this RayCluster is created by a RayJob, if so, skip PodGroup creation
+	// A RayCluster created by a RayJob does not own its PodGroup. The RayJob creates it
+	// from the same cluster template and updates it during the supported RayJob lifecycle.
 	if crdType, ok := raycluster.Labels[utils.RayOriginatedFromCRDLabelKey]; ok && crdType == utils.RayOriginatedFromCRDLabelValue(utils.RayJobCRD) {
 		return nil
 	}
 
 	minMember, totalResource := v.calculatePodGroupParams(&raycluster.Spec)
-	subGroupPolicy := calculateSubGroupPolicy(&raycluster.Spec)
+	subGroupPolicy := calculateSubGroupPolicy(raycluster, &raycluster.Spec)
 
 	_, err := v.syncPodGroup(ctx, raycluster, minMember, totalResource, subGroupPolicy)
 	return err
@@ -81,7 +82,7 @@ func (v *VolcanoBatchScheduler) handleRayJob(ctx context.Context, rayJob *rayv1.
 
 	var totalResourceList []corev1.ResourceList
 	minMember, totalResource := v.calculatePodGroupParams(rayJob.Spec.RayClusterSpec)
-	subGroupPolicy := calculateSubGroupPolicy(rayJob.Spec.RayClusterSpec)
+	subGroupPolicy := calculateSubGroupPolicy(rayJob, rayJob.Spec.RayClusterSpec)
 	totalResourceList = append(totalResourceList, totalResource)
 
 	// MinMember intentionally excludes the submitter pod to avoid a startup deadlock
@@ -215,8 +216,15 @@ func (v *VolcanoBatchScheduler) calculatePodGroupParams(rayClusterSpec *rayv1.Ra
 // calculateSubGroupPolicy maps every required logical Ray replica to a Volcano subgroup.
 // A subgroup contains NumOfHosts Pods, and MinSubGroups follows the same autoscaling or
 // effective desired replica semantics used to calculate the PodGroup's global MinMember.
-func calculateSubGroupPolicy(rayClusterSpec *rayv1.RayClusterSpec) []volcanoschedulingv1beta1.SubGroupPolicySpec {
-	if !features.Enabled(features.RayMultiHostIndexing) {
+func calculateSubGroupPolicy(owner metav1.Object, rayClusterSpec *rayv1.RayClusterSpec) []volcanoschedulingv1beta1.SubGroupPolicySpec {
+	if !features.Enabled(features.VolcanoSubGroupPolicy) || !features.Enabled(features.RayMultiHostIndexing) {
+		return nil
+	}
+
+	// The existing top-level topology labels apply topology constraints to the entire PodGroup.
+	// Generating per-replica subgroups without copying that policy would change those semantics.
+	// Keep the existing behavior until per-worker-group topology configuration is defined.
+	if _, topologyConfigured := owner.GetLabels()[NetworkTopologyModeLabelKey]; topologyConfigured {
 		return nil
 	}
 
@@ -251,7 +259,7 @@ func calculateSubGroupPolicy(rayClusterSpec *rayv1.RayClusterSpec) []volcanosche
 		} else {
 			minSubGroups = utils.GetWorkerGroupDesiredReplicas(workerGroupSpec) / numOfHosts
 		}
-		if minSubGroups < 1 {
+		if minSubGroups < 0 {
 			continue
 		}
 
@@ -387,7 +395,7 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		clusterMinMembers, clusterMinResources := v.calculatePodGroupParams(&cluster.Spec)
 		minMembers = clusterMinMembers
 		totalResourceList = append(totalResourceList, clusterMinResources)
-		subGroupPolicy = calculateSubGroupPolicy(&cluster.Spec)
+		subGroupPolicy = calculateSubGroupPolicy(rayJob, &cluster.Spec)
 	}
 
 	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMembers, utils.SumResourceList(totalResourceList), subGroupPolicy)

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +15,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +26,7 @@ import (
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 const (
@@ -64,8 +67,9 @@ func (v *VolcanoBatchScheduler) handleRayCluster(ctx context.Context, raycluster
 	}
 
 	minMember, totalResource := v.calculatePodGroupParams(&raycluster.Spec)
+	subGroupPolicy := calculateSubGroupPolicy(&raycluster.Spec)
 
-	_, err := v.syncPodGroup(ctx, raycluster, minMember, totalResource)
+	_, err := v.syncPodGroup(ctx, raycluster, minMember, totalResource, subGroupPolicy)
 	return err
 }
 
@@ -77,6 +81,7 @@ func (v *VolcanoBatchScheduler) handleRayJob(ctx context.Context, rayJob *rayv1.
 
 	var totalResourceList []corev1.ResourceList
 	minMember, totalResource := v.calculatePodGroupParams(rayJob.Spec.RayClusterSpec)
+	subGroupPolicy := calculateSubGroupPolicy(rayJob.Spec.RayClusterSpec)
 	totalResourceList = append(totalResourceList, totalResource)
 
 	// MinMember intentionally excludes the submitter pod to avoid a startup deadlock
@@ -84,7 +89,7 @@ func (v *VolcanoBatchScheduler) handleRayJob(ctx context.Context, rayJob *rayv1.
 	// submitter's resource requests into MinResources so capacity is reserved.
 	submitterResource := getSubmitterResource(rayJob)
 	totalResourceList = append(totalResourceList, submitterResource)
-	_, err := v.syncPodGroup(ctx, rayJob, minMember, utils.SumResourceList(totalResourceList))
+	_, err := v.syncPodGroup(ctx, rayJob, minMember, utils.SumResourceList(totalResourceList), subGroupPolicy)
 	return err
 }
 
@@ -150,9 +155,9 @@ func populateLabelsFromObject(parent metav1.Object, child metav1.Object, key str
 }
 
 // syncPodGroup ensures a Volcano PodGroup exists/updated for the given object
-// with the provided size (MinMember) and total resources.
+// with the provided size (MinMember), total resources, and subgroup policy.
 // It returns true if the PodGroup was created or updated, false if no changes were needed.
-func (v *VolcanoBatchScheduler) syncPodGroup(ctx context.Context, owner metav1.Object, size int32, totalResource corev1.ResourceList) (createdOrUpdated bool, err error) {
+func (v *VolcanoBatchScheduler) syncPodGroup(ctx context.Context, owner metav1.Object, size int32, totalResource corev1.ResourceList, subGroupPolicy []volcanoschedulingv1beta1.SubGroupPolicySpec) (createdOrUpdated bool, err error) {
 	logger := ctrl.LoggerFrom(ctx).WithName(pluginName)
 
 	createdOrUpdated = false
@@ -164,7 +169,7 @@ func (v *VolcanoBatchScheduler) syncPodGroup(ctx context.Context, owner metav1.O
 			return
 		}
 
-		podGroup, err = createPodGroup(owner, podGroupName, size, totalResource)
+		podGroup, err = createPodGroup(owner, podGroupName, size, totalResource, subGroupPolicy)
 		if err != nil {
 			logger.Error(err, "Failed to create pod group specification", "PodGroup.Error", err)
 			return
@@ -183,9 +188,10 @@ func (v *VolcanoBatchScheduler) syncPodGroup(ctx context.Context, owner metav1.O
 		return
 	}
 
-	if podGroup.Spec.MinMember != size || podGroup.Spec.MinResources == nil || !quotav1.Equals(*podGroup.Spec.MinResources, totalResource) {
+	if podGroup.Spec.MinMember != size || podGroup.Spec.MinResources == nil || !quotav1.Equals(*podGroup.Spec.MinResources, totalResource) || !apiequality.Semantic.DeepEqual(podGroup.Spec.SubGroupPolicy, subGroupPolicy) {
 		podGroup.Spec.MinMember = size
 		podGroup.Spec.MinResources = &totalResource
+		podGroup.Spec.SubGroupPolicy = subGroupPolicy
 		if err = v.cli.Update(ctx, &podGroup); err != nil {
 			logger.Error(err, "failed to update PodGroup", "name", podGroupName, "ownerKind", utils.GetCRDType(owner.GetLabels()[utils.RayOriginatedFromCRDLabelKey]), "ownerName", owner.GetName(), "ownerNamespace", owner.GetNamespace())
 			return
@@ -206,7 +212,71 @@ func (v *VolcanoBatchScheduler) calculatePodGroupParams(rayClusterSpec *rayv1.Ra
 	return utils.CalculateMinReplicas(rayCluster) + 1, utils.CalculateMinResources(rayCluster)
 }
 
-func createPodGroup(owner metav1.Object, podGroupName string, size int32, totalResource corev1.ResourceList) (volcanoschedulingv1beta1.PodGroup, error) {
+// calculateSubGroupPolicy maps every required logical Ray replica to a Volcano subgroup.
+// A subgroup contains NumOfHosts Pods, and MinSubGroups follows the same autoscaling or
+// effective desired replica semantics used to calculate the PodGroup's global MinMember.
+func calculateSubGroupPolicy(rayClusterSpec *rayv1.RayClusterSpec) []volcanoschedulingv1beta1.SubGroupPolicySpec {
+	if !features.Enabled(features.RayMultiHostIndexing) {
+		return nil
+	}
+
+	subGroupPolicy := []volcanoschedulingv1beta1.SubGroupPolicySpec{
+		{
+			Name:         utils.RayNodeHeadGroupLabelValue,
+			SubGroupSize: ptr.To[int32](1),
+			MinSubGroups: ptr.To[int32](1),
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue,
+				},
+			},
+			MatchLabelKeys: []string{utils.RayNodeGroupLabelKey},
+		},
+	}
+
+	autoscalingEnabled := utils.IsAutoscalingEnabled(rayClusterSpec)
+	for _, workerGroupSpec := range rayClusterSpec.WorkerGroupSpecs {
+		if workerGroupSpec.Suspend != nil && *workerGroupSpec.Suspend {
+			continue
+		}
+
+		numOfHosts := workerGroupSpec.NumOfHosts
+		if numOfHosts < 1 {
+			continue
+		}
+
+		var minSubGroups int32
+		if autoscalingEnabled {
+			minSubGroups = ptr.Deref(workerGroupSpec.MinReplicas, int32(0))
+		} else {
+			minSubGroups = utils.GetWorkerGroupDesiredReplicas(workerGroupSpec) / numOfHosts
+		}
+		if minSubGroups < 1 {
+			continue
+		}
+
+		matchLabelKey := utils.RayWorkerReplicaIndexKey
+		if numOfHosts > 1 {
+			matchLabelKey = utils.RayWorkerReplicaNameKey
+		}
+
+		subGroupPolicy = append(subGroupPolicy, volcanoschedulingv1beta1.SubGroupPolicySpec{
+			Name:         workerGroupSpec.GroupName,
+			SubGroupSize: new(numOfHosts),
+			MinSubGroups: new(minSubGroups),
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					utils.RayNodeGroupLabelKey: workerGroupSpec.GroupName,
+				},
+			},
+			MatchLabelKeys: []string{matchLabelKey},
+		})
+	}
+
+	return subGroupPolicy
+}
+
+func createPodGroup(owner metav1.Object, podGroupName string, size int32, totalResource corev1.ResourceList, subGroupPolicy []volcanoschedulingv1beta1.SubGroupPolicySpec) (volcanoschedulingv1beta1.PodGroup, error) {
 	var ownerRef metav1.OwnerReference
 	switch obj := owner.(type) {
 	case *rayv1.RayCluster:
@@ -226,8 +296,9 @@ func createPodGroup(owner metav1.Object, podGroupName string, size int32, totalR
 			Annotations:     annotations,
 		},
 		Spec: volcanoschedulingv1beta1.PodGroupSpec{
-			MinMember:    size,
-			MinResources: &totalResource,
+			MinMember:      size,
+			MinResources:   &totalResource,
+			SubGroupPolicy: subGroupPolicy,
 		},
 		Status: volcanoschedulingv1beta1.PodGroupStatus{
 			Phase: volcanoschedulingv1beta1.PodGroupPending,
@@ -294,6 +365,7 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 
 	var minMembers int32
 	var totalResourceList []corev1.ResourceList
+	var subGroupPolicy []volcanoschedulingv1beta1.SubGroupPolicySpec
 
 	if len(rayJob.Status.RayClusterName) == 0 {
 		// The RayClusterName has not been assigned so that there is no PodGroup to update.
@@ -315,9 +387,10 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		clusterMinMembers, clusterMinResources := v.calculatePodGroupParams(&cluster.Spec)
 		minMembers = clusterMinMembers
 		totalResourceList = append(totalResourceList, clusterMinResources)
+		subGroupPolicy = calculateSubGroupPolicy(&cluster.Spec)
 	}
 
-	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMembers, utils.SumResourceList(totalResourceList))
+	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMembers, utils.SumResourceList(totalResourceList), subGroupPolicy)
 	if err != nil {
 		return false, err
 	}

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -159,13 +159,14 @@ func createTestRayJob(numOfHosts int32) rayv1.RayJob {
 }
 
 func TestCreatePodGroupForRayCluster(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 
 	cluster := createTestRayCluster(1)
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -190,13 +191,14 @@ func TestCreatePodGroupForRayCluster(t *testing.T) {
 }
 
 func TestCreatePodGroupForRayCluster_NumOfHosts2(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 
 	cluster := createTestRayCluster(2)
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -244,7 +246,7 @@ func TestCreatePodGroup_NetworkTopologyBothLabels(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -263,7 +265,7 @@ func TestCreatePodGroup_NetworkTopologyOnlyModeLabel(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -283,7 +285,7 @@ func TestCreatePodGroup_NetworkTopologyHighestTierAllowedNotInt(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 
 	require.Error(t, err)
 	a.Contains(err.Error(), "failed to convert "+NetworkTopologyHighestTierAllowedLabelKey+" label to int")
@@ -291,6 +293,7 @@ func TestCreatePodGroup_NetworkTopologyHighestTierAllowedNotInt(t *testing.T) {
 }
 
 func TestCreatePodGroupForRayJob(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 	ctx := context.Background()
 
@@ -522,6 +525,8 @@ func TestCalculatePodGroupParams(t *testing.T) {
 }
 
 func TestCalculateSubGroupPolicy(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
+
 	t.Run("autoscaling uses each active worker group's minimum logical replicas", func(t *testing.T) {
 		cluster := createTestRayCluster(1)
 		cluster.Spec.EnableInTreeAutoscaling = new(true)
@@ -553,16 +558,16 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 				Replicas:    ptr.To[int32](2),
 				MinReplicas: ptr.To[int32](0),
 				MaxReplicas: ptr.To[int32](2),
-				NumOfHosts:  1,
+				NumOfHosts:  2,
 			},
 		}
 
-		policies := calculateSubGroupPolicy(&cluster.Spec)
+		policies := calculateSubGroupPolicy(&cluster, &cluster.Spec)
 		scheduler := &VolcanoBatchScheduler{}
 		minMember, _ := scheduler.calculatePodGroupParams(&cluster.Spec)
 
 		assert.Equal(t, int32(13), minMember)
-		require.Len(t, policies, 3)
+		require.Len(t, policies, 4)
 		assert.Equal(t, utils.RayNodeHeadGroupLabelValue, policies[0].Name)
 		assert.Equal(t, int32(1), ptr.Deref(policies[0].SubGroupSize, int32(0)))
 		assert.Equal(t, int32(1), ptr.Deref(policies[0].MinSubGroups, int32(0)))
@@ -580,6 +585,11 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 		assert.Equal(t, int32(4), ptr.Deref(policies[2].MinSubGroups, int32(0)))
 		assert.Equal(t, map[string]string{utils.RayNodeGroupLabelKey: "gpu-group"}, policies[2].LabelSelector.MatchLabels)
 		assert.Equal(t, []string{utils.RayWorkerReplicaNameKey}, policies[2].MatchLabelKeys)
+
+		assert.Equal(t, "zero-minimum-group", policies[3].Name)
+		assert.Equal(t, int32(2), ptr.Deref(policies[3].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(0), ptr.Deref(policies[3].MinSubGroups, int32(-1)))
+		assert.Equal(t, []string{utils.RayWorkerReplicaNameKey}, policies[3].MatchLabelKeys)
 	})
 
 	t.Run("non-autoscaling uses effective desired logical replicas", func(t *testing.T) {
@@ -601,7 +611,7 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 			},
 		}
 
-		policies := calculateSubGroupPolicy(&cluster.Spec)
+		policies := calculateSubGroupPolicy(&cluster, &cluster.Spec)
 
 		require.Len(t, policies, 3)
 		assert.Equal(t, "clamped-to-min", policies[1].Name)
@@ -612,15 +622,31 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 		assert.Equal(t, int32(8), ptr.Deref(policies[2].MinSubGroups, int32(0)))
 	})
 
-	t.Run("feature gate disabled omits subgroup policy", func(t *testing.T) {
+	t.Run("multi-host indexing feature gate disabled omits subgroup policy", func(t *testing.T) {
 		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
 		cluster := createTestRayCluster(2)
 
-		assert.Nil(t, calculateSubGroupPolicy(&cluster.Spec))
+		assert.Nil(t, calculateSubGroupPolicy(&cluster, &cluster.Spec))
+	})
+
+	t.Run("Volcano subgroup policy feature gate disabled omits subgroup policy", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, false)
+		cluster := createTestRayCluster(2)
+
+		assert.Nil(t, calculateSubGroupPolicy(&cluster, &cluster.Spec))
+	})
+
+	t.Run("top-level network topology preserves legacy behavior", func(t *testing.T) {
+		cluster := createTestRayClusterWithLabels(map[string]string{
+			NetworkTopologyModeLabelKey: "soft",
+		})
+
+		assert.Nil(t, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	})
 }
 
 func TestSyncPodGroup_SubGroupPolicy(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	ctx := context.Background()
 	cluster := createTestRayCluster(2)
 	cluster.Spec.WorkerGroupSpecs[0].GroupName = "gpu-group"
@@ -647,7 +673,7 @@ func TestSyncPodGroup_SubGroupPolicy(t *testing.T) {
 	assert.Equal(t, int32(2), ptr.Deref(podGroup.Spec.SubGroupPolicy[1].SubGroupSize, int32(0)))
 
 	minMember, totalResource := scheduler.calculatePodGroupParams(&cluster.Spec)
-	didUpdate, err := scheduler.syncPodGroup(ctx, &cluster, minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	didUpdate, err := scheduler.syncPodGroup(ctx, &cluster, minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 	assert.False(t, didUpdate)
 }
@@ -674,7 +700,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -692,7 +718,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec}) + 1
 		totalResource := utils.CalculateDesiredResources(&rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec})
-		pg, err := createPodGroup(&rayJob, getAppPodGroupName(&rayJob), minMember, totalResource, calculateSubGroupPolicy(rayJob.Spec.RayClusterSpec))
+		pg, err := createPodGroup(&rayJob, getAppPodGroupName(&rayJob), minMember, totalResource, calculateSubGroupPolicy(&rayJob, rayJob.Spec.RayClusterSpec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -707,7 +733,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -720,7 +746,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -729,6 +755,8 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 }
 
 func TestCleanupOnCompletion(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
+
 	t.Run("RayCluster - should be no-op", func(t *testing.T) {
 		a := assert.New(t)
 		require := require.New(t)

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -23,6 +23,30 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
+// legacyVolcanoClient simulates an API server using a pre-v1.14 Volcano CRD,
+// whose structural schema prunes the unknown spec.subGroupPolicy field.
+type legacyVolcanoClient struct {
+	client.Client
+}
+
+func (c *legacyVolcanoClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if podGroup, ok := obj.(*volcanoschedulingv1beta1.PodGroup); ok {
+		legacyPodGroup := podGroup.DeepCopy()
+		legacyPodGroup.Spec.SubGroupPolicy = nil
+		return c.Client.Create(ctx, legacyPodGroup, opts...)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *legacyVolcanoClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if podGroup, ok := obj.(*volcanoschedulingv1beta1.PodGroup); ok {
+		legacyPodGroup := podGroup.DeepCopy()
+		legacyPodGroup.Spec.SubGroupPolicy = nil
+		return c.Client.Update(ctx, legacyPodGroup, opts...)
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
 func createTestRayCluster(numOfHosts int32) rayv1.RayCluster {
 	headSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -159,7 +183,6 @@ func createTestRayJob(numOfHosts int32) rayv1.RayJob {
 }
 
 func TestCreatePodGroupForRayCluster(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 
 	cluster := createTestRayCluster(1)
@@ -191,7 +214,6 @@ func TestCreatePodGroupForRayCluster(t *testing.T) {
 }
 
 func TestCreatePodGroupForRayCluster_NumOfHosts2(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 
 	cluster := createTestRayCluster(2)
@@ -293,7 +315,6 @@ func TestCreatePodGroup_NetworkTopologyHighestTierAllowedNotInt(t *testing.T) {
 }
 
 func TestCreatePodGroupForRayJob(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	a := assert.New(t)
 	ctx := context.Background()
 
@@ -525,8 +546,6 @@ func TestCalculatePodGroupParams(t *testing.T) {
 }
 
 func TestCalculateSubGroupPolicy(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
-
 	t.Run("autoscaling uses each active worker group's minimum logical replicas", func(t *testing.T) {
 		cluster := createTestRayCluster(1)
 		cluster.Spec.EnableInTreeAutoscaling = new(true)
@@ -629,13 +648,6 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 		assert.Nil(t, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	})
 
-	t.Run("Volcano subgroup policy feature gate disabled omits subgroup policy", func(t *testing.T) {
-		features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, false)
-		cluster := createTestRayCluster(2)
-
-		assert.Nil(t, calculateSubGroupPolicy(&cluster, &cluster.Spec))
-	})
-
 	t.Run("top-level network topology preserves legacy behavior", func(t *testing.T) {
 		cluster := createTestRayClusterWithLabels(map[string]string{
 			NetworkTopologyModeLabelKey: "soft",
@@ -646,7 +658,6 @@ func TestCalculateSubGroupPolicy(t *testing.T) {
 }
 
 func TestSyncPodGroup_SubGroupPolicy(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
 	ctx := context.Background()
 	cluster := createTestRayCluster(2)
 	cluster.Spec.WorkerGroupSpecs[0].GroupName = "gpu-group"
@@ -676,6 +687,37 @@ func TestSyncPodGroup_SubGroupPolicy(t *testing.T) {
 	didUpdate, err := scheduler.syncPodGroup(ctx, &cluster, minMember, totalResource, calculateSubGroupPolicy(&cluster, &cluster.Spec))
 	require.NoError(t, err)
 	assert.False(t, didUpdate)
+}
+
+func TestSyncPodGroup_OlderVolcanoCRDPrunesSubGroupPolicy(t *testing.T) {
+	ctx := context.Background()
+	cluster := createTestRayCluster(2)
+	cluster.Spec.WorkerGroupSpecs[0].GroupName = "gpu-group"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(scheme))
+	require.NoError(t, volcanoschedulingv1beta1.AddToScheme(scheme))
+	fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	scheduler := &VolcanoBatchScheduler{cli: &legacyVolcanoClient{Client: fakeCli}}
+
+	// A pre-v1.14 CRD drops SubGroupPolicy but still accepts the PodGroup and
+	// preserves the existing global gang-scheduling fields.
+	require.NoError(t, scheduler.handleRayCluster(ctx, &cluster))
+
+	podGroup := &volcanoschedulingv1beta1.PodGroup{}
+	podGroupKey := client.ObjectKey{Namespace: cluster.Namespace, Name: getAppPodGroupName(&cluster)}
+	require.NoError(t, fakeCli.Get(ctx, podGroupKey, podGroup))
+	assert.Empty(t, podGroup.Spec.SubGroupPolicy)
+	assert.Equal(t, int32(5), podGroup.Spec.MinMember)
+	assert.Equal(t, "1280m", podGroup.Spec.MinResources.Cpu().String())
+
+	// Updates also continue to synchronize the legacy fields without failing.
+	cluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](3)
+	require.NoError(t, scheduler.handleRayCluster(ctx, &cluster))
+	require.NoError(t, fakeCli.Get(ctx, podGroupKey, podGroup))
+	assert.Empty(t, podGroup.Spec.SubGroupPolicy)
+	assert.Equal(t, int32(7), podGroup.Spec.MinMember)
+	assert.Equal(t, "1792m", podGroup.Spec.MinResources.Cpu().String())
 }
 
 func TestGetAppPodGroupName(t *testing.T) {
@@ -755,8 +797,6 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 }
 
 func TestCleanupOnCompletion(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.VolcanoSubGroupPolicy, true)
-
 	t.Run("RayCluster - should be no-op", func(t *testing.T) {
 		a := assert.New(t)
 		require := require.New(t)

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -20,6 +20,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 func createTestRayCluster(numOfHosts int32) rayv1.RayCluster {
@@ -73,6 +74,7 @@ func createTestRayCluster(numOfHosts int32) rayv1.RayCluster {
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
+					GroupName: "small-group",
 					Template: corev1.PodTemplateSpec{
 						Spec: workerSpec,
 					},
@@ -141,6 +143,7 @@ func createTestRayJob(numOfHosts int32) rayv1.RayJob {
 				},
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
+						GroupName: "small-group",
 						Template: corev1.PodTemplateSpec{
 							Spec: workerSpec,
 						},
@@ -162,7 +165,7 @@ func TestCreatePodGroupForRayCluster(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -178,6 +181,12 @@ func TestCreatePodGroupForRayCluster(t *testing.T) {
 
 	// 2 GPUs total
 	a.Equal("2", pg.Spec.MinResources.Name("nvidia.com/gpu", resource.BinarySI).String())
+
+	require.Len(t, pg.Spec.SubGroupPolicy, 2)
+	a.Equal(utils.RayNodeHeadGroupLabelValue, pg.Spec.SubGroupPolicy[0].Name)
+	a.Equal("small-group", pg.Spec.SubGroupPolicy[1].Name)
+	a.Equal(int32(1), ptr.Deref(pg.Spec.SubGroupPolicy[1].SubGroupSize, int32(0)))
+	a.Equal(int32(2), ptr.Deref(pg.Spec.SubGroupPolicy[1].MinSubGroups, int32(0)))
 }
 
 func TestCreatePodGroupForRayCluster_NumOfHosts2(t *testing.T) {
@@ -187,7 +196,7 @@ func TestCreatePodGroupForRayCluster_NumOfHosts2(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -207,6 +216,12 @@ func TestCreatePodGroupForRayCluster_NumOfHosts2(t *testing.T) {
 	// 2 GPUs * 2 (num of hosts) total
 	// 2 GPUs * 2 = 4 GPUs
 	a.Equal("4", pg.Spec.MinResources.Name("nvidia.com/gpu", resource.BinarySI).String())
+
+	require.Len(t, pg.Spec.SubGroupPolicy, 2)
+	a.Equal("small-group", pg.Spec.SubGroupPolicy[1].Name)
+	a.Equal(int32(2), ptr.Deref(pg.Spec.SubGroupPolicy[1].SubGroupSize, int32(0)))
+	a.Equal(int32(2), ptr.Deref(pg.Spec.SubGroupPolicy[1].MinSubGroups, int32(0)))
+	a.Equal([]string{utils.RayWorkerReplicaNameKey}, pg.Spec.SubGroupPolicy[1].MatchLabelKeys)
 }
 
 func createTestRayClusterWithLabels(labels map[string]string) rayv1.RayCluster {
@@ -229,7 +244,7 @@ func TestCreatePodGroup_NetworkTopologyBothLabels(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -248,7 +263,7 @@ func TestCreatePodGroup_NetworkTopologyOnlyModeLabel(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 	require.NoError(t, err)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
@@ -268,7 +283,7 @@ func TestCreatePodGroup_NetworkTopologyHighestTierAllowedNotInt(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 
 	require.Error(t, err)
 	a.Contains(err.Error(), "failed to convert "+NetworkTopologyHighestTierAllowedLabelKey+" label to int")
@@ -306,6 +321,9 @@ func TestCreatePodGroupForRayJob(t *testing.T) {
 		a.Equal("test-priority", pg.Spec.PriorityClassName)
 		a.Len(pg.OwnerReferences, 1)
 		a.Equal("RayJob", pg.OwnerReferences[0].Kind)
+		require.Len(t, pg.Spec.SubGroupPolicy, 2)
+		a.Equal(utils.RayNodeHeadGroupLabelValue, pg.Spec.SubGroupPolicy[0].Name)
+		a.Equal("small-group", pg.Spec.SubGroupPolicy[1].Name)
 	})
 
 	t.Run("K8sJobMode includes submitter pod resources", func(_ *testing.T) {
@@ -503,6 +521,137 @@ func TestCalculatePodGroupParams(t *testing.T) {
 	})
 }
 
+func TestCalculateSubGroupPolicy(t *testing.T) {
+	t.Run("autoscaling uses each active worker group's minimum logical replicas", func(t *testing.T) {
+		cluster := createTestRayCluster(1)
+		cluster.Spec.EnableInTreeAutoscaling = new(true)
+		cluster.Spec.WorkerGroupSpecs = []rayv1.WorkerGroupSpec{
+			{
+				GroupName:   "cpu-group",
+				Replicas:    ptr.To[int32](10),
+				MinReplicas: ptr.To[int32](4),
+				MaxReplicas: ptr.To[int32](10),
+				NumOfHosts:  1,
+			},
+			{
+				GroupName:   "gpu-group",
+				Replicas:    ptr.To[int32](4),
+				MinReplicas: ptr.To[int32](4),
+				MaxReplicas: ptr.To[int32](4),
+				NumOfHosts:  2,
+			},
+			{
+				GroupName:   "suspended-group",
+				Replicas:    ptr.To[int32](2),
+				MinReplicas: ptr.To[int32](2),
+				MaxReplicas: ptr.To[int32](2),
+				NumOfHosts:  1,
+				Suspend:     new(true),
+			},
+			{
+				GroupName:   "zero-minimum-group",
+				Replicas:    ptr.To[int32](2),
+				MinReplicas: ptr.To[int32](0),
+				MaxReplicas: ptr.To[int32](2),
+				NumOfHosts:  1,
+			},
+		}
+
+		policies := calculateSubGroupPolicy(&cluster.Spec)
+		scheduler := &VolcanoBatchScheduler{}
+		minMember, _ := scheduler.calculatePodGroupParams(&cluster.Spec)
+
+		assert.Equal(t, int32(13), minMember)
+		require.Len(t, policies, 3)
+		assert.Equal(t, utils.RayNodeHeadGroupLabelValue, policies[0].Name)
+		assert.Equal(t, int32(1), ptr.Deref(policies[0].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(1), ptr.Deref(policies[0].MinSubGroups, int32(0)))
+		assert.Equal(t, map[string]string{utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue}, policies[0].LabelSelector.MatchLabels)
+		assert.Equal(t, []string{utils.RayNodeGroupLabelKey}, policies[0].MatchLabelKeys)
+
+		assert.Equal(t, "cpu-group", policies[1].Name)
+		assert.Equal(t, int32(1), ptr.Deref(policies[1].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(4), ptr.Deref(policies[1].MinSubGroups, int32(0)))
+		assert.Equal(t, map[string]string{utils.RayNodeGroupLabelKey: "cpu-group"}, policies[1].LabelSelector.MatchLabels)
+		assert.Equal(t, []string{utils.RayWorkerReplicaIndexKey}, policies[1].MatchLabelKeys)
+
+		assert.Equal(t, "gpu-group", policies[2].Name)
+		assert.Equal(t, int32(2), ptr.Deref(policies[2].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(4), ptr.Deref(policies[2].MinSubGroups, int32(0)))
+		assert.Equal(t, map[string]string{utils.RayNodeGroupLabelKey: "gpu-group"}, policies[2].LabelSelector.MatchLabels)
+		assert.Equal(t, []string{utils.RayWorkerReplicaNameKey}, policies[2].MatchLabelKeys)
+	})
+
+	t.Run("non-autoscaling uses effective desired logical replicas", func(t *testing.T) {
+		cluster := createTestRayCluster(1)
+		cluster.Spec.WorkerGroupSpecs = []rayv1.WorkerGroupSpec{
+			{
+				GroupName:   "clamped-to-min",
+				Replicas:    ptr.To[int32](1),
+				MinReplicas: ptr.To[int32](2),
+				MaxReplicas: ptr.To[int32](8),
+				NumOfHosts:  2,
+			},
+			{
+				GroupName:   "clamped-to-max",
+				Replicas:    ptr.To[int32](10),
+				MinReplicas: ptr.To[int32](2),
+				MaxReplicas: ptr.To[int32](8),
+				NumOfHosts:  1,
+			},
+		}
+
+		policies := calculateSubGroupPolicy(&cluster.Spec)
+
+		require.Len(t, policies, 3)
+		assert.Equal(t, "clamped-to-min", policies[1].Name)
+		assert.Equal(t, int32(2), ptr.Deref(policies[1].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(2), ptr.Deref(policies[1].MinSubGroups, int32(0)))
+		assert.Equal(t, "clamped-to-max", policies[2].Name)
+		assert.Equal(t, int32(1), ptr.Deref(policies[2].SubGroupSize, int32(0)))
+		assert.Equal(t, int32(8), ptr.Deref(policies[2].MinSubGroups, int32(0)))
+	})
+
+	t.Run("feature gate disabled omits subgroup policy", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
+		cluster := createTestRayCluster(2)
+
+		assert.Nil(t, calculateSubGroupPolicy(&cluster.Spec))
+	})
+}
+
+func TestSyncPodGroup_SubGroupPolicy(t *testing.T) {
+	ctx := context.Background()
+	cluster := createTestRayCluster(2)
+	cluster.Spec.WorkerGroupSpecs[0].GroupName = "gpu-group"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(scheme))
+	require.NoError(t, volcanoschedulingv1beta1.AddToScheme(scheme))
+	fakeCli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	scheduler := &VolcanoBatchScheduler{cli: fakeCli}
+
+	require.NoError(t, scheduler.handleRayCluster(ctx, &cluster))
+
+	podGroup := &volcanoschedulingv1beta1.PodGroup{}
+	podGroupKey := client.ObjectKey{Namespace: cluster.Namespace, Name: getAppPodGroupName(&cluster)}
+	require.NoError(t, fakeCli.Get(ctx, podGroupKey, podGroup))
+	require.Len(t, podGroup.Spec.SubGroupPolicy, 2)
+	assert.Equal(t, int32(2), ptr.Deref(podGroup.Spec.SubGroupPolicy[1].MinSubGroups, int32(0)))
+
+	cluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](3)
+	require.NoError(t, scheduler.handleRayCluster(ctx, &cluster))
+	require.NoError(t, fakeCli.Get(ctx, podGroupKey, podGroup))
+	require.Len(t, podGroup.Spec.SubGroupPolicy, 2)
+	assert.Equal(t, int32(3), ptr.Deref(podGroup.Spec.SubGroupPolicy[1].MinSubGroups, int32(0)))
+	assert.Equal(t, int32(2), ptr.Deref(podGroup.Spec.SubGroupPolicy[1].SubGroupSize, int32(0)))
+
+	minMember, totalResource := scheduler.calculatePodGroupParams(&cluster.Spec)
+	didUpdate, err := scheduler.syncPodGroup(ctx, &cluster, minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
+	require.NoError(t, err)
+	assert.False(t, didUpdate)
+}
+
 func TestGetAppPodGroupName(t *testing.T) {
 	a := assert.New(t)
 
@@ -525,7 +674,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -543,7 +692,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec}) + 1
 		totalResource := utils.CalculateDesiredResources(&rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec})
-		pg, err := createPodGroup(&rayJob, getAppPodGroupName(&rayJob), minMember, totalResource)
+		pg, err := createPodGroup(&rayJob, getAppPodGroupName(&rayJob), minMember, totalResource, calculateSubGroupPolicy(rayJob.Spec.RayClusterSpec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -558,7 +707,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -571,7 +720,7 @@ func TestCreatePodGroup_OwnerAnnotationsCopied(t *testing.T) {
 
 		minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 		totalResource := utils.CalculateDesiredResources(&cluster)
-		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+		pg, err := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource, calculateSubGroupPolicy(&cluster.Spec))
 		require.NoError(t, err)
 
 		a.NotNil(pg.Annotations)
@@ -740,6 +889,7 @@ func TestCleanupOnCompletion(t *testing.T) {
 		a.Equal(int32(0), retrievedPg.Spec.MinMember)
 		a.True(retrievedPg.Spec.MinResources.Cpu().IsZero())
 		a.True(retrievedPg.Spec.MinResources.Memory().IsZero())
+		a.Empty(retrievedPg.Spec.SubGroupPolicy)
 	})
 
 	t.Run("RayJob - RayCluster exists, recalculates PodGroup from live spec", func(t *testing.T) {
@@ -798,6 +948,9 @@ func TestCleanupOnCompletion(t *testing.T) {
 		a.Equal("768m", retrievedPg.Spec.MinResources.Cpu().String())
 		// 256Mi * 3 (requests, not limits)
 		a.Equal("768Mi", retrievedPg.Spec.MinResources.Memory().String())
+		require.Len(retrievedPg.Spec.SubGroupPolicy, 2)
+		a.Equal("small-group", retrievedPg.Spec.SubGroupPolicy[1].Name)
+		a.Equal(int32(2), ptr.Deref(retrievedPg.Spec.SubGroupPolicy[1].MinSubGroups, int32(0)))
 	})
 
 	t.Run("RayJob - RayCluster exists, recalculates PodGroup with the submitter container", func(t *testing.T) {
@@ -927,6 +1080,8 @@ func TestCleanupOnCompletion(t *testing.T) {
 		a.Equal("256m", retrievedPg.Spec.MinResources.Cpu().String())
 		// 256Mi * 1 (requests, not limits)
 		a.Equal("256Mi", retrievedPg.Spec.MinResources.Memory().String())
+		require.Len(retrievedPg.Spec.SubGroupPolicy, 1)
+		a.Equal(utils.RayNodeHeadGroupLabelValue, retrievedPg.Spec.SubGroupPolicy[0].Name)
 	})
 
 	t.Run("RayJob - RayCluster being deleted, updates PodGroup with empty resources", func(t *testing.T) {

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -34,7 +34,7 @@ require (
 	sigs.k8s.io/scheduler-plugins v0.33.5
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2
 	sigs.k8s.io/yaml v1.6.0
-	volcano.sh/apis v1.13.0
+	volcano.sh/apis v1.15.2
 )
 
 require (

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -282,5 +282,5 @@ sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
-volcano.sh/apis v1.13.0 h1:MZKCBBxsgsT4eJXO1//MXq2KddBFLq9tZETTAt2YjMI=
-volcano.sh/apis v1.13.0/go.mod h1:kGpNdIPbPAN1e6DMFFbcYNLiYhJ8yD5apf0PpKjfs88=
+volcano.sh/apis v1.15.2 h1:L36cw3pRU+nqrrFoNuHMVJJ364bjzeTHiSrBZ1XTJBk=
+volcano.sh/apis v1.15.2/go.mod h1:rIDP5D1IR0Tq0uGIMCjMdTEDXMzyTMbwlXhxtMdxLls=

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -34,14 +34,6 @@ const (
 	// Enables multi-host worker indexing
 	RayMultiHostIndexing featuregate.Feature = "RayMultiHostIndexing"
 
-	// owner: @OneSizeFitsQuorum
-	// rep: https://github.com/ray-project/kuberay/issues/4656
-	// alpha: v1.7
-	//
-	// Enables automatic Volcano SubGroupPolicy generation from Ray worker replica semantics.
-	// Requires Volcano v1.15.2+ and RayMultiHostIndexing.
-	VolcanoSubGroupPolicy featuregate.Feature = "VolcanoSubGroupPolicy"
-
 	// owner: @ryanaoleary
 	// rep: https://github.com/ray-project/enhancements/pull/58
 	// alpha: v1.5
@@ -114,7 +106,6 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RayClusterStatusConditions:       {Default: true, PreRelease: featuregate.Beta},
 	RayJobDeletionPolicy:             {Default: true, PreRelease: featuregate.Beta},
 	RayMultiHostIndexing:             {Default: true, PreRelease: featuregate.Beta},
-	VolcanoSubGroupPolicy:            {Default: false, PreRelease: featuregate.Alpha},
 	RayServiceIncrementalUpgrade:     {Default: true, PreRelease: featuregate.Beta},
 	RayCronJob:                       {Default: false, PreRelease: featuregate.Alpha},
 	SidecarSubmitterRestart:          {Default: false, PreRelease: featuregate.Alpha},

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -34,6 +34,14 @@ const (
 	// Enables multi-host worker indexing
 	RayMultiHostIndexing featuregate.Feature = "RayMultiHostIndexing"
 
+	// owner: @OneSizeFitsQuorum
+	// rep: https://github.com/ray-project/kuberay/issues/4656
+	// alpha: v1.7
+	//
+	// Enables automatic Volcano SubGroupPolicy generation from Ray worker replica semantics.
+	// Requires Volcano v1.15.2+ and RayMultiHostIndexing.
+	VolcanoSubGroupPolicy featuregate.Feature = "VolcanoSubGroupPolicy"
+
 	// owner: @ryanaoleary
 	// rep: https://github.com/ray-project/enhancements/pull/58
 	// alpha: v1.5
@@ -106,6 +114,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RayClusterStatusConditions:       {Default: true, PreRelease: featuregate.Beta},
 	RayJobDeletionPolicy:             {Default: true, PreRelease: featuregate.Beta},
 	RayMultiHostIndexing:             {Default: true, PreRelease: featuregate.Beta},
+	VolcanoSubGroupPolicy:            {Default: false, PreRelease: featuregate.Alpha},
 	RayServiceIncrementalUpgrade:     {Default: true, PreRelease: featuregate.Beta},
 	RayCronJob:                       {Default: false, PreRelease: featuregate.Alpha},
 	SidecarSubmitterRestart:          {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
## Why are these changes needed?

A global Volcano `minMember` can be satisfied by surplus elastic CPU workers even when a GPU worker group is below its minimum. This PR populates `PodGroup.spec.subGroupPolicy` from existing Ray replica settings to express each worker group's minimum number of complete replicas, including multi-host replicas. No Ray API fields are added; `volcano.sh/apis` is updated to v1.15.2.

| Volcano field | Ray mapping |
| --- | --- |
| `name` / `labelSelector.matchLabels` | Worker group name / `ray.io/group: <groupName>` |
| `subGroupSize` | `numOfHosts` |
| `minSubGroups` | Autoscaling: `minReplicas`; otherwise: effective desired logical replicas |
| `matchLabelKeys` | Single-host: `ray.io/worker-group-replica-index`; multi-host: `ray.io/worker-group-replica-name` |

For example, `minReplicas: 2` and `numOfHosts: 2` require two complete two-Pod replicas, not merely four arbitrary Pods.

The head contributes one required single-Pod subgroup. Suspended worker groups and the RayJob submitter are excluded; active zero-minimum groups retain their policies. Policies synchronize alongside `minMember` and `minResources` for standalone RayClusters and follow the existing RayJob initialization and terminal-cleanup lifecycle.

### Requirements and compatibility

- Uses the existing, default-enabled `RayMultiHostIndexing` gate for replica identity labels; no new feature gate is added.
- Requires a supporting Volcano scheduler and CRD for subgroup guarantees. Volcano v1.14+ CRDs store this field; live scheduling was validated with v1.15.2 and gang plugin options `enabledSubJobReady`, `enabledSubJobPipelined`, and `enabledSubJobOrder` enabled.
- **Older CRDs prune the field and retain global gang behavior. Each reconciliation then sends a redundant PodGroup PUT.** Upgrade Volcano and its matching CRDs to use subgroup guarantees and avoid this overhead. We accept this overhead on older CRDs to avoid the long-term maintenance cost of capability detection, cached or persistent state, and upgrade invalidation/re-detection logic. Keeping this path stateless also allows policies to be persisted on the next reconciliation after a CRD upgrade without restarting KubeRay.
- Existing top-level Volcano network-topology configuration retains legacy behavior without generated subgroup policies. Per-group topology configuration is outside this PR.

## Related issue number

Related to #4656; topology work in #4843 is outside this PR.

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

Unit tests cover policy generation, synchronization, and legacy-CRD pruning; targeted tests, race checks, vet, and CI passed.

On KIND with Volcano v1.15.2, KubeRay-equivalent PodGroups/Pods with `minMember: 7`, one head, four CPU Pods, and three GPU Pods remained Pending: the GPU group required two complete two-host replicas. Adding the missing GPU host allowed all nine Pods to run. This validates the scheduler contract; KubeRay's generation path is tested separately.

Volcano v1.13.0 CRD checks confirmed pruning preserves global fields and an otherwise identical PUT leaves `resourceVersion` unchanged. Maintainer tests also verified legacy scheduling and policy adoption after a CRD upgrade ([results](https://github.com/ray-project/kuberay/pull/5249#issuecomment-5573613921)).
