### PR TITLE
Honor dashboard address overrides in RayJob submitters

### DIFF
--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -110,6 +110,15 @@ spec:
   #     containers:
   #     - name: my-custom-rayjob-submitter-pod
   #       image: rayproject/ray:2.52.0
+  #       # In K8sJobMode, set this in the first container of spec.submitterPodTemplate
+  #       # to override the dashboard address used by the default submitter command.
+  #       # It must point to the same Ray cluster that the operator monitors.
+  #       # Use a dashboard base address (host:port or HTTP(S) URL), not the GCS port
+  #       # or /api/gcs_healthz path. Trailing slashes are removed; unset or empty
+  #       # values fall back to status.dashboardURL. This applies to new submitter Pods.
+  #       env:
+  #         - name: RAY_DASHBOARD_ADDRESS
+  #           value: "http://your-head-address:8265"
   #       # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
   #       # Specifying Command is not recommended.
   #       # command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -89,6 +89,7 @@ func getMetadataJSONForSubmitCommand(rayJobInstance *rayv1.RayJob, metadata map[
 // BuildJobSubmitCommand builds the `ray job submit` command based on submission mode.
 func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.JobSubmissionMode) ([]string, error) {
 	var address string
+	var cmd []string
 	port := utils.DefaultDashboardPort
 
 	switch submissionMode {
@@ -99,16 +100,23 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 		port = int(utils.FindContainerPort(&rayHeadContainer, utils.DashboardPortName, utils.DefaultDashboardPort))
 		address = "http://127.0.0.1:" + strconv.Itoa(port)
 	case rayv1.K8sJobMode:
-		// Submitter is a separate K8s Job; use cluster dashboard address.
-		address = rayJobInstance.Status.DashboardURL
-		if !strings.HasPrefix(address, "http://") {
-			address = "http://" + address
-		}
+		// Resolve the override in the submitter Pod so valueFrom entries work too.
+		// Single-quote the fallback to keep shell metacharacters literal.
+		fallback := "'" + strings.ReplaceAll(rayJobInstance.Status.DashboardURL, "'", "'\"'\"'") + "'"
+		cmd = append(cmd, `dashboard_address=`+fallback+`;
+dashboard_address="${RAY_DASHBOARD_ADDRESS:-$dashboard_address}";
+case "$dashboard_address" in
+  http://*|https://*) ;;
+  *) dashboard_address="http://$dashboard_address" ;;
+esac;
+while [ "${dashboard_address%/}" != "$dashboard_address" ]; do
+  dashboard_address="${dashboard_address%/}";
+done;`)
+		address = `"$dashboard_address"`
 	default:
 		return nil, fmt.Errorf("unsupported submission mode for job submit command: %s", submissionMode)
 	}
 
-	var cmd []string
 	metadata := rayJobInstance.Spec.Metadata
 	jobId := rayJobInstance.Status.JobId
 	entrypoint := strings.TrimSpace(rayJobInstance.Spec.Entrypoint)
@@ -132,22 +140,24 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 	// Wait until Ray Dashboard GCS is healthy before proceeding.
 	// In SidecarMode the submitter shares the head Pod's network namespace, so we
 	// probe localhost. In K8sJobMode the submitter runs in a separate Pod and must
-	// reach the dashboard through the head Service.
-	var healthURL string
+	// reach the dashboard through the configured address.
+	var rayDashboardGCSHealthCommand, waitingMessage string
 	if submissionMode == rayv1.SidecarMode {
-		healthURL = fmt.Sprintf("http://localhost:%d/%s", port, utils.RayDashboardGCSHealthPath)
+		healthURL := fmt.Sprintf("http://localhost:%d/%s", port, utils.RayDashboardGCSHealthPath)
+		rayDashboardGCSHealthCommand = fmt.Sprintf(utils.BasePythonHealthCommand, healthURL, utils.RayDashboardGCSHealthCheckTimeoutSeconds)
+		waitingMessage = strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at " + address + " ...")
 	} else {
-		healthURL = address + "/" + utils.RayDashboardGCSHealthPath
+		// Pass the URL as an argument, never as Python source.
+		rayDashboardGCSHealthCommand = fmt.Sprintf(
+			`python -c "import sys, urllib.request; r=urllib.request.urlopen(sys.argv[1], timeout=%d); exit(0 if b'success' in r.read() else 1)" "$dashboard_address/%s"`,
+			utils.RayDashboardGCSHealthCheckTimeoutSeconds, utils.RayDashboardGCSHealthPath,
+		)
+		waitingMessage = `"Waiting for Ray Dashboard GCS to become healthy at $dashboard_address ..."`
 	}
-	rayDashboardGCSHealthCommand := fmt.Sprintf(
-		utils.BasePythonHealthCommand,
-		healthURL,
-		utils.RayDashboardGCSHealthCheckTimeoutSeconds,
-	)
 
 	waitLoop := []string{
 		"until", rayDashboardGCSHealthCommand, ">/dev/null", "2>&1", ";",
-		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at " + address + " ..."), ";", "sleep", "2", ";", "done", ";",
+		"do", "echo", waitingMessage, ";", "sleep", "2", ";", "done", ";",
 	}
 	cmd = append(cmd, waitLoop...)
 

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -1,10 +1,16 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,17 +75,28 @@ pip: ["python-multipart==0.0.6"]
 	assert.Equal(t, expectedMap, actualMap)
 }
 
