### PR TITLE
rayservice: deduplicate target capacity updates using cluster status

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1708,13 +1708,21 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 		return err
 	}
 
-	// Check if ServeConfig requires update
-	if currentTargetCapacity, ok := serveConfig["target_capacity"].(float64); ok {
-		if int32(currentTargetCapacity) == goalTargetCapacity {
-			logger.Info("target_capacity already updated on RayCluster", "target_capacity", currentTargetCapacity)
-			// No update required, return early
-			return nil
-		}
+	// YAML decoding preserves whole numbers as int64, including JSON values
+	// such as 50.0. Compare without truncating fractional capacities.
+	var currentTargetCapacity float64
+	capacityPresent := true
+	switch value := serveConfig["target_capacity"].(type) {
+	case int64:
+		currentTargetCapacity = float64(value)
+	case float64:
+		currentTargetCapacity = value
+	default:
+		capacityPresent = false
+	}
+	if capacityPresent && currentTargetCapacity == float64(goalTargetCapacity) {
+		logger.Info("target_capacity already updated on RayCluster", "target_capacity", currentTargetCapacity)
+		return nil
 	}
 
 	serveConfig["target_capacity"] = goalTargetCapacity

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1697,6 +1697,20 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster, rayDashboardClient dashboardclient.RayDashboardClientInterface, goalTargetCapacity int32) error {
 	logger := ctrl.LoggerFrom(ctx).WithValues("RayCluster", rayClusterInstance.Name)
 
+	// The cached config contains the original spec, not the capacity applied during
+	// an incremental upgrade. Compare the capacity tracked for this cluster instead.
+	var currentTargetCapacity *int32
+	switch rayClusterInstance.Name {
+	case rayServiceInstance.Status.ActiveServiceStatus.RayClusterName:
+		currentTargetCapacity = rayServiceInstance.Status.ActiveServiceStatus.TargetCapacity
+	case rayServiceInstance.Status.PendingServiceStatus.RayClusterName:
+		currentTargetCapacity = rayServiceInstance.Status.PendingServiceStatus.TargetCapacity
+	}
+	if currentTargetCapacity != nil && *currentTargetCapacity == goalTargetCapacity {
+		logger.Info("target_capacity already updated on RayCluster", "target_capacity", *currentTargetCapacity)
+		return nil
+	}
+
 	// Retrieve cached ServeConfig from last reconciliation for cluster to update
 	cachedConfig := r.getServeConfigFromCache(rayServiceInstance, rayClusterInstance.Name)
 	if cachedConfig == "" {
@@ -1706,23 +1720,6 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 	serveConfig := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(cachedConfig), &serveConfig); err != nil {
 		return err
-	}
-
-	// YAML decoding preserves whole numbers as int64, including JSON values
-	// such as 50.0. Compare without truncating fractional capacities.
-	var currentTargetCapacity float64
-	capacityPresent := true
-	switch value := serveConfig["target_capacity"].(type) {
-	case int64:
-		currentTargetCapacity = float64(value)
-	case float64:
-		currentTargetCapacity = value
-	default:
-		capacityPresent = false
-	}
-	if capacityPresent && currentTargetCapacity == float64(goalTargetCapacity) {
-		logger.Info("target_capacity already updated on RayCluster", "target_capacity", currentTargetCapacity)
-		return nil
 	}
 
 	serveConfig["target_capacity"] = goalTargetCapacity
@@ -1761,17 +1758,10 @@ func (r *RayServiceReconciler) reconcileServeTargetCapacity(ctx context.Context,
 	activeRayServiceStatus := &rayServiceInstance.Status.ActiveServiceStatus
 	pendingRayServiceStatus := &rayServiceInstance.Status.PendingServiceStatus
 
-	// Set initial TargetCapacity values if unset
-	if activeRayServiceStatus.TargetCapacity == nil {
-		activeRayServiceStatus.TargetCapacity = new(int32(100))
-	}
-	if pendingRayServiceStatus.TargetCapacity == nil {
-		pendingRayServiceStatus.TargetCapacity = new(int32(0))
-	}
-
-	// Retrieve the current observed Status fields for NewClusterWithIncrementalUpgrade
-	activeTargetCapacity := *activeRayServiceStatus.TargetCapacity
-	pendingTargetCapacity := *pendingRayServiceStatus.TargetCapacity
+	// Use defaults for upgrade calculations without recording them as applied capacity.
+	// Status is advanced only after the Dashboard accepts a capacity update.
+	activeTargetCapacity := ptr.Deref(activeRayServiceStatus.TargetCapacity, 100)
+	pendingTargetCapacity := ptr.Deref(pendingRayServiceStatus.TargetCapacity, 0)
 	pendingTrafficRoutedPercent := ptr.Deref(pendingRayServiceStatus.TrafficRoutedPercent, 0)
 
 	// Retrieve MaxSurgePercent - the maximum amount to change TargetCapacity by

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3269,3 +3269,38 @@ func TestHandleSuspendObservedGeneration(t *testing.T) {
 		assert.Equal(t, int64(4), rayService.Status.ObservedGeneration)
 	})
 }
