### PR TITLE
kubectl-plugin: close log files during archive extraction

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -432,26 +432,33 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 		case tar.TypeReg:
 			// Check for overflow: G115
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
-				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
-			}
-			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // overflow is guarded by bounds check above
-			if err != nil {
-				return fmt.Errorf("Error creating file: %w", err)
-			}
-			defer outFile.Close()
-			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
-			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
+				fmt.Fprintf(options.ioStreams.Out,
+					"Skipping file %q: mode value %d is outside the valid range for os.FileMode\n",
+					header.Name,
+					header.Mode)
+			} else if err := func() error {
+				outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // mode is range-checked above
 				if err != nil {
-					if errors.Is(err, io.EOF) {
+					return fmt.Errorf("Error creating file: %w", err)
+				}
+				defer outFile.Close()
+
+				// This is to limit the copy size for a decompression bomb, currently set arbitrarily
+				for {
+					n, err := io.CopyN(outFile, tarReader, 1000000)
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						return fmt.Errorf("failed while writing to file: %w", err)
+					}
+					if n == 0 {
 						break
 					}
-					return fmt.Errorf("failed while writing to file: %w", err)
 				}
-				if n == 0 {
-					break
-				}
+				return nil
+			}(); err != nil {
+				return err
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -482,6 +483,90 @@ func TestDownloadRayLogFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, curr.Body, string(actualContent))
 	}
+}
+
+func TestDownloadRayLogFilesSkipsInvalidMode(t *testing.T) {
+	fakeDir := t.TempDir()
+	testStreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	options := NewClusterLogOptions(cmdutil.NewFactory(genericclioptions.NewConfigFlags(true)), testStreams)
+	options.outputDir = fakeDir
+
+	tarBuffer := new(bytes.Buffer)
+	tarWriter := tar.NewWriter(tarBuffer)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     ".",
+		Mode:     0o755,
+	}))
+	invalidContents := []byte("must not be written")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "invalid-mode.log",
+		Mode:     -1,
+		Size:     int64(len(invalidContents)),
+	}))
+	_, err := tarWriter.Write(invalidContents)
+	require.NoError(t, err)
+	validContents := []byte("valid log contents\n")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "valid.log",
+		Mode:     0o644,
+		Size:     int64(len(validContents)),
+	}))
+	_, err = tarWriter.Write(validContents)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+
+	rayHead := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-ray-head"}}
+	executor, err := fakeNewSPDYExecutor("GET", &url.URL{}, tarBuffer)
+	require.NoError(t, err)
+	require.NoError(t, options.downloadRayLogFiles(context.Background(), executor, rayHead))
+
+	assert.Contains(t, out.String(), "Skipping file \"invalid-mode.log\"")
+	_, err = os.Stat(filepath.Join(fakeDir, rayHead.Name, "invalid-mode.log"))
+	assert.True(t, os.IsNotExist(err))
+	contents, err := os.ReadFile(filepath.Join(fakeDir, rayHead.Name, "valid.log"))
+	require.NoError(t, err)
+	assert.Equal(t, validContents, contents)
+}
+
+func TestDownloadRayLogFilesClosesFilesDuringExtraction(t *testing.T) {
+	const fileCount = 2048
+
+	fakeDir := t.TempDir()
+	testStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	options := NewClusterLogOptions(cmdutil.NewFactory(genericclioptions.NewConfigFlags(true)), testStreams)
+	options.outputDir = fakeDir
+
+	tarBuffer := new(bytes.Buffer)
+	tarWriter := tar.NewWriter(tarBuffer)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     ".",
+		Mode:     0o755,
+	}))
+	for index := range fileCount {
+		contents := fmt.Appendf(nil, "log line %d\n", index)
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     fmt.Sprintf("log-%04d.txt", index),
+			Mode:     0o644,
+			Size:     int64(len(contents)),
+		}))
+		_, err := tarWriter.Write(contents)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tarWriter.Close())
+
+	rayHead := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-ray-head"}}
+	executor, err := fakeNewSPDYExecutor("GET", &url.URL{}, tarBuffer)
+	require.NoError(t, err)
+	require.NoError(t, options.downloadRayLogFiles(context.Background(), executor, rayHead))
+
+	files, err := os.ReadDir(filepath.Join(fakeDir, rayHead.Name))
+	require.NoError(t, err)
+	assert.Len(t, files, fileCount)
 }
 
 // createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.


### PR DESCRIPTION
## Why are these changes needed?

`downloadRayLogFiles` still has two resource-handling problems in the current `master` branch. An out-of-range tar header mode is reported but then converted to `os.FileMode`, and file closures are deferred until the entire archive loop returns. This change skips invalid-mode entries before conversion and scopes each file close to one extraction iteration.

The change also applies the retention-free behavior to archive processing after a skipped entry: subsequent valid entries continue to extract normally.

## Related issue number

Fixes #4779

## Test plan

```console
go test ./kubectl-plugin/pkg/cmd/log -run 'TestDownloadRayLogFiles(SkipsInvalidMode|ClosesFilesDuringExtraction)?$' -count=1 -v
go test ./kubectl-plugin/pkg/cmd/log -count=1
go test -race ./kubectl-plugin/pkg/cmd/log -count=1
go vet ./kubectl-plugin/pkg/cmd/log
```

The focused coverage verifies that an invalid file mode does not create a file and that a later valid entry still extracts. It also extracts 2,048 files to ensure descriptors are closed during the archive loop.
