### PR TITLE
Kubernetes WAS v1alpha3 improvements (in-place gang resize + PodGroupPremptionPolicy)

### DIFF
--- a/ci/kind-config-buildkite-kubernetes-was-v1alpha3.yml
+++ b/ci/kind-config-buildkite-kubernetes-was-v1alpha3.yml
@@ -14,13 +14,15 @@ nodes:
     kind: ClusterConfiguration
     apiServer:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        # GenericWorkload serves the Workload/PodGroup APIs; PodGroupPreemptionPolicy
+        # lets the apiserver persist the gated PodGroup/Workload preemptionPolicy field.
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"
         runtime-config: "scheduling.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha3=true"
       certSANs:
         - "docker"
     controllerManager:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"
     scheduler:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"

--- a/docs/guidance/kubernetes-was.md
+++ b/docs/guidance/kubernetes-was.md
@@ -12,7 +12,7 @@ Distributed AI/ML workloads on Kubernetes can suffer from partial scheduling. So
 hold expensive nodes idle while waiting for the remaining pods, or partially scheduled groups block other workloads
 indefinitely. Gang scheduling solves this by treating a group of pods as an atomic unit.
 
-Kubernetes WAS uses the Workload and PodGroup APIs introduced by [KEP-4671][kep-4671] and [KEP-5832][kep-5832].
+Kubernetes WAS uses the in-tree Kubernetes `scheduling.k8s.io` Workload and PodGroup APIs.
 Unlike Volcano, YuniKorn, or other external schedulers, it keeps pods on the Kubernetes default scheduler and sets
 `spec.schedulingGroup` on each pod to connect it to its PodGroup.
 
@@ -22,7 +22,8 @@ Unlike Volcano, YuniKorn, or other external schedulers, it keeps pods on the Kub
 - `scheduling.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha3=true` in the kube-apiserver runtime config. KubeRay uses
   v1alpha3, while kube-scheduler's GenericWorkload integration requires v1beta1 to be served as well.
 - `GenericWorkload=true` on the kube-apiserver, kube-controller-manager, and kube-scheduler.
