### PR TITLE
[Grafana] Update dashboards to Ray 2.58

### DIFF
--- a/config/grafana/data_grafana_dashboard.json
+++ b/config/grafana/data_grafana_dashboard.json
@@ -9517,9 +9517,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_initialize_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_initialize_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}, {{operator}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -9657,9 +9657,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_total_blocked_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_total_blocked_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -9797,9 +9797,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_user_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_user_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -9937,9 +9937,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_get_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_get_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10077,9 +10077,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_next_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_next_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10217,9 +10217,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_format_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_format_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10357,9 +10357,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_collate_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_collate_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10497,9 +10497,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_finalize_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_finalize_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10637,9 +10637,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_blocks_local{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_blocks_local{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Blocks: {{dataset}}",
+                            "legendFormat": "Blocks: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10777,9 +10777,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_blocks_remote{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_blocks_remote{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Blocks: {{dataset}}",
+                            "legendFormat": "Blocks: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -10917,9 +10917,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_unknown_location{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_unknown_location{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Blocks: {{dataset}}",
+                            "legendFormat": "Blocks: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -11057,9 +11057,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_prefetched_bytes{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_prefetched_bytes{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Prefetched Bytes: {{dataset}}",
+                            "legendFormat": "Prefetched Bytes: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -11197,9 +11197,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_time_to_first_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_time_to_first_batch_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -11337,9 +11337,9 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum(ray_data_iter_get_ref_bundles_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset)",
+                            "expr": "sum(ray_data_iter_get_ref_bundles_seconds{dataset=~\"$DatasetID\",SessionName=~\"$SessionName\",ray_io_cluster=~\"$Cluster\"}) by (dataset, split)",
                             "interval": "",
-                            "legendFormat": "Seconds: {{dataset}}",
+                            "legendFormat": "Seconds: {{dataset}}, {{split}}",
                             "queryType": "randomWalk",
                             "refId": "A"
                         }
@@ -12012,7 +12012,7 @@
     "schemaVersion": 27,
     "style": "dark",
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "templating": {
         "list": [
@@ -12138,7 +12138,7 @@
                 },
                 "datasource": "${datasource}",
                 "definition": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
-                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automaticaly with Prometheus PodMonitor.",
+                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
                 "error": null,
                 "hide": 0,
                 "includeAll": true,

--- a/config/grafana/data_llm_grafana_dashboard.json
+++ b/config/grafana/data_llm_grafana_dashboard.json
@@ -1911,7 +1911,7 @@
     "schemaVersion": 27,
     "style": "dark",
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "templating": {
         "list": [

--- a/config/grafana/default_grafana_dashboard.json
+++ b/config/grafana/default_grafana_dashboard.json
@@ -6114,7 +6114,7 @@
     "schemaVersion": 27,
     "style": "dark",
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "templating": {
         "list": [

--- a/config/grafana/serve_deployment_grafana_dashboard.json
+++ b/config/grafana/serve_deployment_grafana_dashboard.json
@@ -2147,7 +2147,7 @@
     "schemaVersion": 27,
     "style": "dark",
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "templating": {
         "list": [
@@ -2314,7 +2314,7 @@
                 },
                 "datasource": "${datasource}",
                 "definition": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
-                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automaticaly with Prometheus PodMonitor.",
+                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
                 "error": null,
                 "hide": 0,
                 "includeAll": true,

--- a/config/grafana/serve_llm_grafana_dashboard.json
+++ b/config/grafana/serve_llm_grafana_dashboard.json
@@ -121,7 +121,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", deployment=~\"$deployment\"}[$interval]))",
+                    "expr": "sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -129,7 +129,7 @@
                 },
                 {
                     "exemplar": true,
-                    "expr": "sum(rate(ray_serve_deployment_request_counter_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", deployment=~\"$deployment\"}[$interval]))",
+                    "expr": "sum(rate(ray_serve_deployment_request_counter_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
                     "legendFormat": "Total QPS",
                     "queryType": "randomWalk",
@@ -269,7 +269,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -277,7 +277,7 @@
                 },
                 {
                     "exemplar": true,
-                    "expr": "sum(rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))",
+                    "expr": "sum(rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
                     "legendFormat": "Total",
                     "queryType": "randomWalk",
@@ -417,7 +417,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_generation_tokens_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_generation_tokens_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -425,7 +425,7 @@
                 },
                 {
                     "exemplar": true,
-                    "expr": "sum(rate(ray_vllm_generation_tokens_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))",
+                    "expr": "sum(rate(ray_vllm_generation_tokens_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
                     "legendFormat": "Total",
                     "queryType": "randomWalk",
@@ -578,7 +578,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -718,7 +718,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -858,7 +858,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -998,7 +998,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1138,7 +1138,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1278,7 +1278,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1418,7 +1418,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1558,7 +1558,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1698,7 +1698,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1851,7 +1851,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (ray_vllm_kv_cache_usage_perc{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (ray_vllm_kv_cache_usage_perc{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -1991,7 +1991,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "100 * ((sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) / sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))) and on(WorkerId) (sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "100 * ((sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) / sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))) and on(WorkerId) (sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2144,7 +2144,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2284,7 +2284,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2424,7 +2424,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_prompt_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2564,7 +2564,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2704,7 +2704,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2844,7 +2844,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_request_generation_tokens_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -2997,7 +2997,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_running{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_running{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3137,7 +3137,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_swapped{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_swapped{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3277,7 +3277,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_waiting{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (ray_vllm_num_requests_waiting{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3417,7 +3417,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(finished_reason, WorkerId) (increase(ray_vllm_request_success_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(finished_reason, WorkerId) (increase(ray_vllm_request_success_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{finished_reason}} \u2014 {{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3557,7 +3557,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_queue_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_queue_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3697,7 +3697,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_prefill_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_prefill_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3837,7 +3837,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_decode_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_request_decode_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -3990,7 +3990,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    * 1000\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    * 1000\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4130,7 +4130,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_bytes_transferred_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    / 1024 / 1024 / 1024\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_bytes_transferred_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    / 1024 / 1024 / 1024\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4270,7 +4270,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4410,7 +4410,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n    * 1000\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_sum{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    * 1000\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_nixl_post_time_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4550,7 +4550,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (increase(ray_vllm_nixl_num_failed_transfers{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (increase(ray_vllm_nixl_num_failed_transfers{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4690,7 +4690,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum by(WorkerId) (increase(ray_vllm_nixl_num_kv_expired_reqs_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{ deployment=~\"$deployment\"} * 0 + 1)",
+                    "expr": "sum by(WorkerId) (increase(ray_vllm_nixl_num_kv_expired_reqs_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
                     "interval": "",
                     "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
@@ -4748,6 +4748,1312 @@
                 "x": 0,
                 "y": 102
             },
+            "id": 508,
+            "title": "KV Cache Offload / Reload",
+            "type": "row",
+            "panels": [
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "GPU-to-CPU KV data/s.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "GBs"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 0,
+                        "y": 103,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 52,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "(sum by(WorkerId) (rate(ray_vllm_kv_offload_store_bytes_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)) / 1024 / 1024 / 1024",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Store Throughput",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "GBs",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "CPU-to-GPU KV data/s.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "GBs"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 8,
+                        "y": 103,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 53,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "(sum by(WorkerId) (rate(ray_vllm_kv_offload_load_bytes_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)) / 1024 / 1024 / 1024",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Reload Throughput",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "GBs",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "KV store and reload operations/s.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "ops"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 16,
+                        "y": 103,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 54,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "sum by(WorkerId) (rate(ray_vllm_kv_offload_store_size_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "store \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        },
+                        {
+                            "exemplar": true,
+                            "expr": "sum by(WorkerId) (rate(ray_vllm_kv_offload_load_size_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "reload \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "B"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Store and Reload Operations/s",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "ops",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "GPU-to-CPU KV transfer bandwidth.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "GBs"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 0,
+                        "y": 111,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 55,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_store_bytes_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_store_time_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    / 1024 / 1024 / 1024\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_store_time_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Store Bandwidth",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "GBs",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "CPU-to-GPU KV transfer bandwidth.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "GBs"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 8,
+                        "y": 111,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 56,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "(\n  (\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_load_bytes_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_load_time_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    / 1024 / 1024 / 1024\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_load_time_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Reload Bandwidth",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "GBs",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "Share of the CPU KV pool pinned by in-flight transfers. Sustained values near 100% mean transfers may be dropped.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "percentunit"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 16,
+                        "y": 111,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 57,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "sum by(WorkerId) (ray_vllm_kv_offload_cpu_cache_usage_perc{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "total \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        },
+                        {
+                            "exemplar": true,
+                            "expr": "sum by(WorkerId) (ray_vllm_kv_offload_cpu_cache_write_usage_perc{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "stores \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "B"
+                        },
+                        {
+                            "exemplar": true,
+                            "expr": "sum by(WorkerId) (ray_vllm_kv_offload_cpu_cache_read_usage_perc{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"})\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "reloads \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "C"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: CPU Capacity Pinned by Transfers",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "percentunit",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "Connector prefix-cache hit rate.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "percent"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 0,
+                        "y": 119,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 58,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "100 * (\n  (\n    sum by(WorkerId) (rate(ray_vllm_external_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_external_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_external_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: External Prefix Hit Rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "percent",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "Prompt tokens served from either cache tier, GPU or offloaded.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "percent"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 8,
+                        "y": 119,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 60,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "100 * (\n  (\n    (\n      sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n      +\n      sum by(WorkerId) (rate(ray_vllm_external_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    )\n    /\n    sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "overall \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        },
+                        {
+                            "exemplar": true,
+                            "expr": "100 * (\n  (\n    sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "GPU only \u2014 {{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "B"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Overall Prefix Hit Rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "percent",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "${datasource}",
+                    "description": "P90 offloaded-prefix lookup latency.",
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "x": 16,
+                        "y": 119,
+                        "w": 8,
+                        "h": 8
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 59,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": true,
+                        "current": true,
+                        "hideEmpty": false,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": null,
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "7.5.17",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX",
+                            "dashes": true,
+                            "color": "#1F60C4",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "$$hashKey": "object:78",
+                            "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "$$hashKey": "object:2987",
+                            "alias": "MAX + PENDING",
+                            "dashes": true,
+                            "color": "#777777",
+                            "fill": 0,
+                            "stack": false
+                        },
+                        {
+                            "alias": "/Container/",
+                            "hiddenSeries": true
+                        },
+                        {
+                            "alias": "Container MAX",
+                            "dashes": true,
+                            "color": "#73BF69",
+                            "fill": 0,
+                            "stack": false,
+                            "hiddenSeries": true
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "exemplar": true,
+                            "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, WorkerId) (rate(ray_vllm_kv_offload_lookup_sync_delay_seconds_bucket{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(WorkerId)\n  (\n    sum by(WorkerId) (rate(ray_vllm_kv_offload_lookup_sync_delay_seconds_count{model_name=~\"$vllm_model_name\", WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)\n* on(WorkerId) group_left(deployment, replica)\nmax by(WorkerId, deployment, replica) (ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"} * 0 + 1)",
+                            "interval": "",
+                            "legendFormat": "{{deployment}}: {{replica}}",
+                            "queryType": "randomWalk",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "KV Offload: Lookup Delay -- P90",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "s",
+                            "label": "",
+                            "logBase": 1,
+                            "max": null,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:629",
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                }
+            ]
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 127
+            },
             "id": 507,
             "title": "Token Distribution",
             "type": "row",
@@ -4802,7 +6108,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1d])))",
+                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d])))",
                             "interval": "",
                             "legendFormat": "Input: {{model_name}}",
                             "queryType": "randomWalk",
@@ -4810,7 +6116,7 @@
                         },
                         {
                             "exemplar": true,
-                            "expr": "(sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1d])))",
+                            "expr": "(sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d])))",
                             "interval": "",
                             "legendFormat": "Generated: {{model_name}}",
                             "queryType": "randomWalk",
@@ -4899,7 +6205,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1h]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1h]))",
                             "interval": "",
                             "legendFormat": "Input: {{model_name}}",
                             "queryType": "randomWalk",
@@ -4907,7 +6213,7 @@
                         },
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1h]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1h]))",
                             "interval": "",
                             "legendFormat": "Generated: {{model_name}}",
                             "queryType": "randomWalk",
@@ -4996,7 +6302,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1d]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d]))",
                             "interval": "",
                             "legendFormat": "{{model_name}}",
                             "queryType": "randomWalk",
@@ -5069,7 +6375,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1d]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d]))",
                             "interval": "",
                             "legendFormat": "{{model_name}}",
                             "queryType": "randomWalk",
@@ -5157,7 +6463,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[2m]))[24h:1m])",
+                            "expr": "max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[2m]))[24h:1m])",
                             "interval": "",
                             "legendFormat": "{{model_name}}",
                             "queryType": "randomWalk",
