### PR TITLE
[History Server][test] Add unit tests for state_transitions

### DIFF
--- a/historyserver/pkg/eventserver/state_transition_test.go
+++ b/historyserver/pkg/eventserver/state_transition_test.go
@@ -1,0 +1,54 @@
+package eventserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockT struct {
+	state     string
+	timestamp time.Time
+}
+
+func (m mockT) GetState() string        { return m.state }
+func (m mockT) GetTimestamp() time.Time { return m.timestamp }
+
+func TestMergeStateTransitions(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		existing []mockT
+		new      []mockT
+		expected []mockT
+	}{
+		{
+			name:     "merge_and_sort",
+			existing: []mockT{{state: "PENDING", timestamp: t1}, {state: "STOPPED", timestamp: t3}},
+			new:      []mockT{{state: "RUNNING", timestamp: t2}},
+			expected: []mockT{{state: "PENDING", timestamp: t1}, {state: "RUNNING", timestamp: t2}, {state: "STOPPED", timestamp: t3}},
+		},
+		{
+			name:     "deduplicate_identical_states",
+			existing: []mockT{{state: "PENDING", timestamp: t1}},
+			new:      []mockT{{state: "PENDING", timestamp: t1}, {state: "RUNNING", timestamp: t2}},
+			expected: []mockT{{state: "PENDING", timestamp: t1}, {state: "RUNNING", timestamp: t2}},
+		},
+		{
+			name:     "empty",
+			existing: []mockT{},
+			new:      []mockT{},
+			expected: []mockT{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, MergeStateTransitions(tc.existing, tc.new))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`pkg/eventserver/state_transition.go` previously had 0% test coverage. This PR adds table-driven unit tests verifying the
  merge, sort, and deduplication logic, bringing the file's coverage to 100%.

## Related issue number

Part of #5222 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

``` bash
go test ./pkg/eventserver/... -v
go test ./pkg/eventserver/... -coverprofile=coverage.out
go tool cover -func=coverage.out | grep state_transition
```