+const testDashboardAddressResolution = `dashboard_address='http://127.0.0.1:8265';
+dashboard_address="${RAY_DASHBOARD_ADDRESS:-$dashboard_address}";
+case "$dashboard_address" in
+  http://*|https://*) ;;
+  *) dashboard_address="http://$dashboard_address" ;;
+esac;
+while [ "${dashboard_address%/}" != "$dashboard_address" ]; do
+  dashboard_address="${dashboard_address%/}";
+done;`
+
 func TestBuildJobSubmitCommandWithK8sJobMode(t *testing.T) {
 	testRayJob := rayJobTemplate()
 	expected := []string{
+		testDashboardAddressResolution,
 		"until",
-		fmt.Sprintf(utils.BasePythonHealthCommand, "http://127.0.0.1:8265/"+utils.RayDashboardGCSHealthPath, utils.RayDashboardGCSHealthCheckTimeoutSeconds),
+		`python -c "import sys, urllib.request; r=urllib.request.urlopen(sys.argv[1], timeout=10); exit(0 if b'success' in r.read() else 1)" "$dashboard_address/api/gcs_healthz"`,
 		">/dev/null", "2>&1", ";",
-		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at http://127.0.0.1:8265 ..."), ";", "sleep", "2", ";", "done", ";",
+		"do", "echo", `"Waiting for Ray Dashboard GCS to become healthy at $dashboard_address ..."`, ";", "sleep", "2", ";", "done", ";",
 		"if",
-		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
+		"!", "ray", "job", "status", "--address", `"$dashboard_address"`, "testJobId", ">/dev/null", "2>&1",
 		";", "then",
-		"ray", "job", "submit", "--address", "http://127.0.0.1:8265", "--no-wait",
+		"ray", "job", "submit", "--address", `"$dashboard_address"`, "--no-wait",
 		"--runtime-env-json", strconv.Quote(`{"test":"test"}`),
 		"--metadata-json", strconv.Quote(`{"testKey":"testValue"}`),
 		"--submission-id", "testJobId",
@@ -89,11 +106,115 @@ func TestBuildJobSubmitCommandWithK8sJobMode(t *testing.T) {
 		"--",
 		"echo no quote 'single quote' \"double quote\"",
 		";", "fi", ";",
-		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
+		"ray", "job", "logs", "--address", `"$dashboard_address"`, "--follow", "testJobId",
 	}
 	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
 	require.NoError(t, err)
 	assert.Equal(t, expected, command)
+}
+
+func TestBuildJobSubmitCommandDashboardAddressRuntime(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		fallback string
+		expected string
+		unset    bool
+	}{
+		{name: "unset", unset: true, expected: "http://head-svc:8265"},
+		{name: "empty", expected: "http://head-svc:8265"},
+		{name: "host and port", override: "proxy:8265", expected: "http://proxy:8265"},
+		{name: "http", override: "http://proxy:8265", expected: "http://proxy:8265"},
+		{name: "https", override: "https://proxy:443", expected: "https://proxy:443"},
+		{name: "host trailing slash", override: "proxy:8265/", expected: "http://proxy:8265"},
+		{name: "http trailing slashes", override: "http://proxy:8265///", expected: "http://proxy:8265"},
+		{name: "https base path", override: "https://proxy:443/ray///", expected: "https://proxy:443/ray"},
+		{name: "https fallback", fallback: "https://head-svc:8265///", expected: "https://head-svc:8265"},
+		{name: "literal override", override: "https://proxy:443/a'\"$HOME`exit 1`$(exit 1) space///", expected: "https://proxy:443/a'\"$HOME`exit 1`$(exit 1) space"},
+		{name: "literal fallback", fallback: "https://head-svc:8265/a'\"$HOME`exit 1`$(exit 1) space///", expected: "https://head-svc:8265/a'\"$HOME`exit 1`$(exit 1) space"},
+	}
+	for _, tt := range tests {
+		for _, existingJob := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/existing=%t", tt.name, existingJob), func(t *testing.T) {
+				rayJob := rayJobTemplate()
+				rayJob.Status.DashboardURL = "head-svc:8265"
+				if tt.fallback != "" {
+					rayJob.Status.DashboardURL = tt.fallback
+				}
+				command, err := BuildJobSubmitCommand(rayJob, rayv1.K8sJobMode)
+				require.NoError(t, err)
+
+				// Record argument boundaries, and fail the first health check to exercise
+				// the waiting message and retry interval without actually sleeping.
+				dir := t.TempDir()
+				stubs := map[string]string{
+					"python": `printf '%s\0' health "$3" >> "$CALL_LOG"
+printf '\n' >> "$CALL_LOG"
+if [ ! -e "$HEALTH_READY" ]; then
+  : > "$HEALTH_READY"
+  exit 1
+fi
+`,
+					"sleep": `printf '%s\0' sleep "$@" >> "$CALL_LOG"
+printf '\n' >> "$CALL_LOG"
+`,
+					"ray": `printf '%s\0' ray "$@" >> "$CALL_LOG"
+printf '\n' >> "$CALL_LOG"
+if [ "$2" = status ]; then exit "$STATUS_EXIT_CODE"; fi
+`,
+				}
+				for name, script := range stubs {
+					require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+script), 0o700))
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, "/bin/bash", "-ce", "--", strings.Join(command, " "))
+				cmd.WaitDelay = time.Second
+				// Use a controlled environment so the unset case cannot inherit an override.
+				cmd.Env = []string{
+					"PATH=" + dir,
+					"CALL_LOG=" + filepath.Join(dir, "calls"),
+					"HEALTH_READY=" + filepath.Join(dir, "healthy"),
+					"STATUS_EXIT_CODE=1",
+				}
+				if existingJob {
+					cmd.Env[len(cmd.Env)-1] = "STATUS_EXIT_CODE=0"
+				}
+				if !tt.unset {
+					cmd.Env = append(cmd.Env, utils.RAY_DASHBOARD_ADDRESS+"="+tt.override)
+				}
+				output, err := cmd.CombinedOutput()
+				require.NoError(t, err, "%s", output)
+				assert.Equal(t, "Waiting for Ray Dashboard GCS to become healthy at "+tt.expected+" ...\n", string(output))
+
+				calls, err := os.ReadFile(filepath.Join(dir, "calls"))
+				require.NoError(t, err)
+				var actual [][]string
+				for _, call := range strings.Split(strings.TrimSuffix(string(calls), "\n"), "\n") {
+					actual = append(actual, strings.Split(strings.TrimSuffix(call, "\x00"), "\x00"))
+				}
+				expected := [][]string{
+					{"health", tt.expected + "/api/gcs_healthz"},
+					{"sleep", "2"},
+					{"health", tt.expected + "/api/gcs_healthz"},
+					{"ray", "job", "status", "--address", tt.expected, "testJobId"},
+				}
+				if !existingJob {
+					expected = append(expected, []string{
+						"ray", "job", "submit", "--address", tt.expected, "--no-wait",
+						"--runtime-env-json", `{"test":"test"}`,
+						"--metadata-json", `{"testKey":"testValue"}`,
+						"--submission-id", "testJobId",
+						"--entrypoint-num-cpus", "1.000000", "--entrypoint-num-gpus", "0.500000",
+						"--entrypoint-resources", `{"Custom_1": 1, "Custom_2": 5.5}`,
+						"--", "echo", "no", "quote", "single quote", "double quote",
+					})
+				}
+				expected = append(expected, []string{"ray", "job", "logs", "--address", tt.expected, "--follow", "testJobId"})
+				assert.Equal(t, expected, actual)
+			})
+		}
+	}
 }
 
 func TestBuildJobSubmitCommandWithSidecarMode(t *testing.T) {
@@ -202,18 +323,6 @@ func TestBuildJobSubmitCommandWithSidecarModeCustomDashboardPort(t *testing.T) {
 	assert.NotContains(t, command[1], "wget")
 }
 
-func TestBuildJobSubmitCommandWithK8sJobModeHealthWaitLoop(t *testing.T) {
-	testRayJob := rayJobTemplate()
-	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(command), 2)
-	assert.Equal(t, "until", command[0])
-	assert.Contains(t, command[1], "python -c")
-	assert.Contains(t, command[1], utils.RayDashboardGCSHealthPath)
-	assert.Contains(t, command[1], "127.0.0.1:8265")
-	assert.NotContains(t, command[1], "wget")
-}
-
 func TestBuildJobSubmitCommandWithSidecarModeAndFeatureGate(t *testing.T) {
 	// Enable the SidecarSubmitterRestart feature gate for this test
 	features.SetFeatureGateDuringTest(t, features.SidecarSubmitterRestart, true)
@@ -283,21 +392,22 @@ pip: ["python-multipart==0.0.6"]
 		},
 	}
 	expected := []string{
+		testDashboardAddressResolution,
 		"until",
-		fmt.Sprintf(utils.BasePythonHealthCommand, "http://127.0.0.1:8265/"+utils.RayDashboardGCSHealthPath, utils.RayDashboardGCSHealthCheckTimeoutSeconds),
+		`python -c "import sys, urllib.request; r=urllib.request.urlopen(sys.argv[1], timeout=10); exit(0 if b'success' in r.read() else 1)" "$dashboard_address/api/gcs_healthz"`,
 		">/dev/null", "2>&1", ";",
-		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at http://127.0.0.1:8265 ..."), ";", "sleep", "2", ";", "done", ";",
+		"do", "echo", `"Waiting for Ray Dashboard GCS to become healthy at $dashboard_address ..."`, ";", "sleep", "2", ";", "done", ";",
 		"if",
-		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
+		"!", "ray", "job", "status", "--address", `"$dashboard_address"`, "testJobId", ">/dev/null", "2>&1",
 		";", "then",
-		"ray", "job", "submit", "--address", "http://127.0.0.1:8265", "--no-wait",
+		"ray", "job", "submit", "--address", `"$dashboard_address"`, "--no-wait",
 		"--runtime-env-json", strconv.Quote(`{"working_dir":"https://github.com/ray-project/serve_config_examples/archive/b393e77bbd6aba0881e3d94c05f968f05a387b96.zip","pip":["python-multipart==0.0.6"]}`),
 		"--metadata-json", strconv.Quote(`{"testKey":"testValue"}`),
 		"--submission-id", "testJobId",
 		"--",
 		"echo no quote 'single quote' \"double quote\"",
 		";", "fi", ";",
-		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
+		"ray", "job", "logs", "--address", `"$dashboard_address"`, "--follow", "testJobId",
 	}
 	command, err := BuildJobSubmitCommand(rayJobWithYAML, rayv1.K8sJobMode)
 	require.NoError(t, err)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -652,7 +652,9 @@ func configureSubmitterContainer(container *corev1.Container, rayJobInstance *ra
 	// Users can use `RAY_DASHBOARD_ADDRESS` to specify the dashboard address and `RAY_JOB_SUBMISSION_ID` to specify the job id to avoid
 	// double submission in the `ray job submit` command. For example:
 	// ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID ...
-	container.Env = append(container.Env, corev1.EnvVar{Name: utils.RAY_DASHBOARD_ADDRESS, Value: rayJobInstance.Status.DashboardURL})
+	if !utils.EnvVarExists(utils.RAY_DASHBOARD_ADDRESS, container.Env) {
+		container.Env = append(container.Env, corev1.EnvVar{Name: utils.RAY_DASHBOARD_ADDRESS, Value: rayJobInstance.Status.DashboardURL})
+	}
 	container.Env = append(container.Env, corev1.EnvVar{Name: utils.RAY_JOB_SUBMISSION_ID, Value: rayJobInstance.Status.JobId})
 	if rayClusterInstance != nil && utils.IsAuthEnabled(&rayClusterInstance.Spec) {
 		common.SetContainerTokenAuthEnvVars(rayClusterInstance.Name, container, rayClusterInstance.Spec.AuthOptions)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -29,6 +29,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics/mocks"
 	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
@@ -191,11 +192,9 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	submitterTemplate, err = getSubmitterTemplate(rayJobInstanceWithTemplate, rayClusterInstance)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	expectedK8sJobModeArgs := []string{
-		"until " + fmt.Sprintf(utils.BasePythonHealthCommand, "http://test-url/"+utils.RayDashboardGCSHealthPath, utils.RayDashboardGCSHealthCheckTimeoutSeconds) +
-			" >/dev/null 2>&1 ; do echo \"Waiting for Ray Dashboard GCS to become healthy at http://test-url ...\" ; sleep 2 ; done ; " +
-			"if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id",
-	}
+	jobCmd, err := common.BuildJobSubmitCommand(rayJobInstanceWithTemplate, rayv1.K8sJobMode)
+	require.NoError(t, err)
+	expectedK8sJobModeArgs := []string{strings.Join(jobCmd, " ")}
 	assert.Equal(t, expectedK8sJobModeArgs, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
@@ -225,6 +224,56 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	envVar, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env)
 	assert.True(t, found)
 	assert.Equal(t, "test-job-id", envVar.Value)
+}
+
+func TestConfigureSubmitterContainerDashboardAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []corev1.EnvVar
+	}{
+		{name: "absent"},
+		{name: "literal", env: []corev1.EnvVar{{Name: utils.RAY_DASHBOARD_ADDRESS, Value: "https://proxy:8265/"}}},
+		{name: "empty", env: []corev1.EnvVar{{Name: utils.RAY_DASHBOARD_ADDRESS, Value: ""}}},
+		{name: "valueFrom", env: []corev1.EnvVar{{
+			Name: utils.RAY_DASHBOARD_ADDRESS,
+			ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "dashboard-config"}, Key: "address",
+			}},
+		}}},
+	}
+	for _, tt := range tests {
+		for _, customCommand := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/customCommand=%t", tt.name, customCommand), func(t *testing.T) {
+				container := corev1.Container{Env: append([]corev1.EnvVar{{Name: "OTHER", Value: "preserved"}}, tt.env...)}
+				if customCommand {
+					container.Command = []string{"custom-submitter"}
+					container.Args = []string{"custom-argument"}
+				}
+				rayJob := &rayv1.RayJob{Status: rayv1.RayJobStatus{DashboardURL: "head-svc:8265", JobId: "test-job-id"}}
+				require.NoError(t, configureSubmitterContainer(&container, rayJob, nil, rayv1.K8sJobMode))
+				var dashboardEntries []corev1.EnvVar
+				for _, env := range container.Env {
+					if env.Name == utils.RAY_DASHBOARD_ADDRESS {
+						dashboardEntries = append(dashboardEntries, env)
+					}
+				}
+				expected := tt.env
+				if len(expected) == 0 {
+					expected = []corev1.EnvVar{{Name: utils.RAY_DASHBOARD_ADDRESS, Value: rayJob.Status.DashboardURL}}
+				}
+				assert.Equal(t, expected, dashboardEntries)
+				assert.Contains(t, container.Env, corev1.EnvVar{Name: "OTHER", Value: "preserved"})
+				if customCommand {
+					assert.Equal(t, []string{"custom-submitter"}, container.Command)
+					assert.Equal(t, []string{"custom-argument"}, container.Args)
+				} else {
+					assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, container.Command)
+					require.Len(t, container.Args, 1)
+					assert.Contains(t, container.Args[0], "${RAY_DASHBOARD_ADDRESS:-$dashboard_address}")
+				}
+			})
+		}
+	}
 }
 
 func TestGetSubmitterContainerWithFeatureGate(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

The default K8sJobMode submitter currently embeds status.dashboardURL in its command, ignoring RAY_DASHBOARD_ADDRESS. The controller also appends a default environment entry even when an override is configured.

  This change honors the override at runtime, falls back when unset or empty, and normalizes hostname-and-port and HTTP(S) addresses. Health checks and all Ray job CLI commands use the resolved address. Explicit environment entries, including valueFrom, are preserved.

The sample documents the override. Sidecar behavior, custom commands, and duplicate-submission protection remain unchanged.

  ## Related issue number

  N/A

  ## Labels

  - [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the doc-updates-required label.
  - [ ] If this PR contains breaking changes, I have added the breaking-change label.

  ## Checks

  - [x] I've made sure the tests are passing.

  ## Testing Strategy

  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

  Common and controller suites passed with Kubernetes 1.37.0 envtest. Automated shell tests cover fallback, address normalization, health retries, consistent addresses, new submissions, and reattachment.

  ## Manual test instructions

  1. Configure RAY_DASHBOARD_ADDRESS in the first container of spec.submitterPodTemplate, pointing to an alternate dashboard address for the same Ray cluster.
  2. Create the RayJob and verify the default submitter completes successfully through that address.
  3. Repeat with an empty value to verify fallback to status.dashboardURL.