@@ -5246,7 +6552,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1d]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1d]))",
                             "interval": "",
                             "legendFormat": "{{model_name}}",
                             "queryType": "randomWalk",
@@ -5325,7 +6631,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1w])) +\nsum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1w]))) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w])) +\nsum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "{{ model_name}}",
                             "queryType": "randomWalk",
@@ -5402,7 +6708,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "{{ model_name}}",
                             "queryType": "randomWalk",
@@ -5479,7 +6785,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "In: {{ model_name}}",
                             "queryType": "randomWalk",
@@ -5487,7 +6793,7 @@
                         },
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "Out: {{ model_name }}",
                             "queryType": "randomWalk",
@@ -5564,7 +6870,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1w])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1w])))/ sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w])))/ sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "{{ model_name}}",
                             "queryType": "randomWalk",
@@ -5641,7 +6947,7 @@
                     "targets": [
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\"}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_prompt_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "In: {{ model_name}}",
                             "queryType": "randomWalk",
@@ -5649,7 +6955,7 @@
                         },
                         {
                             "exemplar": true,
-                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\"}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\"}[1w]))",
+                            "expr": "sum by (model_name) (delta(ray_vllm_generation_tokens_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{WorkerId=~\"$workerid\", ray_io_cluster=~\"$Cluster\"}[1w]))",
                             "interval": "",
                             "legendFormat": "Out: {{ model_name}}",
                             "queryType": "randomWalk",
@@ -5693,7 +6999,7 @@
     "schemaVersion": 27,
     "style": "dark",
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "templating": {
         "list": [
@@ -5719,9 +7025,9 @@
                 "type": "query",
                 "hide": 0,
                 "datasource": "${datasource}",
-                "definition": "label_values(ray_vllm:request_prompt_tokens_sum{}, model_name)",
+                "definition": "label_values(ray_vllm_request_prompt_tokens_sum{}, model_name)",
                 "query": {
-                    "query": "label_values(ray_vllm:request_prompt_tokens_sum{}, model_name)",
+                    "query": "label_values(ray_vllm_request_prompt_tokens_sum{}, model_name)",
                     "refId": "StandardVariableQuery"
                 },
                 "refresh": 1,
@@ -5744,9 +7050,9 @@
                 "type": "query",
                 "hide": 0,
                 "datasource": "${datasource}",
-                "definition": "label_values(ray_vllm:request_prompt_tokens_sum{}, WorkerId)",
+                "definition": "label_values(ray_vllm_request_prompt_tokens_sum{}, WorkerId)",
                 "query": {
-                    "query": "label_values(ray_vllm:request_prompt_tokens_sum{}, WorkerId)",
+                    "query": "label_values(ray_vllm_request_prompt_tokens_sum{}, WorkerId)",
                     "refId": "StandardVariableQuery"
                 },
                 "refresh": 1,
@@ -5787,6 +7093,35 @@
                         "$__all"
                     ]
                 }
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": false
+                },
+                "datasource": "${datasource}",
+                "definition": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
+                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
+                "error": null,
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "Cluster",
+                "options": [],
+                "query": {
+                    "query": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 2,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             },
             {
                 "name": "interval",

--- a/config/grafana/serve_llm_sglang_grafana_dashboard.json
+++ b/config/grafana/serve_llm_sglang_grafana_dashboard.json
@@ -19,184 +19,17 @@
     "links": [],
     "panels": [
         {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Aggregated utilization of all physical resources (CPU, GPU, memory, disk, or etc.) across the cluster. Ignores application variable.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "%"
-                },
-                "overrides": []
-            },
+            "collapsed": false,
             "gridPos": {
+                "h": 1,
+                "w": 24,
                 "x": 0,
-                "y": 0,
-                "w": 12,
-                "h": 8
+                "y": 0
             },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 5,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "avg(ray_node_cpu_utilization{ray_io_cluster=~\"$Cluster\"})",
-                    "interval": "",
-                    "legendFormat": "CPU (physical)",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_node_gpus_utilization{ray_io_cluster=~\"$Cluster\"}) / on() (sum(autoscaler_cluster_resources{resource='GPU',ray_io_cluster=~\"$Cluster\"}) or vector(0))",
-                    "interval": "",
-                    "legendFormat": "GPU (physical)",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_node_mem_used{ray_io_cluster=~\"$Cluster\"}) / on() (sum(ray_node_mem_total{ray_io_cluster=~\"$Cluster\"})) * 100",
-                    "interval": "",
-                    "legendFormat": "Memory (RAM)",
-                    "queryType": "randomWalk",
-                    "refId": "C"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_node_gram_used{ray_io_cluster=~\"$Cluster\"}) / on() (sum(ray_node_gram_available{ray_io_cluster=~\"$Cluster\"}) + sum(ray_node_gram_used{ray_io_cluster=~\"$Cluster\"})) * 100",
-                    "interval": "",
-                    "legendFormat": "GRAM",
-                    "queryType": "randomWalk",
-                    "refId": "D"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_object_store_memory{ray_io_cluster=~\"$Cluster\"}) / on() sum(ray_resources{Name=\"object_store_memory\",ray_io_cluster=~\"$Cluster\"}) * 100",
-                    "interval": "",
-                    "legendFormat": "Object Store Memory",
-                    "queryType": "randomWalk",
-                    "refId": "E"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_node_disk_usage{ray_io_cluster=~\"$Cluster\"}) / on() (sum(ray_node_disk_free{ray_io_cluster=~\"$Cluster\"}) + sum(ray_node_disk_usage{ray_io_cluster=~\"$Cluster\"})) * 100",
-                    "interval": "",
-                    "legendFormat": "Disk",
-                    "queryType": "randomWalk",
-                    "refId": "F"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Cluster Utilization",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "%",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
+            "id": 601,
+            "title": "Throughput",
+            "type": "row",
+            "panels": []
         },
         {
             "aliasColors": {},
@@ -204,932 +37,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "QPS for each selected application.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "qps"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 12,
-                "y": 0,
-                "w": 12,
-                "h": 8
-            },
-            "fill": 10,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 7,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": true,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_http_requests_total{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route)",
-                    "interval": "",
-                    "legendFormat": "{{application, route}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_grpc_requests_total{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method)",
-                    "interval": "",
-                    "legendFormat": "{{application, method}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "QPS per application",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "qps",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Error QPS for each selected application.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "qps"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
                 "x": 0,
                 "y": 1,
-                "w": 12,
-                "h": 8
-            },
-            "fill": 10,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 8,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": true,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_http_error_requests_total{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route)",
-                    "interval": "",
-                    "legendFormat": "{{application, route}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_grpc_error_requests_total{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method)",
-                    "interval": "",
-                    "legendFormat": "{{application, method}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Error QPS per application",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "qps",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Error QPS for each selected application.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "qps"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 12,
-                "y": 1,
-                "w": 12,
-                "h": 8
-            },
-            "fill": 10,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 17,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": true,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_http_error_requests_total{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route, error_code)",
-                    "interval": "",
-                    "legendFormat": "{{application, route, error_code}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_num_grpc_error_requests_total{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method, error_code)",
-                    "interval": "",
-                    "legendFormat": "{{application, method, error_code}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Error QPS per application per error code",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "qps",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P50 latency for selected applications.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 0,
-                "y": 2,
                 "w": 8,
                 "h": 8
             },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 12,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.5, sum(rate(ray_serve_http_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, route}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.5, sum(rate(ray_serve_grpc_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, method}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.5, sum(rate({__name__=~ \"ray_serve_(http|grpc)_request_latency_ms_bucket\",application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "C"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P50 latency per application",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P90 latency for selected applications.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 8,
-                "y": 2,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 15,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.9, sum(rate(ray_serve_http_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, route}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.9, sum(rate(ray_serve_grpc_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, method}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.9, sum(rate({__name__=~ \"ray_serve_(http|grpc)_request_latency_ms_bucket|ray_serve_grpc_request_latency_ms_bucket\",application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "C"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P90 latency per application",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P99 latency for selected applications.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 16,
-                "y": 2,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 16,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.99, sum(rate(ray_serve_http_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",route=~\"$HTTP_Route\",route!~\"/-/.*\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, route, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, route}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.99, sum(rate(ray_serve_grpc_request_latency_ms_bucket{application=~\"$Application\",application!~\"\",method=~\"$gRPC_Method\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, method, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, method}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.99, sum(rate({__name__=~ \"ray_serve_(http|grpc)_request_latency_ms_bucket|ray_serve_grpc_request_latency_ms_bucket\",application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "C"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P99 latency per application",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Number of replicas per deployment. Ignores \"Application\" variable.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "replicas"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 0,
-                "y": 3,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 2,
@@ -1149,8 +70,8 @@
                 "values": true
             },
             "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
+            "linewidth": 2,
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -1195,23 +116,31 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(ray_serve_deployment_replica_healthy{ray_io_cluster=~\"$Cluster\"}) by (application, deployment)",
+                    "expr": "sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
-                    "legendFormat": "{{application, deployment}}",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_serve_deployment_request_counter_total{deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
+                    "interval": "",
+                    "legendFormat": "Total QPS",
+                    "queryType": "randomWalk",
+                    "refId": "B"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Replicas per deployment",
+            "title": "Requests / s",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -1228,7 +157,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "replicas",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -1256,744 +185,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "QPS for each deployment.",
+            "description": "Number of prefill tokens processed per second.",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "qps"
+                    "unit": "tokens/s"
                 },
                 "overrides": []
             },
             "gridPos": {
                 "x": 8,
-                "y": 3,
+                "y": 1,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 13,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": true,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_deployment_request_counter_total{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, deployment)",
-                    "interval": "",
-                    "legendFormat": "{{application, deployment}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "QPS per deployment",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "qps",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Error QPS for each deplyoment.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "qps"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 16,
-                "y": 3,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 10,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 14,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": true,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "sum(rate(ray_serve_deployment_error_counter_total{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, deployment)",
-                    "interval": "",
-                    "legendFormat": "{{application, deployment}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "Error QPS per deployment",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "qps",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P50 latency per deployment.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 0,
-                "y": 4,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 9,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.5, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, deployment, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, deployment}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.5, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P50 latency per deployment",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P90 latency per deployment.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 8,
-                "y": 4,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 10,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.9, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, deployment, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, deployment}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.9, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P90 latency per deployment",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "P99 latency per deployment.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "ms"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 16,
-                "y": 4,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "hiddenSeries": false,
-            "id": 11,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": null,
-            "options": {
-                "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.17",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX",
-                    "dashes": true,
-                    "color": "#1F60C4",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "$$hashKey": "object:78",
-                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
-                    "hiddenSeries": true
-                },
-                {
-                    "$$hashKey": "object:2987",
-                    "alias": "MAX + PENDING",
-                    "dashes": true,
-                    "color": "#777777",
-                    "fill": 0,
-                    "stack": false
-                },
-                {
-                    "alias": "/Container/",
-                    "hiddenSeries": true
-                },
-                {
-                    "alias": "Container MAX",
-                    "dashes": true,
-                    "color": "#73BF69",
-                    "fill": 0,
-                    "stack": false,
-                    "hiddenSeries": true
-                }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.99, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (application, deployment, le))",
-                    "interval": "",
-                    "legendFormat": "{{application, deployment}}",
-                    "queryType": "randomWalk",
-                    "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "histogram_quantile(0.99, sum(rate(ray_serve_deployment_processing_latency_ms_bucket{application=~\"$Application\",application!~\"\",ray_io_cluster=~\"$Cluster\"}[5m])) by (le))",
-                    "interval": "",
-                    "legendFormat": "Total",
-                    "queryType": "randomWalk",
-                    "refId": "B"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "P99 latency per deployment",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "$$hashKey": "object:628",
-                    "format": "ms",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": "0",
-                    "show": true
-                },
-                {
-                    "$$hashKey": "object:629",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "description": "Number of requests queued per deployment. Ignores \"Application\" variable.",
-            "fieldConfig": {
-                "defaults": {
-                    "unit": "requests"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "x": 0,
-                "y": 5,
-                "w": 8,
-                "h": 8
-            },
-            "fill": 0,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 3,
@@ -2013,7 +218,7 @@
                 "values": true
             },
             "lines": true,
-            "linewidth": 1,
+            "linewidth": 2,
             "nullPointMode": null,
             "options": {
                 "alertThreshold": true
@@ -2064,18 +269,26 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(ray_serve_deployment_queued_queries{ray_io_cluster=~\"$Cluster\"}) by (application, deployment)",
+                    "expr": "sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_total{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
-                    "legendFormat": "{{application, deployment}}",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_sglang_prompt_tokens_total{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
+                    "interval": "",
+                    "legendFormat": "Total",
+                    "queryType": "randomWalk",
+                    "refId": "B"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Queue size per deployment",
+            "title": "Prompt Tokens/s",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2092,7 +305,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "requests",
+                    "format": "tokens/s",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2120,20 +333,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "Number of nodes in this cluster. Ignores \"Application\" variable.",
+            "description": "Number of generation tokens emitted per second.",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "nodes"
+                    "unit": "tokens/s"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 8,
-                "y": 5,
+                "x": 16,
+                "y": 1,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 4,
@@ -2153,8 +366,8 @@
                 "values": true
             },
             "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "connected",
+            "linewidth": 2,
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -2199,39 +412,31 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(autoscaler_active_nodes{ray_io_cluster=~\"$Cluster\"}) by (NodeType)",
+                    "expr": "sum by(deployment, replica) (rate(ray_sglang_generation_tokens_total{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
-                    "legendFormat": "Active Nodes: {{NodeType}}",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 },
                 {
                     "exemplar": true,
-                    "expr": "sum(autoscaler_recently_failed_nodes{ray_io_cluster=~\"$Cluster\"}) by (NodeType)",
+                    "expr": "sum(rate(ray_sglang_generation_tokens_total{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
                     "interval": "",
-                    "legendFormat": "Failed Nodes: {{NodeType}}",
+                    "legendFormat": "Total",
                     "queryType": "randomWalk",
                     "refId": "B"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(autoscaler_pending_nodes{ray_io_cluster=~\"$Cluster\"}) by (NodeType)",
-                    "interval": "",
-                    "legendFormat": "Pending Nodes: {{NodeType}}",
-                    "queryType": "randomWalk",
-                    "refId": "C"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Node count",
+            "title": "Generation Tokens/s",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2248,7 +453,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "nodes",
+                    "format": "tokens/s",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2271,21 +476,34 @@
             }
         },
         {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "id": 602,
+            "title": "Latency",
+            "type": "row",
+            "panels": []
+        },
+        {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "Network speed per node. Ignores \"Application\" variable.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "Bps"
+                    "unit": "s"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 16,
-                "y": 5,
+                "x": 0,
+                "y": 18,
                 "w": 8,
                 "h": 8
             },
@@ -2360,26 +578,18 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "sum(ray_node_network_receive_speed{ray_io_cluster=~\"$Cluster\"}) by (instance)",
+                    "expr": "(\n  (\n    sum by(deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_sum{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Recv: {{instance}}",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum(ray_node_network_send_speed{ray_io_cluster=~\"$Cluster\"}) by (instance)",
-                    "interval": "",
-                    "legendFormat": "Send: {{instance}}",
-                    "queryType": "randomWalk",
-                    "refId": "B"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Node network",
+            "title": "TPOT -- Mean",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2396,7 +606,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "Bps",
+                    "format": "s",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2424,20 +634,1586 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The number of ongoing requests in the HTTP Proxy.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "requests"
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 8,
+                "y": 18,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 7,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TPOT -- P50",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 16,
+                "y": 18,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 8,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_inter_token_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TPOT -- P90",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
                 },
                 "overrides": []
             },
             "gridPos": {
                 "x": 0,
-                "y": 6,
+                "y": 26,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 9,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  (\n    sum by(deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_sum{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TTFT -- Mean",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 8,
+                "y": 26,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TTFT -- P50",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 16,
+                "y": 26,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 11,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_time_to_first_token_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TTFT -- P90",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "End-to-end request latency (in seconds).",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 0,
+                "y": 34,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 12,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  (\n    sum by(deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_sum{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Request Latency -- Mean",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "End-to-end request latency (in seconds).",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 8,
+                "y": 34,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 13,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Request Latency -- P50",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "End-to-end request latency (in seconds).",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 16,
+                "y": 34,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 14,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_e2e_request_latency_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Request Latency -- P90",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 42
+            },
+            "id": 603,
+            "title": "Cache",
+            "type": "row",
+            "panels": []
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Fraction of KV cache tokens currently in use.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 0,
+                "y": 59,
+                "w": 12,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 16,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by(deployment, replica) (ray_sglang_token_usage{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"})",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "KV Cache Utilization",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "percentunit",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Prefix cache hit rate over the selected interval.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 12,
+                "y": 59,
+                "w": 12,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 17,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by(deployment, replica) (ray_sglang_cache_hit_rate{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"})",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Cache Hit Rate",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "percentunit",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 67
+            },
+            "id": 604,
+            "title": "Request Length",
+            "type": "row",
+            "panels": []
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 0,
+                "y": 68,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 19,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  (\n    sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_sum{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Prompt Length -- Mean",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 8,
+                "y": 68,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 20,
@@ -2458,7 +2234,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -2503,14 +2279,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_num_ongoing_http_requests{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Ongoing HTTP Requests",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -2519,7 +2295,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Ongoing HTTP Requests",
+            "title": "Prompt Length -- P50",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2536,7 +2312,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "requests",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2564,20 +2340,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The number of ongoing requests in the gRPC Proxy.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "requests"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 8,
-                "y": 6,
+                "x": 16,
+                "y": 68,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 21,
@@ -2598,7 +2374,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -2643,14 +2419,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_num_ongoing_grpc_requests{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_prompt_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Ongoing gRPC Requests",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -2659,7 +2435,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Ongoing gRPC Requests",
+            "title": "Prompt Length -- P90",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2676,7 +2452,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "requests",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2704,20 +2480,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The number of request scheduling tasks in the router.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "tasks"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 16,
-                "y": 6,
+                "x": 0,
+                "y": 76,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 22,
@@ -2738,7 +2514,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -2783,14 +2559,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_num_scheduling_tasks{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "(\n  (\n    sum by(deployment, replica) (rate(ray_sglang_generation_tokens_histogram_sum{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n    /\n    sum by(deployment, replica) (rate(ray_sglang_generation_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_generation_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Scheduling Tasks",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -2799,7 +2575,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Scheduling Tasks",
+            "title": "Generation Length -- Mean",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2816,7 +2592,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "tasks",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2844,20 +2620,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The number of request scheduling tasks in the router that are undergoing backoff.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "tasks"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 0,
-                "y": 7,
+                "x": 8,
+                "y": 76,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 23,
@@ -2878,7 +2654,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -2923,14 +2699,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_num_scheduling_tasks_in_backoff{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_generation_tokens_histogram_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_generation_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Scheduling Tasks in Backoff",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -2939,7 +2715,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Scheduling Tasks in Backoff",
+            "title": "Generation Length -- P50",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -2956,7 +2732,7 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "tasks",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -2984,20 +2760,20 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The duration of the last control loop.",
+            "description": "",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "seconds"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 8,
-                "y": 7,
+                "x": 16,
+                "y": 76,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
             "id": 24,
@@ -3018,7 +2794,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -3063,14 +2839,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_controller_control_loop_duration_s{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_generation_tokens_histogram_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_generation_tokens_histogram_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
                     "interval": "",
-                    "legendFormat": "Control Loop Duration",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -3079,7 +2855,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Controller Control Loop Duration",
+            "title": "Generation Length -- P90",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -3096,7 +2872,160 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "seconds",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 84
+            },
+            "id": 605,
+            "title": "Scheduler",
+            "type": "row",
+            "panels": []
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Requests currently being processed by the scheduler.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 0,
+                "y": 93,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 26,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by(deployment, replica) (ray_sglang_num_running_reqs{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"})",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler: Running",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -3124,23 +3053,23 @@
             "dashLength": 10,
             "dashes": false,
             "datasource": "${datasource}",
-            "description": "The number of control loops performed by the controller. Increases monotonically over the controller's lifetime.",
+            "description": "Requests waiting in the scheduler queue.",
             "fieldConfig": {
                 "defaults": {
-                    "unit": "loops"
+                    "unit": "short"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "x": 16,
-                "y": 7,
+                "x": 8,
+                "y": 93,
                 "w": 8,
                 "h": 8
             },
-            "fill": 10,
+            "fill": 1,
             "fillGradient": 0,
             "hiddenSeries": false,
-            "id": 25,
+            "id": 27,
             "legend": {
                 "alignAsTable": true,
                 "avg": true,
@@ -3158,7 +3087,7 @@
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "connected",
+            "nullPointMode": null,
             "options": {
                 "alertThreshold": true
             },
@@ -3203,14 +3132,14 @@
                 }
             ],
             "spaceLength": 10,
-            "stack": true,
+            "stack": false,
             "steppedLine": false,
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "ray_serve_controller_num_control_loops{ray_io_cluster=~\"$Cluster\"}",
+                    "expr": "sum by(deployment, replica) (ray_sglang_num_queue_reqs{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"})",
                     "interval": "",
-                    "legendFormat": "Control Loops",
+                    "legendFormat": "{{deployment}}: {{replica}}",
                     "queryType": "randomWalk",
                     "refId": "A"
                 }
@@ -3219,7 +3148,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Number of Control Loops",
+            "title": "Scheduler: Queued",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -3236,7 +3165,567 @@
             "yaxes": [
                 {
                     "$$hashKey": "object:628",
-                    "format": "loops",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Requests paused (e.g. for async weight reload).",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 16,
+                "y": 93,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 28,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by(deployment, replica) (ray_sglang_num_paused_reqs{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"})",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Scheduler: Paused",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Time requests spend waiting before scheduling.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 0,
+                "y": 101,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 29,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.5,\n    sum by (le, deployment, replica) (rate(ray_sglang_queue_time_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_queue_time_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Queue Time -- P50",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Time requests spend waiting before scheduling.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 8,
+                "y": 101,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 30,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "(\n  histogram_quantile(\n    0.9,\n    sum by (le, deployment, replica) (rate(ray_sglang_queue_time_seconds_bucket{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))\n  )\n  and on(deployment, replica)\n  (\n    sum by(deployment, replica) (rate(ray_sglang_queue_time_seconds_count{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval])) > 0\n  )\n)",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Queue Time -- P90",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Aborted requests over the selected interval.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "x": 16,
+                "y": 101,
+                "w": 8,
+                "h": 8
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 31,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by(deployment, replica) (rate(ray_sglang_num_aborted_requests_total{model_name=~\"$sglang_model_name\", deployment=~\"$deployment\", ray_io_cluster=~\"$Cluster\"}[$interval]))",
+                    "interval": "",
+                    "legendFormat": "{{deployment}}: {{replica}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Aborted Requests / s",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "short",
                     "label": "",
                     "logBase": 1,
                     "max": null,
@@ -3284,6 +3773,19 @@
                 "type": "datasource"
             },
             {
+                "name": "sglang_model_name",
+                "label": "SGLang Model Name",
+                "type": "query",
+                "hide": 0,
+                "datasource": "${datasource}",
+                "definition": "label_values(ray_sglang_prompt_tokens_total{}, model_name)",
+                "query": {
+                    "query": "label_values(ray_sglang_prompt_tokens_total{}, model_name)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "includeAll": true,
+                "multi": false,
                 "allValue": ".*",
                 "current": {
                     "selected": true,
@@ -3293,32 +3795,22 @@
                     "value": [
                         "$__all"
                     ]
-                },
-                "datasource": "${datasource}",
-                "definition": "label_values(ray_serve_deployment_replica_healthy{}, application)",
-                "description": null,
-                "error": null,
-                "hide": 0,
-                "includeAll": true,
-                "label": null,
-                "multi": true,
-                "name": "Application",
-                "options": [],
-                "query": {
-                    "query": "label_values(ray_serve_deployment_replica_healthy{}, application)",
-                    "refId": "Prometheus-Instance-Variable-Query"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                }
             },
             {
+                "name": "deployment",
+                "label": "Deployment",
+                "type": "query",
+                "hide": 0,
+                "datasource": "${datasource}",
+                "definition": "label_values(ray_serve_deployment_request_counter_total{}, deployment)",
+                "query": {
+                    "query": "label_values(ray_serve_deployment_request_counter_total{}, deployment)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "includeAll": true,
+                "multi": true,
                 "allValue": ".*",
                 "current": {
                     "selected": true,
@@ -3328,94 +3820,67 @@
                     "value": [
                         "$__all"
                     ]
-                },
-                "datasource": "${datasource}",
-                "definition": "label_values(ray_serve_num_http_requests_total{}, route)",
-                "description": null,
-                "error": null,
-                "hide": 0,
-                "includeAll": true,
-                "label": "HTTP Route",
-                "multi": true,
-                "name": "HTTP_Route",
-                "options": [],
-                "query": {
-                    "query": "label_values(ray_serve_num_http_requests_total{}, route)",
-                    "refId": "Prometheus-Instance-Variable-Query"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                }
             },
             {
-                "allValue": ".*",
-                "current": {
-                    "selected": true,
-                    "text": [
-                        "All"
-                    ],
-                    "value": [
-                        "$__all"
-                    ]
-                },
-                "datasource": "${datasource}",
-                "definition": "label_values(ray_serve_num_grpc_requests_total{}, method)",
-                "description": null,
-                "error": null,
-                "hide": 0,
-                "includeAll": true,
-                "label": "gRPC Service Method",
-                "multi": true,
-                "name": "gRPC_Method",
-                "options": [],
-                "query": {
-                    "query": "label_values(ray_serve_num_grpc_requests_total{}, method)",
-                    "refId": "Prometheus-Instance-Variable-Query"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
+                "name": "Cluster",
+                "label": "Cluster",
+                "description": "Filter queries to specific Ray clusters. The ray_io_cluster label is set per cluster (automatic for KubeRay via Prometheus PodMonitor).",
                 "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": ".*",
-                "current": {
-                    "selected": false
-                },
+                "hide": 0,
                 "datasource": "${datasource}",
                 "definition": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
-                "description": "Filter queries to specific Ray clusters for KubeRay. When ingesting metrics across multiple ray clusters, the ray_io_cluster label should be set per cluster. For KubeRay users, this is done automatically with Prometheus PodMonitor.",
-                "error": null,
-                "hide": 0,
-                "includeAll": true,
-                "label": null,
-                "multi": false,
-                "name": "Cluster",
-                "options": [],
                 "query": {
                     "query": "label_values(ray_node_network_receive_speed{}, ray_io_cluster)",
                     "refId": "StandardVariableQuery"
                 },
                 "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 2,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "includeAll": true,
+                "multi": false,
+                "allValue": ".*",
+                "current": {
+                    "selected": false
+                }
+            },
+            {
+                "name": "interval",
+                "label": "Interval",
+                "type": "custom",
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "30s",
+                        "value": "30s"
+                    },
+                    {
+                        "selected": false,
+                        "text": "1m",
+                        "value": "1m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "5m",
+                        "value": "5m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "10m",
+                        "value": "10m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "15m",
+                        "value": "15m"
+                    }
+                ],
+                "current": {
+                    "selected": true,
+                    "text": "5m",
+                    "value": "5m"
+                }
             }
         ]
     },
@@ -3429,7 +3894,7 @@
     },
     "timepicker": {},
     "timezone": "",
-    "title": "Serve Dashboard",
-    "uid": "rayServeDashboard",
+    "title": "Serve LLM SGLang Dashboard",
+    "uid": "rayServeLlmSglangDashboard",
     "version": 1
 }

--- a/config/grafana/train_grafana_dashboard.json
+++ b/config/grafana/train_grafana_dashboard.json
@@ -2222,6 +2222,1459 @@
                     }
                 }
             ]
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 66
+            },
+            "id": 21,
+            "title": "Data Ingestion",
+            "type": "row",
+            "panels": []
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Per-batch data loading time exposed as training stall, not hidden behind data loader pipelining, taken as the max across ranks so it reflects the slowest rank, per dataset, over the last ${window}. Use to identify if training is stalled on data loading; ideally this value is 0, and any non-zero value indicates stall.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 67
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 18,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "max by (dataset) (1000 * sum(rate(ray_data_iter_total_blocked_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split))",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Max Exposed Data Loading Time",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Share of per-batch data loading time spent in each stage (production wait -> data transfer -> batching -> format -> collate -> finalize), across ranks, over the last ${window}. If exposed data loading time is 0, the stages do not contribute to training stall and are hidden by data loading pipelining; otherwise, use this graph to identify the offending stages.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 67
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 19,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "connected",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Production Wait: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Data Transfer: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "B"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Batching: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "C"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Format: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "D"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Collate: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "E"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) / (sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset) + sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset))",
+                    "interval": "",
+                    "legendFormat": "Finalize: {{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "F"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Percentage Data Loading Breakdown by Stage",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "percentunit",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Rows per second consumed by the training loop, one line per rank, averaged over the last ${window}.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "rowsps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 75
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 27,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_iter_rows_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Data Ingest Throughput by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "rowsps",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Rows/sec the Ray Data pipeline delivers to the training workers, over the last ${window}; only reported for datasets split across workers (DataConfig `datasets_to_split`), so non-split datasets show no data here.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "rowsps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 75
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 29,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum(rate(ray_data_output_rows{operator=~\"split.*\", SessionName=~\"$SessionName\"}[$window])) by (dataset)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Data Production Throughput",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "rowsps",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time the data loader spends waiting for the Ray Data pipeline to produce the next block, one line per rank, over the last ${window}. Use to identify data production stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 83
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 30,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_get_ref_bundles_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Production Wait Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time spent resolving and transferring data blocks, one line per rank, over the last ${window}. Use to identify data transfer stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 83
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 22,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_get_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Data Transfer Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time spent building batches (slicing, local shuffle), one line per rank, over the last ${window}. Use to identify batching stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 91
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 23,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_next_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Batching Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time spent converting blocks to the batch format, one line per rank, over the last ${window}. Use to identify formatting stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 91
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 24,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_format_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Format Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time spent in the user collate function, one line per rank, over the last ${window}. Use to identify collation stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 99
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 25,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_collate_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Collate Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "description": "Average per-batch time spent in finalize (e.g. host-to-device transfer), one line per rank, over the last ${window}. Use to identify finalization stragglers.",
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "ms/batch"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 99
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "hiddenSeries": false,
+            "id": 26,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": null,
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.17",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX",
+                    "dashes": true,
+                    "color": "#1F60C4",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "$$hashKey": "object:78",
+                    "alias": "/FINISHED|FAILED|DEAD|REMOVED|Failed Nodes:/",
+                    "hiddenSeries": true
+                },
+                {
+                    "$$hashKey": "object:2987",
+                    "alias": "MAX + PENDING",
+                    "dashes": true,
+                    "color": "#777777",
+                    "fill": 0,
+                    "stack": false
+                },
+                {
+                    "alias": "/Container/",
+                    "hiddenSeries": true
+                },
+                {
+                    "alias": "Container MAX",
+                    "dashes": true,
+                    "color": "#73BF69",
+                    "fill": 0,
+                    "stack": false,
+                    "hiddenSeries": true
+                }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "1000 * sum(rate(ray_data_iter_finalize_batch_seconds{SessionName=~\"$SessionName\"}[$window])) by (dataset, split) / sum(rate(ray_data_iter_batches_total{SessionName=~\"$SessionName\"}[$window])) by (dataset, split)",
+                    "interval": "",
+                    "legendFormat": "{{dataset}}, {{split}}",
+                    "queryType": "randomWalk",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Finalize Time by Rank",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:628",
+                    "format": "ms/batch",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:629",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         }
     ],
     "time": {
@@ -2256,6 +3709,45 @@
                 "current": {
                     "selected": false
                 }
+            },
+            {
+                "name": "window",
+                "label": "Window",
+                "type": "interval",
+                "description": "Averaging window for rate() calculations. Use a smaller window to surface spikes, a larger window to smooth out the whole run.",
+                "query": "30s,1m,5m,15m",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "30s",
+                        "value": "30s"
+                    },
+                    {
+                        "selected": true,
+                        "text": "1m",
+                        "value": "1m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "5m",
+                        "value": "5m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "15m",
+                        "value": "15m"
+                    }
+                ],
+                "current": {
+                    "selected": true,
+                    "text": "1m",
+                    "value": "1m"
+                },
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "refresh": 2,
+                "hide": 0
             },
             {
                 "name": "SessionName",
@@ -2501,7 +3993,7 @@
         ]
     },
     "tags": [
-        "rayVersion:2.56.0"
+        "rayVersion:2.58.0"
     ],
     "rayMeta": [
         "supportsGlobalFilterOverride"


### PR DESCRIPTION
## Why are these changes needed?

Refresh the Grafana dashboards under `config/grafana` to the versions shipped with Ray 2.58.0.

The dashboards were copied from a `rayproject/ray:2.58.0` head Pod at `/tmp/ray/session_latest/metrics/grafana/dashboards/`, following the documented dashboard update process. This updates the seven existing Ray dashboards and adds the new `serve_llm_sglang_grafana_dashboard.json`.

## Related issue number

N/A

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

- Verified every Ray dashboard is valid JSON with `jq`.
- Verified every dashboard has a unique UID and the `rayVersion:2.58.0` tag.
- Verified the checked-in files exactly match the files generated by the Ray 2.58.0 head Pod.
- Generated each dashboard ConfigMap with `kubectl create configmap --dry-run=client` and verified every object remains below the Kubernetes 1 MB object-size limit.
- Ran `git diff --check`.