-- Fixed-size RayCluster worker groups. Autoscaling RayClusters are not supported.
+- (Optional, only for the [gang preemption policy](#preemption-policy)) `PodGroupPreemptionPolicy=true` on the
+  kube-apiserver and kube-scheduler.
 
 ## Enable Kubernetes WAS
 
@@ -78,8 +79,11 @@ Once enabled and opted in, a RayCluster is scheduled as a single gang:
   contributes `replicas × numOfHosts` pods. Suspended worker groups contribute nothing.
 - **Default scheduler.** Pods are placed by the standard Kubernetes scheduler; there is no separate scheduler to
   install or run.
-- **Editing and scaling.** Changing worker groups or replica counts is picked up automatically — the gang requirement
-  is updated to match the new cluster shape.
+- **Editing and scaling.** Changing worker groups or replica counts is picked up automatically — the gang size is
+  updated in place on the existing Workload and PodGroup (they are not deleted and recreated).
+- **Autoscaling.** Autoscaling RayClusters (`enableInTreeAutoscaling: true`) are gang scheduled at a floor of one head
+  pod plus each worker group's `minReplicas`. The autoscaler can then add pods above that floor; those extra pods
+  schedule individually without waiting on the gang, so scaling up never deadlocks the cluster.
 - **Suspend and resume.** Suspending a RayCluster deletes its pods but keeps the Workload and PodGroup in place;
   resuming reuses them so the recreated pods rejoin the same gang.
 - **Cleanup.** The scheduling resources are garbage collected automatically when the RayCluster is deleted.
@@ -91,11 +95,45 @@ kubectl get pods -n <namespace> -l ray.io/cluster=<raycluster-name> \
   -o custom-columns=NAME:.metadata.name,GROUP:.spec.schedulingGroup.podGroupName
 ```
 
+## Preemption policy
+
+By default a scheduled gang can preempt lower-priority pods to make room (`PreemptLowerPriority`). You can also mark a
+gang as non-preempting (`Never`) so it waits for capacity rather than evicting other workloads.
+
+This is controlled through a Kubernetes `PriorityClass`: the priority admission
+controller derives a PodGroup's `preemptionPolicy` from its `priorityClassName`. To use it:
+
+1. Enable the KubeRay operator feature gate `KubernetesWASPodGroupPreemptionPolicy` (alpha, disabled by default), in
+   addition to `KubernetesWAS`.
+2. Enable the Kubernetes cluster `PodGroupPreemptionPolicy` feature gate on the kube-apiserver and kube-scheduler
+   (Kubernetes 1.37+).
+3. Create a `PriorityClass` with the desired policy and assign it to **all** Ray pods (the head and every worker group):
+
+   ```yaml
+   apiVersion: scheduling.k8s.io/v1
+   kind: PriorityClass
+   metadata:
+     name: ray-no-preemption
+   value: 1000
+   preemptionPolicy: Never
+   ```
+
+   ```yaml
+   # In each RayCluster pod template (head and workers):
+   spec:
+     priorityClassName: ray-no-preemption
+   ```
+
+KubeRay then reflects that `priorityClassName` onto the whole-cluster Workload and PodGroup, and the priority admission
+controller populates the PodGroup's `preemptionPolicy` from the class. All pods in the gang must use the **same**
+`PriorityClass` — the Kubernetes scheduler requires a uniform priority across a PodGroup.
+
+If either feature gate is off, the `preemptionPolicy` field is left unset and the gang uses the default
+`PreemptLowerPriority` (the operator logs a one-time startup warning when its gate is on so the requirement is visible).
+
 ## Limitations
 
 - This release is tied to the Kubernetes `scheduling.k8s.io/v1alpha3` alpha API served by Kubernetes 1.37.
-- Autoscaling RayClusters are skipped and any existing Workload/PodGroup resources for that RayCluster are cleaned up.
-  Fixed-size worker groups only.
 - The entire RayCluster is scheduled as one gang. Partial scheduling of a subset of worker groups is not supported; if
   the cluster cannot be scheduled in full, none of its pods are scheduled.
 - `spec.schedulingGroup` on pods is immutable. If you add the opt-in label to an already-running RayCluster, existing
@@ -120,10 +158,10 @@ If pods are gated even though there appears to be capacity, confirm the cluster 
 The pod scheduling group is set at pod creation and is immutable. If you add the `ray.io/gang-scheduling-enabled` label
 to an already-running RayCluster, existing pods are not affected — they pick up gang scheduling only when recreated.
 
-### Autoscaling clusters are not gang scheduled
+### The gang's preemption policy is not applied
 
-Autoscaling is intentionally unsupported. A RayCluster with `enableInTreeAutoscaling: true` is scheduled normally, pod
-by pod, and no scheduling group is set on its pods.
-
-[kep-4671]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling
-[kep-5832]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5832-decouple-podgroup-api
+If a gang still preempts (or the PodGroup's `preemptionPolicy` is unset) when you expected `Never`, check that: the
+operator `KubernetesWASPodGroupPreemptionPolicy` gate is on; the Kubernetes cluster `PodGroupPreemptionPolicy` gate is enabled
+on the kube-apiserver and kube-scheduler; and **every** Ray pod (head and all worker groups) references the same
+`PriorityClass`. If the pods carry different priorities the scheduler rejects the gang, since a PodGroup requires a
+uniform priority.

--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -417,6 +417,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end -}}
 {{- if or .batchSchedulerEnabled (eq .batchSchedulerName "volcano") }}
 - apiGroups:

--- a/helm-chart/kuberay-operator/tests/multiple_namespaces_role_test.yaml
+++ b/helm-chart/kuberay-operator/tests/multiple_namespaces_role_test.yaml
@@ -29,6 +29,17 @@ tests:
               - patch
               - update
               - watch
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - scheduling.k8s.io
+            resources:
+              - priorityclasses
+            verbs:
+              - get
+              - list
+              - watch
 
   - it: Should include scheduling.k8s.io RBAC rules for Kubernetes WAS v1alpha3
     set:
@@ -53,4 +64,15 @@ tests:
               - list
               - patch
               - update
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - scheduling.k8s.io
+            resources:
+              - priorityclasses
+            verbs:
+              - get
+              - list
               - watch

--- a/helm-chart/kuberay-operator/tests/role_test.yaml
+++ b/helm-chart/kuberay-operator/tests/role_test.yaml
@@ -56,3 +56,14 @@ tests:
               - patch
               - update
               - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - scheduling.k8s.io
+            resources:
+              - priorityclasses
+            verbs:
+              - get
+              - list
+              - watch

--- a/ray-operator/config/overlays/kubernetes-was-v1alpha3/deployment-override.yaml
+++ b/ray-operator/config/overlays/kubernetes-was-v1alpha3/deployment-override.yaml
@@ -11,4 +11,4 @@ spec:
       containers:
       - name: kuberay-operator
         args:
-        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,KubernetesWAS=true
+        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,KubernetesWAS=true,KubernetesWASPodGroupPreemptionPolicy=true

--- a/ray-operator/config/overlays/kubernetes-was-v1alpha3/kustomization.yaml
+++ b/ray-operator/config/overlays/kubernetes-was-v1alpha3/kustomization.yaml
@@ -40,3 +40,14 @@ patches:
             - patch
             - update
             - watch
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+            - scheduling.k8s.io
+          resources:
+            - priorityclasses
+          verbs:
+            - get
+            - list
+            - watch

--- a/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha3/kubernetes_was_v1alpha3.go
+++ b/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha3/kubernetes_was_v1alpha3.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,7 @@ import (
 	kuberneteswas "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/kubernetes-was"
 	batchschedulerutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/utils"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 const (
@@ -35,7 +37,6 @@ const (
 
 const (
 	skipReasonGangSchedulingDisabled = "gang scheduling not enabled on RayCluster"
-	skipReasonAutoscaling            = "autoscaling is not yet supported"
 )
 
 type KubernetesWASV1Alpha3Scheduler struct {
@@ -108,10 +109,10 @@ func (p *Provider) ConfigureReconciler(b *builder.Builder) *builder.Builder {
 		Owns(&schedulingv1alpha3.PodGroup{})
 }
 
-// Preserve the existing reconciliation behavior by deleting stale resources in
-// dependency order and recreating them on later reconciles.
+// syncSchedulingResources creates the Workload and PodGroup on the first reconcile and
+// patches gang.minCount in place on later reconciles (v1alpha3 minCount is mutable).
 func (k *KubernetesWASV1Alpha3Scheduler) syncSchedulingResources(ctx context.Context, rayCluster *rayv1.RayCluster) error {
-	workload, podGroup, err := k.buildSchedulingResources(rayCluster)
+	workload, podGroup, err := k.buildSchedulingResources(ctx, rayCluster)
 	if err != nil {
 		return fmt.Errorf("failed to build scheduling resources for RayCluster %s/%s: %w", rayCluster.Namespace, rayCluster.Name, err)
 	}
@@ -120,7 +121,6 @@ func (k *KubernetesWASV1Alpha3Scheduler) syncSchedulingResources(ctx context.Con
 	}
 	return k.syncPodGroup(ctx, rayCluster, podGroup)
 }
-
 func (k *KubernetesWASV1Alpha3Scheduler) syncWorkload(ctx context.Context, rayCluster *rayv1.RayCluster, desired *schedulingv1alpha3.Workload) error {
 	existing := &schedulingv1alpha3.Workload{}
 	found, err := k.getSchedulingResource(ctx, "Workload", client.ObjectKeyFromObject(desired), existing)
@@ -142,28 +142,14 @@ func (k *KubernetesWASV1Alpha3Scheduler) syncWorkload(ctx context.Context, rayCl
 	if existing.DeletionTimestamp != nil {
 		return fmt.Errorf("Workload %s/%s is being deleted, will retry", existing.Namespace, existing.Name)
 	}
-	if !isWorkloadStale(existing, desired) {
+	// gang.minCount is mutable in v1alpha3, so a RayCluster resize edits minCount on the
+	// existing Workload in place instead of deleting and recreating it.
+	existingGang := workloadClusterGang(existing)
+	desiredMinCount := desired.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount
+	if !gangNeedsMinCountPatch(existingGang, desiredMinCount) {
 		return nil
 	}
-
-	// Delete the runtime PodGroup before deleting the immutable Workload it
-	// references. A later reconcile recreates the Workload before the PodGroup.
-	podGroupKey := client.ObjectKey{Name: clusterPodGroupName(rayCluster.Name), Namespace: rayCluster.Namespace}
-	podGroup := &schedulingv1alpha3.PodGroup{}
-	if found, err := k.getSchedulingResource(ctx, "PodGroup", podGroupKey, podGroup); err != nil {
-		return err
-	} else if found && metav1.IsControlledBy(podGroup, rayCluster) {
-		if _, err := k.deletePodGroup(ctx, podGroup); err != nil {
-			return err
-		}
-		return fmt.Errorf("deleted PodGroup %s/%s before replacing stale Workload, will retry after deletion completes", podGroup.Namespace, podGroup.Name)
-	}
-
-	// PodGroup is gone or not ours; safe to delete the stale Workload.
-	if err := client.IgnoreNotFound(k.deleteWithUIDPrecondition(ctx, existing)); err != nil {
-		return fmt.Errorf("failed to delete stale Workload %s/%s: %w", existing.Namespace, existing.Name, err)
-	}
-	return fmt.Errorf("deleted stale Workload %s/%s, will retry after deletion completes", existing.Namespace, existing.Name)
+	return k.patchGangMinCount(ctx, "Workload", existing, existingGang, desiredMinCount)
 }
 
 func (k *KubernetesWASV1Alpha3Scheduler) syncPodGroup(ctx context.Context, rayCluster *rayv1.RayCluster, desired *schedulingv1alpha3.PodGroup) error {
@@ -185,37 +171,28 @@ func (k *KubernetesWASV1Alpha3Scheduler) syncPodGroup(ctx context.Context, rayCl
 		return fmt.Errorf("PodGroup %s/%s already exists and is not owned by this RayCluster; rename it or use a different RayCluster name to avoid the collision", existing.Namespace, existing.Name)
 	}
 	if existing.DeletionTimestamp != nil {
-		if _, err := k.deletePodGroup(ctx, existing); err != nil {
+		// The PodGroup is terminating (e.g. deleted out of band). Drop KubeRay's protection
+		// finalizer so it can finish deleting; a later reconcile finds it gone and recreates it.
+		// Resizes never reach here — they patch gang.minCount in place rather than deleting.
+		if _, err := k.removeProtectionFinalizer(ctx, existing); err != nil {
 			return err
 		}
 		return fmt.Errorf("PodGroup %s/%s is being deleted, will retry", existing.Namespace, existing.Name)
 	}
-	// MinCount changed; existing PodGroup is stale and must be recreated.
+	// gang.minCount is mutable in v1alpha3, so a RayCluster resize edits minCount on the
+	// existing PodGroup in place.
 	existingGang := existing.Spec.SchedulingPolicy.Gang
-	if existingGang != nil && existingGang.MinCount == desired.Spec.SchedulingPolicy.Gang.MinCount {
+	desiredMinCount := desired.Spec.SchedulingPolicy.Gang.MinCount
+	if !gangNeedsMinCountPatch(existingGang, desiredMinCount) {
 		return nil
 	}
-
-	// Remove the protection finalizer before deleting the stale PodGroup.
-	if _, err := k.deletePodGroup(ctx, existing); err != nil {
-		return err
-	}
-	return fmt.Errorf("deleted stale PodGroup %s/%s, will retry after deletion completes", existing.Namespace, existing.Name)
+	return k.patchGangMinCount(ctx, "PodGroup", existing, existingGang, desiredMinCount)
 }
 
 func (k *KubernetesWASV1Alpha3Scheduler) deletePodGroup(ctx context.Context, podGroup *schedulingv1alpha3.PodGroup) (bool, error) {
-	// Kubernetes uses this finalizer to protect a PodGroup while Pods still
-	// reference it. KubeRay removes it before explicitly deleting an owned
-	// PodGroup because replacement or cleanup may occur before those Pods
-	// terminate.
-	didDelete := controllerutil.RemoveFinalizer(podGroup, podGroupProtectionFinalizer)
-	if didDelete {
-		if err := k.cli.Update(ctx, podGroup); err != nil {
-			if errors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, fmt.Errorf("failed to remove finalizer from PodGroup %s/%s: %w", podGroup.Namespace, podGroup.Name, err)
-		}
+	didDelete, err := k.removeProtectionFinalizer(ctx, podGroup)
+	if err != nil {
+		return false, err
 	}
 	if podGroup.DeletionTimestamp != nil {
 		return didDelete, nil
@@ -229,16 +206,69 @@ func (k *KubernetesWASV1Alpha3Scheduler) deletePodGroup(ctx context.Context, pod
 	return true, nil
 }
 
-// buildClusterSchedulingPolicy gang schedules the head and all desired workers.
+// removeProtectionFinalizer drops KubeRay's PodGroup protection finalizer and persists the
+// change, reporting whether the finalizer was present. Kubernetes adds this finalizer to
+// protect a PodGroup while Pods still reference it; KubeRay removes it before deleting or
+// unsticking an owned PodGroup. A NotFound on update means the PodGroup is already gone.
+func (k *KubernetesWASV1Alpha3Scheduler) removeProtectionFinalizer(ctx context.Context, podGroup *schedulingv1alpha3.PodGroup) (bool, error) {
+	if !controllerutil.RemoveFinalizer(podGroup, podGroupProtectionFinalizer) {
+		return false, nil
+	}
+	if err := k.cli.Update(ctx, podGroup); err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to remove finalizer from PodGroup %s/%s: %w", podGroup.Namespace, podGroup.Name, err)
+	}
+	return true, nil
+}
+
+// buildClusterSchedulingPolicy gang schedules the whole cluster at the gang floor.
 func buildClusterSchedulingPolicy(rayCluster *rayv1.RayCluster) schedulingv1alpha3.PodGroupSchedulingPolicy {
-	minCount := int32(1) + utils.CalculateDesiredReplicas(rayCluster)
 	return schedulingv1alpha3.PodGroupSchedulingPolicy{
-		Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: minCount},
+		Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: clusterGangMinCount(rayCluster)},
 	}
 }
 
-func (k *KubernetesWASV1Alpha3Scheduler) buildSchedulingResources(rayCluster *rayv1.RayCluster) (*schedulingv1alpha3.Workload, *schedulingv1alpha3.PodGroup, error) {
+// gangNeedsMinCountPatch reports whether the live gang policy differs from the desired
+// minCount and can be patched. A nil gang is left untouched (the builder always sets one,
+// so nil means an object we did not create or that drifted).
+func gangNeedsMinCountPatch(existing *schedulingv1alpha3.GangSchedulingPolicy, desiredMinCount int32) bool {
+	return existing != nil && existing.MinCount != desiredMinCount
+}
+
+// workloadClusterGang returns the gang policy of the single whole-cluster template, or nil.
+func workloadClusterGang(workload *schedulingv1alpha3.Workload) *schedulingv1alpha3.GangSchedulingPolicy {
+	if len(workload.Spec.PodGroupTemplates) != 1 {
+		return nil
+	}
+	return workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang
+}
+
+// patchGangMinCount patches gang.minCount on a live Workload or PodGroup in place. The caller
+// supplies the object's gang pointer, already confirmed non-nil and differing from desired.
+func (k *KubernetesWASV1Alpha3Scheduler) patchGangMinCount(ctx context.Context, kind string, obj client.Object, gang *schedulingv1alpha3.GangSchedulingPolicy, desiredMinCount int32) error {
+	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
+	gang.MinCount = desiredMinCount
+	if err := k.cli.Patch(ctx, obj, patch); err != nil {
+		return fmt.Errorf("failed to patch %s %s/%s minCount: %w", kind, obj.GetNamespace(), obj.GetName(), err)
+	}
+	return nil
+}
+
+// clusterGangMinCount is the whole-cluster gang floor: the full desired size
+// (1 head + all desired workers) normally, or 1 head + minReplicas when the Ray
+// autoscaler is enabled so it can grow above the floor without deadlocking the gang.
+func clusterGangMinCount(rayCluster *rayv1.RayCluster) int32 {
+	if utils.IsAutoscalingEnabled(&rayCluster.Spec) {
+		return int32(1) + utils.CalculateMinReplicas(rayCluster)
+	}
+	return int32(1) + utils.CalculateDesiredReplicas(rayCluster)
+}
+
+func (k *KubernetesWASV1Alpha3Scheduler) buildSchedulingResources(ctx context.Context, rayCluster *rayv1.RayCluster) (*schedulingv1alpha3.Workload, *schedulingv1alpha3.PodGroup, error) {
 	policy := buildClusterSchedulingPolicy(rayCluster)
+	priorityClassName, preemption, err := k.resolveGangPriority(ctx, rayCluster)
+	if err != nil {
+		return nil, nil, err
+	}
 	workload := &schedulingv1alpha3.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rayCluster.Name,
@@ -256,8 +286,10 @@ func (k *KubernetesWASV1Alpha3Scheduler) buildSchedulingResources(rayCluster *ra
 				Name:     rayCluster.Name,
 			},
 			PodGroupTemplates: []schedulingv1alpha3.PodGroupTemplate{{
-				Name:             clusterPodGroupTemplateName,
-				SchedulingPolicy: policy,
+				Name:              clusterPodGroupTemplateName,
+				PriorityClassName: priorityClassName,
+				SchedulingPolicy:  policy,
+				PreemptionPolicy:  preemption,
 			}},
 		},
 	}
@@ -274,7 +306,9 @@ func (k *KubernetesWASV1Alpha3Scheduler) buildSchedulingResources(rayCluster *ra
 				WorkloadName: rayCluster.Name,
 				TemplateName: clusterPodGroupTemplateName,
 			},
-			SchedulingPolicy: policy,
+			PriorityClassName: priorityClassName,
+			SchedulingPolicy:  policy,
+			PreemptionPolicy:  preemption,
 		},
 	}
 
@@ -286,6 +320,9 @@ func (k *KubernetesWASV1Alpha3Scheduler) buildSchedulingResources(rayCluster *ra
 	return workload, podGroup, nil
 }
 
+// deleteSchedulingResources tears down the owned PodGroup before the Workload (dependency
+// order). While teardown is in progress it returns a non-nil error so the caller requeues;
+// the bool reports whether anything was actually deleted on this pass.
 func (k *KubernetesWASV1Alpha3Scheduler) deleteSchedulingResources(ctx context.Context, rayCluster *rayv1.RayCluster) (bool, error) {
 	podGroup := &schedulingv1alpha3.PodGroup{}
 	podGroupKey := client.ObjectKey{Name: clusterPodGroupName(rayCluster.Name), Namespace: rayCluster.Namespace}
@@ -351,22 +388,37 @@ func schedulingSkipReason(rayCluster *rayv1.RayCluster) string {
 	if !strings.EqualFold(rayCluster.GetLabels()[utils.RayGangSchedulingEnabled], "true") {
 		return skipReasonGangSchedulingDisabled
 	}
-	// TODO: support the Ray autoscaler with workload-aware scheduling.
-	if utils.IsAutoscalingEnabled(&rayCluster.Spec) {
-		return skipReasonAutoscaling
-	}
 	return ""
 }
 
-func isWorkloadStale(existing, desired *schedulingv1alpha3.Workload) bool {
-	if len(existing.Spec.PodGroupTemplates) != 1 {
-		return true
+// resolveGangPriority reflects the RayCluster pods' PriorityClass onto the whole-cluster gang so
+// the scheduling.k8s.io priority admission controller populates the PodGroup's priority and
+// preemptionPolicy. It returns the priority class name and the preemptionPolicy that admission
+// will compute from it, or zero values when the KubernetesWASPodGroupPreemptionPolicy gate is off,
+// the pods set no priority class, or the class is absent. The PodGroup's preemptionPolicy must
+// equal the value admission derives from the class, so it is read from the class (not set freely).
+// All Ray pods must share this priority class for the gang to schedule (the scheduler requires a
+// uniform priority across the PodGroup); the head group's class is treated as authoritative.
+func (k *KubernetesWASV1Alpha3Scheduler) resolveGangPriority(ctx context.Context, rayCluster *rayv1.RayCluster) (string, *schedulingv1alpha3.PreemptionPolicy, error) {
+	if !features.Enabled(features.KubernetesWASPodGroupPreemptionPolicy) {
+		return "", nil, nil
 	}
-
-	existingTemplate := existing.Spec.PodGroupTemplates[0]
-	desiredTemplate := desired.Spec.PodGroupTemplates[0]
-	existingGang := existingTemplate.SchedulingPolicy.Gang
-	return existingTemplate.Name != desiredTemplate.Name || existingGang == nil || existingGang.MinCount != desiredTemplate.SchedulingPolicy.Gang.MinCount
+	priorityClassName := rayCluster.Spec.HeadGroupSpec.Template.Spec.PriorityClassName
+	if priorityClassName == "" {
+		return "", nil, nil
+	}
+	priorityClass := &schedulingv1.PriorityClass{}
+	if err := k.cli.Get(ctx, client.ObjectKey{Name: priorityClassName}, priorityClass); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil, nil
+		}
+		return "", nil, fmt.Errorf("failed to get PriorityClass %s: %w", priorityClassName, err)
+	}
+	policy := schedulingv1alpha3.PreemptLowerPriority
+	if priorityClass.PreemptionPolicy != nil {
+		policy = schedulingv1alpha3.PreemptionPolicy(*priorityClass.PreemptionPolicy)
+	}
+	return priorityClassName, &policy, nil
 }
 
 func clusterPodGroupName(clusterName string) string {

--- a/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha3/kubernetes_was_v1alpha3_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/kubernetes-was/v1alpha3/kubernetes_was_v1alpha3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,7 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 func TestAddMetadataToChildResourceSetsDefaultSchedulerName(t *testing.T) {
@@ -47,10 +49,8 @@ func TestName(t *testing.T) {
 
 func TestDoBatchSchedulingOnSubmissionCreatesWorkloadAndPodGroups(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
 	rayCluster := newTestRayCluster(newWorkerGroup())
+	scheduler, fakeClient := newTestScheduler(t)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.NoError(t, err)
@@ -74,39 +74,34 @@ func TestDoBatchSchedulingOnSubmissionCreatesWorkloadAndPodGroups(t *testing.T) 
 	assert.Equal(t, "cluster", clusterPodGroup.Spec.WorkloadRef.TemplateName)
 }
 
-func TestDoBatchSchedulingOnSubmissionSkipsAndCleansUpWhenAutoscalingEnabled(t *testing.T) {
+func TestDoBatchSchedulingOnSubmissionGangsFloorWhenAutoscalingEnabled(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
-	rayCluster := newTestRayCluster(newWorkerGroup())
-	existingWorkload := &schedulingv1alpha3.Workload{ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace}}
-	existingPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-cluster-cluster",
-		Namespace: rayCluster.Namespace,
-		Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
-	}}
-	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	// Autoscaling clusters are no longer skipped: they gang schedule at the floor
+	// (1 head + minReplicas) so the autoscaler can grow above the floor without
+	// deadlocking the gang. minReplicas (2) differs from the desired replicas (5).
+	rayCluster := newTestRayCluster(newAutoscalingWorkerGroup("workers", 2, 5))
 	enableAutoscaling := true
 	rayCluster.Spec.EnableInTreeAutoscaling = &enableAutoscaling
+	scheduler, fakeClient := newTestScheduler(t)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "waiting for PodGroup default/test-cluster-cluster")
-	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, &schedulingv1alpha3.Workload{}))
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, &schedulingv1alpha3.PodGroup{})
-	assert.True(t, apierrors.IsNotFound(err))
-
-	err = scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.NoError(t, err)
 
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, &schedulingv1alpha3.Workload{})
-	assert.True(t, apierrors.IsNotFound(err))
+	workload := &schedulingv1alpha3.Workload{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, workload))
+	require.Len(t, workload.Spec.PodGroupTemplates, 1)
+	require.NotNil(t, workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang)
+	// Floor MinCount = 1 head + 2 minReplicas.
+	assert.Equal(t, int32(3), workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount)
+
+	clusterPodGroup := &schedulingv1alpha3.PodGroup{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, clusterPodGroup))
+	require.NotNil(t, clusterPodGroup.Spec.SchedulingPolicy.Gang)
+	assert.Equal(t, int32(3), clusterPodGroup.Spec.SchedulingPolicy.Gang.MinCount)
 }
 
 func TestDoBatchSchedulingOnSubmissionSkipsAndCleansUpWithoutGangLabel(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	delete(rayCluster.Labels, utils.RayGangSchedulingEnabled)
 	existingWorkload := &schedulingv1alpha3.Workload{ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace}}
@@ -116,8 +111,7 @@ func TestDoBatchSchedulingOnSubmissionSkipsAndCleansUpWithoutGangLabel(t *testin
 		Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
 	}}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.Error(t, err)
@@ -135,13 +129,11 @@ func TestDoBatchSchedulingOnSubmissionSkipsAndCleansUpWithoutGangLabel(t *testin
 
 func TestDoBatchSchedulingOnSubmissionAllowsManyWorkerGroups(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
 	// The single whole-cluster PodGroup uses only one of the 8 template slots, so
 	// there is no longer a cap on the number of worker groups.
 	workerGroupCount := schedulingv1alpha3.WorkloadMaxPodGroupTemplates + 2
 	rayCluster := newTestRayCluster(newWorkerGroups(workerGroupCount)...)
+	scheduler, fakeClient := newTestScheduler(t)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.NoError(t, err)
@@ -167,16 +159,12 @@ func TestAddMetadataToChildResourceSetsSchedulingGroup(t *testing.T) {
 	// Both head and worker pods reference the single whole-cluster PodGroup.
 	headPod := &corev1.Pod{}
 	scheduler.AddMetadataToChildResource(context.Background(), rayCluster, headPod, utils.RayNodeHeadGroupLabelValue)
-	require.NotNil(t, headPod.Spec.SchedulingGroup)
-	require.NotNil(t, headPod.Spec.SchedulingGroup.PodGroupName)
-	assert.Equal(t, "test-cluster-cluster", *headPod.Spec.SchedulingGroup.PodGroupName)
+	assertPodGroupMembership(t, headPod, "test-cluster-cluster")
 	assert.Equal(t, corev1.DefaultSchedulerName, headPod.Spec.SchedulerName)
 
 	workerPod := &corev1.Pod{}
 	scheduler.AddMetadataToChildResource(context.Background(), rayCluster, workerPod, "workers")
-	require.NotNil(t, workerPod.Spec.SchedulingGroup)
-	require.NotNil(t, workerPod.Spec.SchedulingGroup.PodGroupName)
-	assert.Equal(t, "test-cluster-cluster", *workerPod.Spec.SchedulingGroup.PodGroupName)
+	assertPodGroupMembership(t, workerPod, "test-cluster-cluster")
 }
 
 func TestAddMetadataToChildResourceSetsTemplateSchedulingGroup(t *testing.T) {
@@ -186,13 +174,11 @@ func TestAddMetadataToChildResourceSetsTemplateSchedulingGroup(t *testing.T) {
 	template := &corev1.PodTemplateSpec{}
 	scheduler.AddMetadataToChildResource(context.Background(), rayCluster, template, "workers")
 
-	require.NotNil(t, template.Spec.SchedulingGroup)
-	require.NotNil(t, template.Spec.SchedulingGroup.PodGroupName)
-	assert.Equal(t, "test-cluster-cluster", *template.Spec.SchedulingGroup.PodGroupName)
+	assertPodGroupMembership(t, template, "test-cluster-cluster")
 	assert.Equal(t, corev1.DefaultSchedulerName, template.Spec.SchedulerName)
 }
 
-func TestAddMetadataToChildResourceSkipsSchedulingGroupWhenAutoscalingEnabled(t *testing.T) {
+func TestAddMetadataToChildResourceSetsSchedulingGroupWhenAutoscalingEnabled(t *testing.T) {
 	scheduler := &KubernetesWASV1Alpha3Scheduler{}
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	enableAutoscaling := true
@@ -201,14 +187,14 @@ func TestAddMetadataToChildResourceSkipsSchedulingGroupWhenAutoscalingEnabled(t 
 	pod := &corev1.Pod{}
 	scheduler.AddMetadataToChildResource(context.Background(), rayCluster, pod, "workers")
 
-	// Skipped clusters are left untouched: no scheduling group and no forced scheduler name.
-	assert.Nil(t, pod.Spec.SchedulingGroup)
-	assert.Empty(t, pod.Spec.SchedulerName)
+	// Autoscaling clusters are gang scheduled at the floor, so their pods still join
+	// the whole-cluster PodGroup and get the default scheduler name.
+	assertPodGroupMembership(t, pod, "test-cluster-cluster")
+	assert.Equal(t, corev1.DefaultSchedulerName, pod.Spec.SchedulerName)
 }
 
 func TestCleanupOnCompletionDeletesSchedulingResourcesInDependencyOrder(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	existingWorkload := &schedulingv1alpha3.Workload{ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace}}
 	existingPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{
@@ -217,8 +203,7 @@ func TestCleanupOnCompletionDeletesSchedulingResourcesInDependencyOrder(t *testi
 		Finalizers: []string{podGroupProtectionFinalizer},
 	}}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
 	didCleanup, err := scheduler.CleanupOnCompletion(ctx, rayCluster)
 	require.Error(t, err)
@@ -239,7 +224,6 @@ func TestCleanupOnCompletionDeletesSchedulingResourcesInDependencyOrder(t *testi
 
 func TestCleanupOnCompletionSkipsForeignPodGroupAndDeletesOwnedWorkload(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster.Name = "foreign-cluster"
@@ -252,8 +236,7 @@ func TestCleanupOnCompletionSkipsForeignPodGroupAndDeletesOwnedWorkload(t *testi
 	}}
 	setRayClusterControllerReference(rayCluster, ownedWorkload)
 	setRayClusterControllerReference(foreignRayCluster, foreignPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(ownedWorkload, foreignPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, ownedWorkload, foreignPodGroup)
 
 	didCleanup, err := scheduler.CleanupOnCompletion(ctx, rayCluster)
 	require.NoError(t, err)
@@ -269,7 +252,6 @@ func TestCleanupOnCompletionSkipsForeignPodGroupAndDeletesOwnedWorkload(t *testi
 
 func TestCleanupOnCompletionSkipsForeignWorkloadAndDeletesOwnedPodGroup(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster.Name = "foreign-cluster"
@@ -282,8 +264,7 @@ func TestCleanupOnCompletionSkipsForeignWorkloadAndDeletesOwnedPodGroup(t *testi
 	}}
 	setRayClusterControllerReference(foreignRayCluster, foreignWorkload)
 	setRayClusterControllerReference(rayCluster, ownedPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(foreignWorkload, ownedPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, foreignWorkload, ownedPodGroup)
 
 	// The owned PodGroup is deleted first, so cleanup reports it is waiting for the
 	// deletion to finish; the same-named foreign Workload is left untouched.
@@ -299,7 +280,6 @@ func TestCleanupOnCompletionSkipsForeignWorkloadAndDeletesOwnedPodGroup(t *testi
 
 func TestCleanupOnCompletionWaitsForPodGroupsBeforeDeletingWorkload(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	existingWorkload := &schedulingv1alpha3.Workload{ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace}}
 	existingPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{
@@ -309,8 +289,7 @@ func TestCleanupOnCompletionWaitsForPodGroupsBeforeDeletingWorkload(t *testing.T
 		Finalizers: []string{podGroupProtectionFinalizer, "example.com/retain"},
 	}}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
 	didCleanup, err := scheduler.CleanupOnCompletion(ctx, rayCluster)
 	require.Error(t, err)
@@ -329,9 +308,7 @@ func TestCleanupOnCompletionWaitsForPodGroupsBeforeDeletingWorkload(t *testing.T
 
 func TestCleanupOnCompletionNotFoundIsNoop(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, _ := newTestScheduler(t)
 
 	didCleanup, err := scheduler.CleanupOnCompletion(ctx, newTestRayCluster(newWorkerGroup()))
 
@@ -341,7 +318,6 @@ func TestCleanupOnCompletionNotFoundIsNoop(t *testing.T) {
 
 func TestSyncSchedulingResourcesRejectsForeignSameNameWorkload(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster.Name = "foreign-cluster"
@@ -354,8 +330,7 @@ func TestSyncSchedulingResourcesRejectsForeignSameNameWorkload(t *testing.T) {
 		}},
 	}
 	setRayClusterControllerReference(foreignRayCluster, foreignWorkload)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(foreignWorkload).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, foreignWorkload)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.Error(t, err)
@@ -370,7 +345,6 @@ func TestSyncSchedulingResourcesRejectsForeignSameNameWorkload(t *testing.T) {
 
 func TestSyncSchedulingResourcesRejectsForeignSameNamePodGroup(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster := newTestRayCluster(newWorkerGroup())
 	foreignRayCluster.Name = "foreign-cluster"
@@ -392,8 +366,7 @@ func TestSyncSchedulingResourcesRejectsForeignSameNamePodGroup(t *testing.T) {
 	}
 	setRayClusterControllerReference(rayCluster, existingWorkload)
 	setRayClusterControllerReference(foreignRayCluster, foreignPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, foreignPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, foreignPodGroup)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.Error(t, err)
@@ -431,6 +404,11 @@ func TestBuildClusterSchedulingPolicy(t *testing.T) {
 			wantMinCount: 7,
 		},
 		{
+			name:         "autoscaling gangs at floor of head plus minReplicas",
+			cluster:      withAutoscaling(newTestRayCluster(newAutoscalingWorkerGroup("workers", 2, 5))),
+			wantMinCount: 3,
+		},
+		{
 			name: "suspended worker group contributes zero",
 			cluster: newTestRayCluster(rayv1.WorkerGroupSpec{
 				GroupName:   "workers",
@@ -454,60 +432,54 @@ func TestBuildClusterSchedulingPolicy(t *testing.T) {
 	}
 }
 
-func TestSyncSchedulingResourcesReplacesStaleResourcesAcrossReconciles(t *testing.T) {
+func TestSyncSchedulingResourcesPatchesStaleResourcesInPlace(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroupWithReplicas("workers", 5))
 	existingWorkload := &schedulingv1alpha3.Workload{
-		ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace, UID: types.UID("stale-workload-uid")},
 		Spec: schedulingv1alpha3.WorkloadSpec{PodGroupTemplates: []schedulingv1alpha3.PodGroupTemplate{
 			{Name: "cluster", SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: 4}}},
 		}},
 	}
-	existingPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{
-		Name:      "test-cluster-cluster",
-		Namespace: rayCluster.Namespace,
-		Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
-	}}
+	existingPodGroup := &schedulingv1alpha3.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-cluster",
+			Namespace: rayCluster.Namespace,
+			UID:       types.UID("stale-podgroup-uid"),
+			Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
+		},
+		Spec: schedulingv1alpha3.PodGroupSpec{
+			SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: 4}},
+		},
+	}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
-	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deleted PodGroup default/test-cluster-cluster before replacing stale Workload")
-	// Replacement teardown is dependency ordered: the Workload remains until its
-	// runtime PodGroup has been removed.
-	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, &schedulingv1alpha3.Workload{}))
-
-	err = scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deleted stale Workload")
-
+	// v1alpha3 gang.minCount is mutable, so a rescale patches the existing objects in
+	// place in a single reconcile without deleting or recreating them.
 	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster))
 
 	workload := &schedulingv1alpha3.Workload{}
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, workload)
-	require.NoError(t, err)
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, workload))
 	require.Len(t, workload.Spec.PodGroupTemplates, 1)
 	require.NotNil(t, workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang)
-	// MinCount = 1 head + 5 worker replicas.
+	// MinCount = 1 head + 5 worker replicas; patched in place so the UID is preserved.
 	assert.Equal(t, int32(6), workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount)
+	assert.Equal(t, existingWorkload.UID, workload.UID)
 
 	podGroup := &schedulingv1alpha3.PodGroup{}
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, podGroup)
-	require.NoError(t, err)
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, podGroup))
 	require.NotNil(t, podGroup.Spec.SchedulingPolicy.Gang)
 	assert.Equal(t, int32(6), podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+	assert.Equal(t, existingPodGroup.UID, podGroup.UID)
 }
 
-func TestSyncSchedulingResourcesRecreatesStalePodGroup(t *testing.T) {
+func TestSyncSchedulingResourcesPatchesStalePodGroupInPlace(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup()) // 3 replicas -> desired MinCount 4
 
 	// The Workload matches the desired spec (not stale), but the PodGroup drifted
-	// to an old MinCount. The stale PodGroup must be deleted and recreated.
+	// to an old MinCount. The stale PodGroup must be patched in place.
 	existingWorkload := &schedulingv1alpha3.Workload{
 		ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace},
 		Spec: schedulingv1alpha3.WorkloadSpec{PodGroupTemplates: []schedulingv1alpha3.PodGroupTemplate{
@@ -518,6 +490,7 @@ func TestSyncSchedulingResourcesRecreatesStalePodGroup(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster-cluster",
 			Namespace: rayCluster.Namespace,
+			UID:       types.UID("stale-podgroup-uid"),
 			Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
 		},
 		Spec: schedulingv1alpha3.PodGroupSpec{
@@ -525,23 +498,19 @@ func TestSyncSchedulingResourcesRecreatesStalePodGroup(t *testing.T) {
 		},
 	}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
-	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deleted stale PodGroup")
 	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster))
 
 	podGroup := &schedulingv1alpha3.PodGroup{}
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, podGroup)
-	require.NoError(t, err)
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster-cluster", Namespace: rayCluster.Namespace}, podGroup))
 	require.NotNil(t, podGroup.Spec.SchedulingPolicy.Gang)
-	// MinCount = 1 head + 3 worker replicas.
+	// MinCount = 1 head + 3 worker replicas; patched in place so the UID is preserved.
 	assert.Equal(t, int32(4), podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+	assert.Equal(t, existingPodGroup.UID, podGroup.UID)
 }
 
-func TestSyncPodGroupDeleteUsesUIDPreconditionAndDefersRecreation(t *testing.T) {
+func TestSyncPodGroupPatchesInPlaceWithoutDeleting(t *testing.T) {
 	ctx := context.Background()
 	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
@@ -572,41 +541,32 @@ func TestSyncPodGroupDeleteUsesUIDPreconditionAndDefersRecreation(t *testing.T) 
 		WithScheme(scheme).
 		WithObjects(existingWorkload, existingPodGroup).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Delete: func(_ context.Context, _ client.WithWatch, object client.Object, options ...client.DeleteOption) error {
-				podGroup, ok := object.(*schedulingv1alpha3.PodGroup)
-				require.True(t, ok)
-				deleteOptions := (&client.DeleteOptions{}).ApplyOptions(options)
-				require.NotNil(t, deleteOptions.Preconditions)
-				require.NotNil(t, deleteOptions.Preconditions.UID)
-				assert.Equal(t, podGroup.UID, *deleteOptions.Preconditions.UID)
+			Delete: func(ctx context.Context, cli client.WithWatch, object client.Object, options ...client.DeleteOption) error {
 				deleteCalled = true
-				// Simulate an API server that accepted Delete but has not removed the
-				// object yet. Reconciliation must not create its replacement now.
-				return nil
+				return cli.Delete(ctx, object, options...)
 			},
 		}).
 		Build()
 	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
 
-	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deleted stale PodGroup")
-	assert.True(t, deleteCalled)
+	// A rescale mutates gang.minCount in place. The PodGroup must not be deleted, and
+	// its UID and unrelated finalizers must survive.
+	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster))
+	assert.False(t, deleteCalled, "PodGroup should be patched in place, never deleted, on a rescale")
 
 	podGroup := &schedulingv1alpha3.PodGroup{}
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: existingPodGroup.Name, Namespace: existingPodGroup.Namespace}, podGroup))
 	require.NotNil(t, podGroup.Spec.SchedulingPolicy.Gang)
-	assert.Equal(t, desiredPolicy.Gang.MinCount-1, podGroup.Spec.SchedulingPolicy.Gang.MinCount)
-	assert.NotContains(t, podGroup.Finalizers, podGroupProtectionFinalizer)
+	assert.Equal(t, desiredPolicy.Gang.MinCount, podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+	assert.Equal(t, existingPodGroup.UID, podGroup.UID)
+	assert.Contains(t, podGroup.Finalizers, podGroupProtectionFinalizer)
 	assert.Contains(t, podGroup.Finalizers, "example.com/retain")
 }
 
 func TestDoBatchSchedulingOnSubmissionIsIdempotentWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
 	rayCluster := newTestRayCluster(newWorkerGroup())
+	scheduler, fakeClient := newTestScheduler(t)
 
 	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster))
 
@@ -634,7 +594,6 @@ func TestDoBatchSchedulingOnSubmissionIsIdempotentWhenUnchanged(t *testing.T) {
 
 func TestSyncSchedulingResourcesRemovesProtectionFinalizerWhenPodGroupBeingDeleted(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 
 	// A non-stale Workload already exists so reconciliation proceeds to the PodGroup.
@@ -657,8 +616,7 @@ func TestSyncSchedulingResourcesRemovesProtectionFinalizerWhenPodGroupBeingDelet
 		DeletionTimestamp: &deletionTime,
 	}}
 	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload, existingPodGroup).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload, existingPodGroup)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.Error(t, err)
@@ -673,7 +631,6 @@ func TestSyncSchedulingResourcesRemovesProtectionFinalizerWhenPodGroupBeingDelet
 
 func TestSyncSchedulingResourcesRetriesWhenWorkloadBeingDeleted(t *testing.T) {
 	ctx := context.Background()
-	scheme := newTestScheme(t)
 	rayCluster := newTestRayCluster(newWorkerGroup())
 
 	// A non-stale Workload exists but is mid-deletion. The scheduler must not proceed
@@ -692,8 +649,7 @@ func TestSyncSchedulingResourcesRetriesWhenWorkloadBeingDeleted(t *testing.T) {
 		}},
 	}
 	setRayClusterControllerReference(rayCluster, existingWorkload)
-	fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).WithObjects(existingWorkload).Build()
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}
+	scheduler, fakeClient := newTestScheduler(t, existingWorkload)
 
 	err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster)
 	require.Error(t, err)
@@ -705,33 +661,133 @@ func TestSyncSchedulingResourcesRetriesWhenWorkloadBeingDeleted(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(getErr))
 }
 
-func TestIsWorkloadStale(t *testing.T) {
-	baseCluster := newTestRayCluster(newWorkerGroupWithReplicas("workers", 3))
-	scheduler := &KubernetesWASV1Alpha3Scheduler{cli: clientFake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()}
-	baseWorkload, _, err := scheduler.buildSchedulingResources(baseCluster)
+func TestResolveGangPriorityGateDisabled(t *testing.T) {
+	// With the gate off the pods' PriorityClass is not reflected onto the gang.
+	scheduler, _ := newTestScheduler(t, newPriorityClass("never-pc", corev1.PreemptNever))
+	rayCluster := newTestRayCluster(newWorkerGroup())
+	rayCluster.Spec.HeadGroupSpec.Template.Spec.PriorityClassName = "never-pc"
+
+	name, policy, err := scheduler.resolveGangPriority(context.Background(), rayCluster)
 	require.NoError(t, err)
+	assert.Empty(t, name)
+	assert.Nil(t, policy)
+}
+
+func TestResolveGangPriority(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KubernetesWASPodGroupPreemptionPolicy, true)
 
 	tests := []struct {
-		name      string
-		workload  *schedulingv1alpha3.Workload
-		cluster   *rayv1.RayCluster
-		wantStale bool
+		name              string
+		priorityClassName string
+		priorityClass     *schedulingv1.PriorityClass
+		wantName          string
+		wantPolicy        *schedulingv1alpha3.PreemptionPolicy
 	}{
-		{name: "no change", workload: baseWorkload.DeepCopy(), cluster: baseCluster, wantStale: false},
-		{name: "worker group added", workload: baseWorkload.DeepCopy(), cluster: newTestRayCluster(newWorkerGroupWithReplicas("workers", 3), newWorkerGroupWithReplicas("gpu", 1)), wantStale: true},
-		{name: "worker group removed", workload: baseWorkload.DeepCopy(), cluster: newTestRayCluster(), wantStale: true},
-		{name: "worker group renamed with same total replicas is not stale", workload: baseWorkload.DeepCopy(), cluster: newTestRayCluster(newWorkerGroupWithReplicas("renamed", 3)), wantStale: false},
-		{name: "replica count changed", workload: baseWorkload.DeepCopy(), cluster: newTestRayCluster(newWorkerGroupWithReplicas("workers", 5)), wantStale: true},
-		{name: "num hosts changed", workload: baseWorkload.DeepCopy(), cluster: newTestRayCluster(workerGroupWithNumOfHosts("workers", 3, 2)), wantStale: true},
+		{name: "no priority class on pods", priorityClassName: "", wantName: "", wantPolicy: nil},
+		{name: "never class", priorityClassName: "never-pc", priorityClass: newPriorityClass("never-pc", corev1.PreemptNever), wantName: "never-pc", wantPolicy: ptrPreemptionPolicy(schedulingv1alpha3.PreemptNever)},
+		{name: "preempt-lower class", priorityClassName: "low-pc", priorityClass: newPriorityClass("low-pc", corev1.PreemptLowerPriority), wantName: "low-pc", wantPolicy: ptrPreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority)},
+		{name: "class without preemptionPolicy defaults to PreemptLowerPriority", priorityClassName: "bare-pc", priorityClass: &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "bare-pc"}, Value: 1000}, wantName: "bare-pc", wantPolicy: ptrPreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority)},
+		{name: "missing class is ignored", priorityClassName: "ghost-pc", priorityClass: nil, wantName: "", wantPolicy: nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			desired, _, err := scheduler.buildSchedulingResources(tt.cluster)
+			var objects []client.Object
+			if tt.priorityClass != nil {
+				objects = append(objects, tt.priorityClass)
+			}
+			scheduler, _ := newTestScheduler(t, objects...)
+			rayCluster := newTestRayCluster(newWorkerGroup())
+			rayCluster.Spec.HeadGroupSpec.Template.Spec.PriorityClassName = tt.priorityClassName
+
+			name, policy, err := scheduler.resolveGangPriority(context.Background(), rayCluster)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantStale, isWorkloadStale(tt.workload, desired))
+			assert.Equal(t, tt.wantName, name)
+			if tt.wantPolicy == nil {
+				assert.Nil(t, policy)
+				return
+			}
+			require.NotNil(t, policy)
+			assert.Equal(t, *tt.wantPolicy, *policy)
 		})
 	}
+}
+
+func TestBuildSchedulingResourcesReflectsPriorityClass(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KubernetesWASPodGroupPreemptionPolicy, true)
+	scheduler, _ := newTestScheduler(t, newPriorityClass("never-pc", corev1.PreemptNever))
+	rayCluster := newTestRayCluster(newWorkerGroup())
+	rayCluster.Spec.HeadGroupSpec.Template.Spec.PriorityClassName = "never-pc"
+
+	workload, podGroup, err := scheduler.buildSchedulingResources(context.Background(), rayCluster)
+	require.NoError(t, err)
+	require.Len(t, workload.Spec.PodGroupTemplates, 1)
+	assert.Equal(t, "never-pc", workload.Spec.PodGroupTemplates[0].PriorityClassName)
+	require.NotNil(t, workload.Spec.PodGroupTemplates[0].PreemptionPolicy)
+	assert.Equal(t, schedulingv1alpha3.PreemptNever, *workload.Spec.PodGroupTemplates[0].PreemptionPolicy)
+	assert.Equal(t, "never-pc", podGroup.Spec.PriorityClassName)
+	require.NotNil(t, podGroup.Spec.PreemptionPolicy)
+	assert.Equal(t, schedulingv1alpha3.PreemptNever, *podGroup.Spec.PreemptionPolicy)
+}
+
+// TestSyncPreservesPriorityFieldsOnRescale locks in that a rescale patches only gang.minCount and
+// leaves the immutable priorityClassName/preemptionPolicy untouched.
+func TestSyncPreservesPriorityFieldsOnRescale(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KubernetesWASPodGroupPreemptionPolicy, true)
+	ctx := context.Background()
+	rayCluster := newTestRayCluster(newWorkerGroupWithReplicas("workers", 5)) // desired MinCount 6
+	rayCluster.Spec.HeadGroupSpec.Template.Spec.PriorityClassName = "never-pc"
+	livePolicy := schedulingv1alpha3.PreemptNever
+	existingWorkload := &schedulingv1alpha3.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: rayCluster.Name, Namespace: rayCluster.Namespace},
+		Spec: schedulingv1alpha3.WorkloadSpec{PodGroupTemplates: []schedulingv1alpha3.PodGroupTemplate{
+			{Name: clusterPodGroupTemplateName, PriorityClassName: "never-pc", PreemptionPolicy: &livePolicy, SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: 4}}},
+		}},
+	}
+	existingPodGroup := &schedulingv1alpha3.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterPodGroupName(rayCluster.Name),
+			Namespace: rayCluster.Namespace,
+			Labels:    map[string]string{utils.RayClusterLabelKey: rayCluster.Name},
+		},
+		Spec: schedulingv1alpha3.PodGroupSpec{
+			PriorityClassName: "never-pc",
+			PreemptionPolicy:  &livePolicy,
+			SchedulingPolicy:  schedulingv1alpha3.PodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: 4}},
+		},
+	}
+	setRayClusterControllerReference(rayCluster, existingWorkload, existingPodGroup)
+	scheduler, fakeClient := newTestScheduler(t, newPriorityClass("never-pc", corev1.PreemptNever), existingWorkload, existingPodGroup)
+
+	require.NoError(t, scheduler.DoBatchSchedulingOnSubmission(ctx, rayCluster))
+
+	workload := &schedulingv1alpha3.Workload{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, workload))
+	require.Len(t, workload.Spec.PodGroupTemplates, 1)
+	require.NotNil(t, workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang)
+	assert.Equal(t, int32(6), workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount)
+	require.NotNil(t, workload.Spec.PodGroupTemplates[0].PreemptionPolicy)
+	assert.Equal(t, schedulingv1alpha3.PreemptNever, *workload.Spec.PodGroupTemplates[0].PreemptionPolicy)
+
+	podGroup := &schedulingv1alpha3.PodGroup{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: clusterPodGroupName(rayCluster.Name), Namespace: rayCluster.Namespace}, podGroup))
+	require.NotNil(t, podGroup.Spec.SchedulingPolicy.Gang)
+	assert.Equal(t, int32(6), podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+	assert.Equal(t, "never-pc", podGroup.Spec.PriorityClassName)
+	require.NotNil(t, podGroup.Spec.PreemptionPolicy)
+	assert.Equal(t, schedulingv1alpha3.PreemptNever, *podGroup.Spec.PreemptionPolicy)
+}
+
+func newPriorityClass(name string, policy corev1.PreemptionPolicy) *schedulingv1.PriorityClass {
+	return &schedulingv1.PriorityClass{
+		ObjectMeta:       metav1.ObjectMeta{Name: name},
+		Value:            1000,
+		PreemptionPolicy: &policy,
+	}
+}
+
+func ptrPreemptionPolicy(policy schedulingv1alpha3.PreemptionPolicy) *schedulingv1alpha3.PreemptionPolicy {
+	return &policy
 }
 
 func TestSchedulingV1alpha3Available(t *testing.T) {
@@ -832,8 +888,35 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, rayv1.AddToScheme(scheme))
+	require.NoError(t, schedulingv1.AddToScheme(scheme))
 	require.NoError(t, schedulingv1alpha3.AddToScheme(scheme))
 	return scheme
+}
+
+// newTestScheduler builds a scheduler backed by a fake client seeded with objects, returning
+// both so tests can assert against the client. Tests needing interceptors build the client inline.
+func newTestScheduler(t *testing.T, objects ...client.Object) (*KubernetesWASV1Alpha3Scheduler, client.Client) {
+	t.Helper()
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(objects...).Build()
+	return &KubernetesWASV1Alpha3Scheduler{cli: fakeClient}, fakeClient
+}
+
+// assertPodGroupMembership asserts that a pod or pod template carries the whole-cluster
+// scheduling group.
+func assertPodGroupMembership(t *testing.T, obj metav1.Object, expectedPodGroupName string) {
+	t.Helper()
+	var schedulingGroup *corev1.PodSchedulingGroup
+	switch o := obj.(type) {
+	case *corev1.Pod:
+		schedulingGroup = o.Spec.SchedulingGroup
+	case *corev1.PodTemplateSpec:
+		schedulingGroup = o.Spec.SchedulingGroup
+	default:
+		t.Fatalf("unsupported object type %T", obj)
+	}
+	require.NotNil(t, schedulingGroup)
+	require.NotNil(t, schedulingGroup.PodGroupName)
+	assert.Equal(t, expectedPodGroupName, *schedulingGroup.PodGroupName)
 }
 
 func TestSchedulingSkippedWhenGangSchedulingDisabled(t *testing.T) {
@@ -900,6 +983,20 @@ func workerGroupWithNumOfHosts(groupName string, replicas int32, numOfHosts int3
 	workerGroup := newWorkerGroupWithReplicas(groupName, replicas)
 	workerGroup.NumOfHosts = numOfHosts
 	return workerGroup
+}
+
+func newAutoscalingWorkerGroup(groupName string, minReplicas, replicas int32) rayv1.WorkerGroupSpec {
+	workerGroup := newWorkerGroupWithReplicas(groupName, replicas)
+	maxReplicas := replicas
+	workerGroup.MinReplicas = &minReplicas
+	workerGroup.MaxReplicas = &maxReplicas
+	return workerGroup
+}
+
+func withAutoscaling(rayCluster *rayv1.RayCluster) *rayv1.RayCluster {
+	enable := true
+	rayCluster.Spec.EnableInTreeAutoscaling = &enable
+	return rayCluster
 }
 
 func newWorkerGroups(count int) []rayv1.WorkerGroupSpec {

--- a/ray-operator/hack/kind-config-kubernetes-was-v1alpha3.yml
+++ b/ray-operator/hack/kind-config-kubernetes-was-v1alpha3.yml
@@ -14,14 +14,16 @@ nodes:
     kind: ClusterConfiguration
     apiServer:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        # GenericWorkload serves the Workload/PodGroup APIs; PodGroupPreemptionPolicy
+        # lets the apiserver persist the gated PodGroup/Workload preemptionPolicy field.
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"
         runtime-config: "scheduling.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha3=true"
       certSANs:
         - "127.0.0.1"
         - "docker"
     controllerManager:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"
     scheduler:
       extraArgs:
-        feature-gates: "GenericWorkload=true"
+        feature-gates: "GenericWorkload=true,PodGroupPreemptionPolicy=true"

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -187,6 +187,7 @@ func main() {
 		exitOnError(err, "Unable to set flag gates for known features")
 	}
 	features.LogFeatureGates(setupLog)
+	warnOnKubernetesWASCapabilityGates()
 
 	// validate the batch scheduler configs,
 	// exit with error if the configs is invalid.
@@ -401,6 +402,13 @@ func exitOnError(err error, msg string, keysAndValues ...any) {
 	if err != nil {
 		setupLog.Error(err, msg, keysAndValues...)
 		os.Exit(1)
+	}
+}
+
+// warnOnKubernetesWASCapabilityGates warns when a WAS gate needs a cluster capability KubeRay does not probe.
+func warnOnKubernetesWASCapabilityGates() {
+	if features.Enabled(features.KubernetesWASPodGroupPreemptionPolicy) {
+		setupLog.Info("WARNING: KubernetesWASPodGroupPreemptionPolicy requires Kubernetes v1.37+ with the PodGroupPreemptionPolicy feature gate enabled; otherwise the preemptionPolicy field is silently ignored")
 	}
 }
 

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -96,6 +96,17 @@ const (
 	// selects the scheduler; it is mutually exclusive with --batch-scheduler and --enable-batch-scheduler.
 	// Requires a Kubernetes cluster that serves the scheduling.k8s.io API with GenericWorkload enabled.
 	KubernetesWAS featuregate.Feature = "KubernetesWAS"
+
+	// owner: @marosset
+	// rep: N/A
+	// alpha: v1.8
+	//
+	// Enables the gang preemption policy for the Kubernetes WAS scheduler: the RayCluster pods'
+	// PriorityClass is reflected onto the whole-cluster PodGroup (priorityClassName + preemptionPolicy)
+	// so the scheduling.k8s.io priority admission controller populates the PodGroup's preemptionPolicy.
+	// Requires the KubernetesWAS gate, Kubernetes v1.37+ serving scheduling.k8s.io/v1alpha3, AND the
+	// clusters PodGroupPreemptionPolicy feature gate enabled.
+	KubernetesWASPodGroupPreemptionPolicy featuregate.Feature = "KubernetesWASPodGroupPreemptionPolicy"
 )
 
 func init() {
@@ -103,17 +114,18 @@ func init() {
 }
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	RayClusterStatusConditions:       {Default: true, PreRelease: featuregate.Beta},
-	RayJobDeletionPolicy:             {Default: true, PreRelease: featuregate.Beta},
-	RayMultiHostIndexing:             {Default: true, PreRelease: featuregate.Beta},
-	RayServiceIncrementalUpgrade:     {Default: true, PreRelease: featuregate.Beta},
-	RayCronJob:                       {Default: false, PreRelease: featuregate.Alpha},
-	SidecarSubmitterRestart:          {Default: false, PreRelease: featuregate.Alpha},
-	RayClusterNetworkPolicy:          {Default: false, PreRelease: featuregate.Alpha},
-	GCSFaultToleranceEmbeddedStorage: {Default: false, PreRelease: featuregate.Alpha},
-	RayClusterMTLS:                   {Default: false, PreRelease: featuregate.Alpha},
-	RayClusterHistoryServer:          {Default: false, PreRelease: featuregate.Alpha},
-	KubernetesWAS:                    {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterStatusConditions:            {Default: true, PreRelease: featuregate.Beta},
+	RayJobDeletionPolicy:                  {Default: true, PreRelease: featuregate.Beta},
+	RayMultiHostIndexing:                  {Default: true, PreRelease: featuregate.Beta},
+	RayServiceIncrementalUpgrade:          {Default: true, PreRelease: featuregate.Beta},
+	RayCronJob:                            {Default: false, PreRelease: featuregate.Alpha},
+	SidecarSubmitterRestart:               {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterNetworkPolicy:               {Default: false, PreRelease: featuregate.Alpha},
+	GCSFaultToleranceEmbeddedStorage:      {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterMTLS:                        {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterHistoryServer:               {Default: false, PreRelease: featuregate.Alpha},
+	KubernetesWAS:                         {Default: false, PreRelease: featuregate.Alpha},
+	KubernetesWASPodGroupPreemptionPolicy: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest is a helper method to override feature gates in tests.

--- a/ray-operator/test/e2ekuberneteswas/kubernetes_was_v1alpha3_test.go
+++ b/ray-operator/test/e2ekuberneteswas/kubernetes_was_v1alpha3_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -25,6 +26,15 @@ import (
 func newWASRayClusterAC(name, namespace string) *rayv1ac.RayClusterApplyConfiguration {
 	return rayv1ac.RayCluster(name, namespace).
 		WithLabels(map[string]string{utils.RayGangSchedulingEnabled: "true"})
+}
+
+// expectClusterPodGroupMembership asserts every pod joins the whole-cluster PodGroup.
+func expectClusterPodGroupMembership(g Gomega, pods []corev1.Pod, clusterName string) {
+	for _, pod := range pods {
+		g.Expect(pod.Spec.SchedulingGroup).NotTo(BeNil(), "pod %s missing schedulingGroup", pod.Name)
+		g.Expect(pod.Spec.SchedulingGroup.PodGroupName).NotTo(BeNil(), "pod %s missing podGroupName", pod.Name)
+		g.Expect(*pod.Spec.SchedulingGroup.PodGroupName).To(Equal(clusterName+"-cluster"), "pod %s has wrong podGroupName", pod.Name)
+	}
 }
 
 func TestKubernetesWAS_CreatesWorkloadAndPodGroups(t *testing.T) {
@@ -177,30 +187,104 @@ func TestKubernetesWAS_MultipleWorkerGroups(t *testing.T) {
 	}
 }
 
-func TestKubernetesWAS_AutoscalingSkipped(t *testing.T) {
+func TestKubernetesWAS_AutoscalingGangsFloor(t *testing.T) {
 	test := With(t)
 	g := NewWithT(t)
 
 	namespace := test.NewTestNamespace()
 
-	rayClusterAC := newWASRayClusterAC("autoscale-skip", namespace.Name).
-		WithSpec(NewRayClusterSpec().WithEnableInTreeAutoscaling(true))
+	// Autoscaling clusters are gang scheduled at the floor (1 head + minReplicas) so
+	// the autoscaler can grow above the floor without deadlocking the gang.
+	rayClusterAC := newWASRayClusterAC("autoscale-floor", namespace.Name).
+		WithSpec(rayv1ac.RayClusterSpec().
+			WithRayVersion(GetRayVersion()).
+			WithEnableInTreeAutoscaling(true).
+			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+				WithTemplate(HeadPodTemplateApplyConfiguration())).
+			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+				WithReplicas(1).
+				WithMinReplicas(1).
+				WithMaxReplicas(3).
+				WithGroupName("small-group").
+				WithRayStartParams(map[string]string{"num-cpus": "1"}).
+				WithTemplate(WorkerPodTemplateApplyConfiguration())))
 
 	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 	LogWithTimestamp(test.T(), "Created RayCluster %s/%s with autoscaling", rayCluster.Namespace, rayCluster.Name)
 
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to start reconciling", rayCluster.Namespace, rayCluster.Name)
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
-	_, err = GetWorkload(test, namespace.Name, rayCluster.Name)
-	g.Expect(errors.IsNotFound(err)).To(BeTrue(), "expected NotFound for Workload, got: %v", err)
+	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
+	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
+	// Floor MinCount = 1 head + 1 minReplica.
+	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount).To(Equal(int32(2)))
+
+	clusterPodGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(clusterPodGroup.Spec.SchedulingPolicy.Gang).NotTo(BeNil())
+	g.Expect(clusterPodGroup.Spec.SchedulingPolicy.Gang.MinCount).To(Equal(int32(2)))
 
 	headPod, err := GetHeadPod(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(headPod.Spec.SchedulerName).To(Equal(corev1.DefaultSchedulerName))
-	g.Expect(headPod.Spec.SchedulingGroup).To(BeNil(), "head pod should not have schedulingGroup when autoscaling is enabled")
+	g.Expect(headPod.Spec.SchedulingGroup).NotTo(BeNil(), "head pod should join the whole-cluster PodGroup when autoscaling is enabled")
+	g.Expect(headPod.Spec.SchedulingGroup.PodGroupName).NotTo(BeNil())
+	g.Expect(*headPod.Spec.SchedulingGroup.PodGroupName).To(Equal(rayCluster.Name + "-cluster"))
+}
+
+// TestKubernetesWAS_AutoscalingSchedulesAboveFloor verifies that when an autoscaling
+// cluster's desired replicas exceed minReplicas, the gang is floored at 1+minReplicas
+// (not the desired size) so the cluster still becomes ready with pods above the floor.
+func TestKubernetesWAS_AutoscalingSchedulesAboveFloor(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	// minReplicas=1 -> floor minCount=2, but 3 workers are desired (above the floor).
+	rayClusterAC := newWASRayClusterAC("autoscale-above-floor", namespace.Name).
+		WithSpec(rayv1ac.RayClusterSpec().
+			WithRayVersion(GetRayVersion()).
+			WithEnableInTreeAutoscaling(true).
+			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+				WithTemplate(HeadPodTemplateApplyConfiguration())).
+			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+				WithReplicas(3).
+				WithMinReplicas(1).
+				WithMaxReplicas(5).
+				WithGroupName("small-group").
+				WithRayStartParams(map[string]string{"num-cpus": "1"}).
+				WithTemplate(WorkerPodTemplateApplyConfiguration())))
+
+	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created autoscaling RayCluster %s/%s with 3 desired workers, minReplicas 1", rayCluster.Namespace, rayCluster.Name)
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
+	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
+	// Floor MinCount = 1 head + 1 minReplica, NOT 1 head + 3 desired replicas. The cluster
+	// reaching Ready above proves the extra pods above the floor still schedule; the exact
+	// running worker count is intentionally not asserted since the autoscaler owns it.
+	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount).To(Equal(int32(2)))
+
+	headPod, err := GetHeadPod(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod.Spec.SchedulingGroup).NotTo(BeNil())
+	g.Expect(headPod.Spec.SchedulingGroup.PodGroupName).NotTo(BeNil())
+	g.Expect(*headPod.Spec.SchedulingGroup.PodGroupName).To(Equal(rayCluster.Name + "-cluster"))
 }
 
 func TestKubernetesWAS_GangSchedules(t *testing.T) {
@@ -406,7 +490,7 @@ func TestKubernetesWAS_ResumeReusesResources(t *testing.T) {
 	g.Expect(*headPod.Spec.SchedulingGroup.PodGroupName).To(Equal(rayCluster.Name + "-cluster"))
 }
 
-func TestKubernetesWAS_ScaleUpRecreatesWorkload(t *testing.T) {
+func TestKubernetesWAS_ScaleUpPatchesWorkloadInPlace(t *testing.T) {
 	test := With(t)
 	g := NewWithT(t)
 
@@ -426,6 +510,9 @@ func TestKubernetesWAS_ScaleUpRecreatesWorkload(t *testing.T) {
 	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 	originalUID := workload.UID
+	podGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	g.Expect(err).NotTo(HaveOccurred())
+	originalPodGroupUID := podGroup.UID
 	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
 	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
 	// MinCount = 1 head + 1 worker replica.
@@ -444,11 +531,11 @@ func TestKubernetesWAS_ScaleUpRecreatesWorkload(t *testing.T) {
 		inner.Expect(RayClusterDesiredWorkerReplicas(rc)).To(Equal(int32(3)))
 	}, TestTimeoutMedium).Should(Succeed())
 
-	LogWithTimestamp(test.T(), "Verifying Workload was recreated with updated minCount")
+	LogWithTimestamp(test.T(), "Verifying the Workload minCount was patched in place (same UID)")
 	g.Eventually(func(inner Gomega) {
 		w, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 		inner.Expect(err).NotTo(HaveOccurred())
-		inner.Expect(w.UID).NotTo(Equal(originalUID), "Workload should have been recreated with a new UID")
+		inner.Expect(w.UID).To(Equal(originalUID), "Workload should be patched in place, preserving its UID")
 		inner.Expect(w.Spec.PodGroupTemplates).To(HaveLen(1))
 		inner.Expect(w.Spec.PodGroupTemplates[0].Name).To(Equal("cluster"))
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
@@ -456,17 +543,17 @@ func TestKubernetesWAS_ScaleUpRecreatesWorkload(t *testing.T) {
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount).To(Equal(int32(4)))
 	}, TestTimeoutShort).Should(Succeed())
 
-	LogWithTimestamp(test.T(), "Waiting for the whole-cluster PodGroup to be recreated with updated minCount")
-	g.Eventually(func() int32 {
-		podGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
-		if err != nil || podGroup.DeletionTimestamp != nil || podGroup.Spec.SchedulingPolicy.Gang == nil {
-			return -1
-		}
-		return podGroup.Spec.SchedulingPolicy.Gang.MinCount
-	}, TestTimeoutShort).Should(Equal(int32(4)))
+	LogWithTimestamp(test.T(), "Verifying the whole-cluster PodGroup minCount was patched in place (same UID)")
+	g.Eventually(func(inner Gomega) {
+		pg, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+		inner.Expect(err).NotTo(HaveOccurred())
+		inner.Expect(pg.UID).To(Equal(originalPodGroupUID), "PodGroup should be patched in place, preserving its UID")
+		inner.Expect(pg.Spec.SchedulingPolicy.Gang).NotTo(BeNil())
+		inner.Expect(pg.Spec.SchedulingPolicy.Gang.MinCount).To(Equal(int32(4)))
+	}, TestTimeoutShort).Should(Succeed())
 }
 
-func TestKubernetesWAS_ScaleDownRecreatesWorkload(t *testing.T) {
+func TestKubernetesWAS_ScaleDownPatchesWorkloadInPlace(t *testing.T) {
 	test := With(t)
 	g := NewWithT(t)
 
@@ -497,6 +584,9 @@ func TestKubernetesWAS_ScaleDownRecreatesWorkload(t *testing.T) {
 	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 	originalUID := workload.UID
+	podGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	g.Expect(err).NotTo(HaveOccurred())
+	originalPodGroupUID := podGroup.UID
 	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
 	g.Expect(workload.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
 	// MinCount = 1 head + 3 worker replicas.
@@ -515,11 +605,11 @@ func TestKubernetesWAS_ScaleDownRecreatesWorkload(t *testing.T) {
 		inner.Expect(RayClusterDesiredWorkerReplicas(rc)).To(Equal(int32(1)))
 	}, TestTimeoutMedium).Should(Succeed())
 
-	LogWithTimestamp(test.T(), "Verifying Workload was recreated with updated minCount")
+	LogWithTimestamp(test.T(), "Verifying the Workload minCount was patched in place (same UID)")
 	g.Eventually(func(inner Gomega) {
 		w, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 		inner.Expect(err).NotTo(HaveOccurred())
-		inner.Expect(w.UID).NotTo(Equal(originalUID), "Workload should have a new UID after scale-down")
+		inner.Expect(w.UID).To(Equal(originalUID), "Workload should be patched in place, preserving its UID")
 		inner.Expect(w.Spec.PodGroupTemplates).To(HaveLen(1))
 		inner.Expect(w.Spec.PodGroupTemplates[0].Name).To(Equal("cluster"))
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
@@ -527,17 +617,17 @@ func TestKubernetesWAS_ScaleDownRecreatesWorkload(t *testing.T) {
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount).To(Equal(int32(2)))
 	}, TestTimeoutShort).Should(Succeed())
 
-	LogWithTimestamp(test.T(), "Waiting for the whole-cluster PodGroup to be recreated with updated minCount")
-	g.Eventually(func() int32 {
-		podGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
-		if err != nil || podGroup.DeletionTimestamp != nil || podGroup.Spec.SchedulingPolicy.Gang == nil {
-			return -1
-		}
-		return podGroup.Spec.SchedulingPolicy.Gang.MinCount
-	}, TestTimeoutShort).Should(Equal(int32(2)))
+	LogWithTimestamp(test.T(), "Verifying the whole-cluster PodGroup minCount was patched in place (same UID)")
+	g.Eventually(func(inner Gomega) {
+		pg, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+		inner.Expect(err).NotTo(HaveOccurred())
+		inner.Expect(pg.UID).To(Equal(originalPodGroupUID), "PodGroup should be patched in place, preserving its UID")
+		inner.Expect(pg.Spec.SchedulingPolicy.Gang).NotTo(BeNil())
+		inner.Expect(pg.Spec.SchedulingPolicy.Gang.MinCount).To(Equal(int32(2)))
+	}, TestTimeoutShort).Should(Succeed())
 }
 
-func TestKubernetesWAS_AddWorkerGroupRecreatesWorkload(t *testing.T) {
+func TestKubernetesWAS_AddWorkerGroupPatchesWorkloadInPlace(t *testing.T) {
 	test := With(t)
 	g := NewWithT(t)
 
@@ -557,6 +647,9 @@ func TestKubernetesWAS_AddWorkerGroupRecreatesWorkload(t *testing.T) {
 	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 	originalUID := workload.UID
+	podGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	g.Expect(err).NotTo(HaveOccurred())
+	originalPodGroupUID := podGroup.UID
 	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
 
 	LogWithTimestamp(test.T(), "Adding second worker group 'gpu-group' to RayCluster")
@@ -574,11 +667,11 @@ func TestKubernetesWAS_AddWorkerGroupRecreatesWorkload(t *testing.T) {
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
-	LogWithTimestamp(test.T(), "Verifying Workload was recreated with a single whole-cluster PodGroupTemplate")
+	LogWithTimestamp(test.T(), "Verifying the Workload minCount was patched in place (same UID, single whole-cluster template)")
 	g.Eventually(func(inner Gomega) {
 		w, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 		inner.Expect(err).NotTo(HaveOccurred())
-		inner.Expect(w.UID).NotTo(Equal(originalUID), "Workload should have a new UID after adding worker group")
+		inner.Expect(w.UID).To(Equal(originalUID), "Workload should be patched in place, preserving its UID")
 		inner.Expect(w.Spec.PodGroupTemplates).To(HaveLen(1))
 		inner.Expect(w.Spec.PodGroupTemplates[0].Name).To(Equal("cluster"))
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
@@ -587,8 +680,9 @@ func TestKubernetesWAS_AddWorkerGroupRecreatesWorkload(t *testing.T) {
 	}, TestTimeoutShort).Should(Succeed())
 
 	g.Eventually(PodGroups(test, namespace.Name), TestTimeoutShort).Should(HaveLen(1))
-	_, err = GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	pg, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pg.UID).To(Equal(originalPodGroupUID), "PodGroup should be patched in place, preserving its UID")
 }
 
 // TestKubernetesWAS_GangAtomicityIncludesHead verifies that the head pod is part
@@ -798,8 +892,8 @@ func TestKubernetesWAS_ManyWorkerGroups(t *testing.T) {
 }
 
 // TestKubernetesWAS_SuspendSingleWorkerGroup verifies that suspending one worker
-// group of several recomputes the whole-cluster gang minCount and recreates the
-// Workload and PodGroup while the head and the remaining worker group keep
+// group of several recomputes the whole-cluster gang minCount and patches the
+// Workload and PodGroup in place while the head and the remaining worker group keep
 // running. Per-worker-group suspension requires the RayJobDeletionPolicy feature
 // gate, which the kubernetes-was-v1alpha3 overlay enables.
 func TestKubernetesWAS_SuspendSingleWorkerGroup(t *testing.T) {
@@ -852,11 +946,11 @@ func TestKubernetesWAS_SuspendSingleWorkerGroup(t *testing.T) {
 	_, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	LogWithTimestamp(test.T(), "Verifying the Workload was recreated with the reduced minCount")
+	LogWithTimestamp(test.T(), "Verifying the Workload minCount was patched in place with the reduced minCount")
 	g.Eventually(func(inner Gomega) {
 		w, err := GetWorkload(test, namespace.Name, rayCluster.Name)
 		inner.Expect(err).NotTo(HaveOccurred())
-		inner.Expect(w.UID).NotTo(Equal(originalWorkloadUID), "Workload should be recreated after suspend")
+		inner.Expect(w.UID).To(Equal(originalWorkloadUID), "Workload should be patched in place after suspend, preserving its UID")
 		inner.Expect(w.Spec.PodGroupTemplates).To(HaveLen(1))
 		inner.Expect(w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang).NotTo(BeNil())
 		// MinCount = 1 head + 1 (group-a); group-b is suspended and contributes 0.
@@ -1009,11 +1103,74 @@ func TestKubernetesWAS_MultiHostWorkerGroup(t *testing.T) {
 		workerPods, err := GetWorkerPods(test, rayCluster)
 		inner.Expect(err).NotTo(HaveOccurred())
 		inner.Expect(workerPods).To(HaveLen(2))
-		for _, pod := range workerPods {
-			inner.Expect(pod.Spec.SchedulingGroup).NotTo(BeNil(), "pod %s missing schedulingGroup", pod.Name)
-			inner.Expect(pod.Spec.SchedulingGroup.PodGroupName).NotTo(BeNil(), "pod %s missing podGroupName", pod.Name)
-			inner.Expect(*pod.Spec.SchedulingGroup.PodGroupName).To(Equal(rayCluster.Name+"-cluster"),
-				"pod %s has wrong podGroupName", pod.Name)
-		}
+		expectClusterPodGroupMembership(inner, workerPods, rayCluster.Name)
 	}, TestTimeoutShort).Should(Succeed())
+}
+
+// TestKubernetesWAS_PreemptionPolicyFromPriorityClass verifies that a Never PriorityClass on the
+// Ray pods is reflected onto the whole-cluster gang: KubeRay stamps priorityClassName on the
+// Workload template + PodGroup, and the scheduling.k8s.io priority admission controller populates
+// their preemptionPolicy to Never. Requires the operator's KubernetesWASPodGroupPreemptionPolicy
+// gate and the Kubernetes cluster PodGroupPreemptionPolicy feature gate (set in the kind config).
+func TestKubernetesWAS_PreemptionPolicyFromPriorityClass(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	// A cluster-scoped PriorityClass carrying preemptionPolicy=Never, used by all Ray pods.
+	preemptNever := corev1.PreemptNever
+	priorityClassName := "was-never-" + namespace.Name
+	_, err := test.Client().Core().SchedulingV1().PriorityClasses().Create(test.Ctx(), &schedulingv1.PriorityClass{
+		ObjectMeta:       metav1.ObjectMeta{Name: priorityClassName},
+		Value:            1000,
+		PreemptionPolicy: &preemptNever,
+		Description:      "WAS e2e: preemptionPolicy=Never",
+	}, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Cleanup(func() {
+		_ = test.Client().Core().SchedulingV1().PriorityClasses().Delete(test.Ctx(), priorityClassName, metav1.DeleteOptions{})
+	})
+
+	// All pods in the gang must share the PriorityClass (the scheduler requires a uniform priority).
+	headTemplate := HeadPodTemplateApplyConfiguration()
+	headTemplate.Spec.WithPriorityClassName(priorityClassName)
+	workerTemplate := WorkerPodTemplateApplyConfiguration()
+	workerTemplate.Spec.WithPriorityClassName(priorityClassName)
+
+	rayClusterAC := newWASRayClusterAC("preempt-never", namespace.Name).
+		WithSpec(rayv1ac.RayClusterSpec().
+			WithRayVersion(GetRayVersion()).
+			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+				WithTemplate(headTemplate)).
+			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+				WithReplicas(1).
+				WithMinReplicas(1).
+				WithMaxReplicas(1).
+				WithGroupName("small-group").
+				WithRayStartParams(map[string]string{"num-cpus": "1"}).
+				WithTemplate(workerTemplate)))
+
+	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayCluster %s/%s with a Never PriorityClass", rayCluster.Namespace, rayCluster.Name)
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	workload, err := GetWorkload(test, namespace.Name, rayCluster.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workload.Spec.PodGroupTemplates).To(HaveLen(1))
+	g.Expect(workload.Spec.PodGroupTemplates[0].PriorityClassName).To(Equal(priorityClassName))
+	g.Expect(workload.Spec.PodGroupTemplates[0].PreemptionPolicy).NotTo(BeNil(), "Workload template preemptionPolicy should be set")
+	g.Expect(*workload.Spec.PodGroupTemplates[0].PreemptionPolicy).To(Equal(schedulingv1alpha3.PreemptNever))
+
+	clusterPodGroup, err := GetPodGroup(test, namespace.Name, rayCluster.Name+"-cluster")
+	g.Expect(err).NotTo(HaveOccurred())
+	// The priority admission controller populated the PodGroup's preemptionPolicy from the class.
+	g.Expect(clusterPodGroup.Spec.PriorityClassName).To(Equal(priorityClassName))
+	g.Expect(clusterPodGroup.Spec.PreemptionPolicy).NotTo(BeNil(), "PodGroup preemptionPolicy should be set")
+	g.Expect(*clusterPodGroup.Spec.PreemptionPolicy).To(Equal(schedulingv1alpha3.PreemptNever))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR implements Kubernetes Workload Aware Scheduling added to the `v1alpha3` scheduling API in Kubernetes v1.37.

New functionality includes:
- Support for ray cluster autoscaling (which is now possible because PodGroup.minCount is mutable)
- PodGroupPremptionPolicy (can specify if a PodGroup can be pre-empted by workloads with a higher PriorityClass)

## Related issue number

Part of https://github.com/ray-project/kuberay/issues/4344

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [x] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

1. Start a kind cluster with required feature gates

```bash
kind create cluster --name k8s-was --config ray-operator/hack/kind-config-kubernetes-was-v1alpha3.yml
```

2. Build, load, deploy kuberay operator

```bash
cd ray-operator
IMG=kuberay/operator:v1alpha3-was make docker-image
IMG=kuberay/operator:v1alpha3-was make deploy-kubernetes-was-v1alpha3
kubectl wait --for=condition=Available=true deployment/kuberay-operator --timeout=120s
```

3. Create a `Never` PriorityClass

```bash
kubecrtl apply -f - <<'EOF'
apiversion: scheduling.k9s.io/v1
kind: PriorityClass
metadata: { name: ray-no-premption }
value: 1000
premptionPolicy:NEVER
EOF
```

4. Deploy a gang-scheduling-enabled ray cluster - start with something like `ray-operator/config/samples/ray-cluster.sample.yaml, **name it was-demo.yaml**, and add the following label and  ProirtyClass to **the head and worker** pod templates, and apply it

```yaml
metadata:
  name: was-demo
  labels: { ray.io/gang-scheduling-enabled: "true" }
spec:
  headGroupSpec:
    template: { spec:  { priorityClassName: ray-no-premption } }
  workerGroupSpecs:
    - replicas: 2
      minReplicas: 2
      template: { spec: { priorityClassName: ray-no-premption }}
```

```bash
kubectl apply -f was-demo.yaml
kubectl wait --for=jsonpath='{.status.state}'=ready raycluster/was-demo
```

5. inspect the workload and podgroup objects

```bash
 kubectl get workload,podgroup
 kubectl get pods -l ray.io/cluster=was-demo -o custom-columns=NAME:.metadata.name,GROUP:.spec.schedulingGroup.podGroupName
 ```

6. inspect the pod group's premption policy

```bash
kubectl get podgroup was-demo-cluster -o jsonpath='{.spec.priorityClassName}{" -> "}{.spec.preemptionPolicy}{"\n"}'
kubectl get workload was-demo -o jsonpath='{.spec.podGroupTemplates[0].preemptionPolicy}{"\n"}'
```

7. in-place resize the worker group

```bash
kubectl get podgroup was-demo-cluster -o jsonpath='UID={.metadata.uid} minCount={.spec.schedulingPolicy.gang.minCount}{"\n"}'
kubectl patch raycluster was-demo --type=json -p='[{"op":"replace","path":"/spec/workerGroupSpecs/0/replicas","value":3}]'
   # expect minCount=4 (1 head + 3 workers), same UID
kubectl get podgroup was-demo-cluster -o jsonpath='UID={.metadata.uid} minCount={.spec.schedulingPolicy.gang.minCount}{"\n"}'
```
  