+
+func TestApplyServeTargetCapacitySkipsUnchangedCapacity(t *testing.T) {
+	for _, config := range []string{`{"target_capacity":50}`, "target_capacity: 50", `{"target_capacity":50.0}`} {
+		for _, cached := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cached=%t", config, cached), func(t *testing.T) {
+				service := &rayv1.RayService{Spec: rayv1.RayServiceSpec{ServeConfigV2: config}}
+				cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
+				dashboard := &utils.FakeRayDashboardClient{}
+				reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+				if cached {
+					reconciler.cacheServeConfig(service, cluster.Name)
+					service.Spec.ServeConfigV2 = `{"target_capacity":0}`
+				}
+				require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
+				assert.Empty(t, dashboard.LastUpdatedConfig, "unchanged capacity must not trigger a deployment update")
+			})
+		}
+	}
+}
+
+func TestApplyServeTargetCapacityUpdatesDifferentCapacity(t *testing.T) {
+	for _, config := range []string{`{"target_capacity":49}`, `{"target_capacity":50.5}`, `{"target_capacity":null}`, `{}`} {
+		t.Run(config, func(t *testing.T) {
+			service := &rayv1.RayService{Spec: rayv1.RayServiceSpec{ServeConfigV2: config},
+				Status: rayv1.RayServiceStatuses{ActiveServiceStatus: rayv1.RayServiceStatus{RayClusterName: "active"}}}
+			cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
+			dashboard := &utils.FakeRayDashboardClient{}
+			reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+			require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
+			assert.JSONEq(t, `{"target_capacity":50}`, string(dashboard.LastUpdatedConfig))
+			require.NotNil(t, service.Status.ActiveServiceStatus.TargetCapacity)
+			assert.EqualValues(t, 50, *service.Status.ActiveServiceStatus.TargetCapacity)
+		})
+	}
+}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3270,37 +3270,130 @@ func TestHandleSuspendObservedGeneration(t *testing.T) {
 	})
 }
 
-func TestApplyServeTargetCapacitySkipsUnchangedCapacity(t *testing.T) {
-	for _, config := range []string{`{"target_capacity":50}`, "target_capacity: 50", `{"target_capacity":50.0}`} {
-		for _, cached := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/cached=%t", config, cached), func(t *testing.T) {
-				service := &rayv1.RayService{Spec: rayv1.RayServiceSpec{ServeConfigV2: config}}
+func TestApplyServeTargetCapacityUsesAppliedCapacity(t *testing.T) {
+	for _, clusterName := range []string{"active", "pending"} {
+		for _, capacity := range []*int32{nil, new(int32(40)), new(int32(50))} {
+			for _, cached := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/capacity=%v/cached=%t", clusterName, ptr.Deref(capacity, -1), cached), func(t *testing.T) {
+					service := &rayv1.RayService{
+						Spec: rayv1.RayServiceSpec{ServeConfigV2: `{"target_capacity":40,"applications":[]}`},
+						Status: rayv1.RayServiceStatuses{
+							ActiveServiceStatus:  rayv1.RayServiceStatus{RayClusterName: "active", TargetCapacity: new(int32(50))},
+							PendingServiceStatus: rayv1.RayServiceStatus{RayClusterName: "pending", TargetCapacity: new(int32(50))},
+						},
+					}
+					status := &service.Status.ActiveServiceStatus
+					if clusterName == "pending" {
+						status = &service.Status.PendingServiceStatus
+					}
+					status.TargetCapacity = capacity
+					cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}
+					dashboard := &utils.FakeRayDashboardClient{}
+					reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+					if cached {
+						reconciler.cacheServeConfig(service, cluster.Name)
+						service.Spec.ServeConfigV2 = `{"target_capacity":0}`
+					}
+					require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
+					if capacity != nil && *capacity == 50 {
+						assert.Empty(t, dashboard.LastUpdatedConfig, "an applied capacity must not trigger another update")
+					} else {
+						assert.JSONEq(t, `{"target_capacity":50,"applications":[]}`, string(dashboard.LastUpdatedConfig))
+					}
+					require.NotNil(t, status.TargetCapacity)
+					assert.EqualValues(t, 50, *status.TargetCapacity)
+
+					// A successful update is also idempotent when the original config is cached.
+					dashboard.LastUpdatedConfig = nil
+					require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
+					assert.Empty(t, dashboard.LastUpdatedConfig)
+				})
+			}
+		}
+	}
+}
+
+// failingCapacityDashboard lets a reconciliation retry a failed deployment update.
+type failingCapacityDashboard struct {
+	utils.FakeRayDashboardClient
+	updateErr error
+}
+
+func (d *failingCapacityDashboard) UpdateDeployments(ctx context.Context, config []byte) error {
+	if d.updateErr != nil {
+		return d.updateErr
+	}
+	return d.FakeRayDashboardClient.UpdateDeployments(ctx, config)
+}
+
+func TestReconcileServeTargetCapacityReturnsToConfiguredCapacity(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+	for _, cached := range []bool{false, true} {
+		for _, failFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("cached=%t/failFirst=%t", cached, failFirst), func(t *testing.T) {
+				service := &rayv1.RayService{
+					Spec: rayv1.RayServiceSpec{
+						ServeConfigV2: `{"target_capacity":60,"applications":[]}`,
+						UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
+							Type:                  ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
+							ClusterUpgradeOptions: &rayv1.ClusterUpgradeOptions{MaxSurgePercent: new(int32(20))},
+						},
+					},
+					Status: rayv1.RayServiceStatuses{
+						ActiveServiceStatus:  rayv1.RayServiceStatus{RayClusterName: "active", TargetCapacity: new(int32(80))},
+						PendingServiceStatus: rayv1.RayServiceStatus{RayClusterName: "pending", TargetCapacity: new(int32(30)), TrafficRoutedPercent: new(int32(30))},
+					},
+				}
 				cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
-				dashboard := &utils.FakeRayDashboardClient{}
 				reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
 				if cached {
 					reconciler.cacheServeConfig(service, cluster.Name)
-					service.Spec.ServeConfigV2 = `{"target_capacity":0}`
+					service.Spec.ServeConfigV2 = `{"target_capacity":0,"applications":[]}`
 				}
-				require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
-				assert.Empty(t, dashboard.LastUpdatedConfig, "unchanged capacity must not trigger a deployment update")
+				dashboard := &failingCapacityDashboard{}
+				if failFirst {
+					dashboard.updateErr = fmt.Errorf("dashboard unavailable")
+					require.ErrorContains(t, reconciler.reconcileServeTargetCapacity(context.Background(), service, cluster, dashboard), "dashboard unavailable")
+					assert.EqualValues(t, 80, *service.Status.ActiveServiceStatus.TargetCapacity)
+					assert.EqualValues(t, 30, *service.Status.PendingServiceStatus.TargetCapacity)
+					dashboard.updateErr = nil
+				}
+				require.NoError(t, reconciler.reconcileServeTargetCapacity(context.Background(), service, cluster, dashboard))
+				assert.JSONEq(t, `{"target_capacity":60,"applications":[]}`, string(dashboard.LastUpdatedConfig))
+				assert.EqualValues(t, 60, *service.Status.ActiveServiceStatus.TargetCapacity)
+				assert.EqualValues(t, 30, *service.Status.PendingServiceStatus.TargetCapacity)
 			})
 		}
 	}
 }
 
-func TestApplyServeTargetCapacityUpdatesDifferentCapacity(t *testing.T) {
-	for _, config := range []string{`{"target_capacity":49}`, `{"target_capacity":50.5}`, `{"target_capacity":null}`, `{}`} {
-		t.Run(config, func(t *testing.T) {
-			service := &rayv1.RayService{Spec: rayv1.RayServiceSpec{ServeConfigV2: config},
-				Status: rayv1.RayServiceStatuses{ActiveServiceStatus: rayv1.RayServiceStatus{RayClusterName: "active"}}}
-			cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
-			dashboard := &utils.FakeRayDashboardClient{}
-			reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
-			require.NoError(t, reconciler.applyServeTargetCapacity(context.Background(), service, cluster, dashboard, 50))
-			assert.JSONEq(t, `{"target_capacity":50}`, string(dashboard.LastUpdatedConfig))
-			require.NotNil(t, service.Status.ActiveServiceStatus.TargetCapacity)
-			assert.EqualValues(t, 50, *service.Status.ActiveServiceStatus.TargetCapacity)
-		})
+func TestReconcileServeTargetCapacityDoesNotApplyDefaultsToStatus(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+	service := &rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{
+			ServeConfigV2: `{"target_capacity":100}`,
+			UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
+				Type:                  ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
+				ClusterUpgradeOptions: &rayv1.ClusterUpgradeOptions{MaxSurgePercent: new(int32(20))},
+			},
+		},
+		Status: rayv1.RayServiceStatuses{
+			ActiveServiceStatus:  rayv1.RayServiceStatus{RayClusterName: "active", TrafficRoutedPercent: new(int32(100))},
+			PendingServiceStatus: rayv1.RayServiceStatus{RayClusterName: "pending"},
+			Conditions:           []metav1.Condition{{Type: string(rayv1.RollbackInProgress), Status: metav1.ConditionTrue}},
+		},
 	}
+	cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
+	reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+	dashboard := &failingCapacityDashboard{updateErr: fmt.Errorf("dashboard unavailable")}
+	require.ErrorContains(t, reconciler.reconcileServeTargetCapacity(context.Background(), service, cluster, dashboard), "dashboard unavailable")
+	assert.Nil(t, service.Status.ActiveServiceStatus.TargetCapacity)
+	assert.Nil(t, service.Status.PendingServiceStatus.TargetCapacity)
+
+	dashboard.updateErr = nil
+	require.NoError(t, reconciler.reconcileServeTargetCapacity(context.Background(), service, cluster, dashboard))
+	assert.JSONEq(t, `{"target_capacity":100}`, string(dashboard.LastUpdatedConfig))
+	require.NotNil(t, service.Status.ActiveServiceStatus.TargetCapacity)
+	assert.EqualValues(t, 100, *service.Status.ActiveServiceStatus.TargetCapacity)
+	assert.Nil(t, service.Status.PendingServiceStatus.TargetCapacity)
 }


### PR DESCRIPTION
## Why are these changes needed?

During incremental RayService upgrades, capacity update deduplication reads `target_capacity` from the cached Serve config. That cache retains the original spec rather than the capacity most recently applied to the cluster. Comparing the original value with the next goal can skip a required Dashboard update and leave the upgrade stalled. For example, an active cluster at 80% that must scale down to 60% never advances if the original config also contains 60%.

Use the matching active or pending cluster's `Status.TargetCapacity` to identify an already-applied target. Missing status remains unknown and requires an update. Keep the original Serve config cache unchanged, and update capacity status only after `UpdateDeployments` succeeds. Reconciliation uses local defaults for missing capacities without recording those defaults as successful updates.

The regression reproduces a return to the original configured capacity through `reconcileServeTargetCapacity`, with and without a cached config. It also verifies that Dashboard failures preserve status and that retries apply the update. Additional tests cover active/pending status selection, missing status, repeated updates, and rollback with missing capacity status.

## Related issue number

Fixes #4777

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Validation from `ray-operator/`:

- Regression failed before the fix: no Dashboard update was sent and active capacity remained 80 instead of 60; a configured Dashboard error was incorrectly bypassed.
- `go test ./controllers/ray -run 'Test(ApplyServeTargetCapacity|ReconcileServeTargetCapacity)' -count=1 -v`
- `go test ./controllers/ray -skip '^TestAPIs$' -count=1`
- `go vet ./controllers/ray`
- `git diff --check`

The controller unit suite passed. Using locally available Kubernetes 1.35.0 envtest binaries, all 21 RayService API specs also passed:

```sh
KUBEBUILDER_ASSETS=<envtest-1.35.0-bin-directory> go test ./controllers/ray -run '^TestAPIs$' -count=1 -timeout=5m -v -ginkgo.focus='RayService env tests' -ginkgo.no-color
```

The full controller envtest attempt (`go test ./controllers/ray -count=1 -timeout=5m`) reached its five-minute timeout during a RayJob test; it did not complete, so it is not counted as passing. The repository's Makefile defaults to Kubernetes 1.37.0; that envtest version and cluster end-to-end tests were not run.
